### PR TITLE
Add GeoBenchV2 Dataset Class wrapper

### DIFF
--- a/src/datasets.py
+++ b/src/datasets.py
@@ -1,14 +1,26 @@
 """Dataset utilities for torchgeo-bench.
 
 This module provides a unified interface to load GeoBench datasets using
-the lightweight GeoBenchDataset class.
+the V1 GeoBenchDataset class and the V2 geobench_v2 package.
 """
 
+import os
+import warnings
 import torch
 import torch.nn.functional as F
 from torch.utils.data import DataLoader
+from typing import Optional, Callable, Tuple, Union
+
 
 from .geobench_dataset import GeoBenchDataset
+
+try:
+    import geobench_v2.datasets as gb_v2
+
+    HAS_V2 = True
+except ImportError:
+    HAS_V2 = False
+
 
 NUM_CLASSES_PER_DATASET = {
     "m-forestnet": 12,
@@ -30,8 +42,203 @@ PARTITION_NAMES = [
     "default",
 ]
 
-# Default GeoBench data root - override via environment variable if needed
 DEFAULT_GEOBENCH_ROOT = "data/classification_v1.0"
+DEFAULT_GEOBENCH_V2_ROOT = "/mnt/SSD2/nils/datasets/GEO-Bench-2/"
+
+# V2 Dataset Registry
+V2_DATASETS = {
+    "benv2",
+    "biomassters",
+    "burn_scars",
+    "caffe",
+    "cloudsen12",
+    "dynamic_earthnet",
+    "everwatch",
+    "flair2",
+    "forestnet",
+    "fotw",
+    "kuro_siwo",
+    "pastis",
+    "spacenet2",
+    "spacenet7",
+    "substation",
+    "treesatai",
+    "wind_turbine",
+    "so2sat",
+}
+
+# V2 Task Types
+V2_TASK_TYPES = {
+    "benv2": "classification",
+    "forestnet": "classification",
+    "so2sat": "classification",
+    "eurosat": "classification",
+    "treesatai": "classification",
+    # Default others to segmentation
+    "biomassters": "segmentation",
+    "burn_scars": "segmentation",
+    "caffe": "segmentation",
+    "cloudsen12": "segmentation",
+    "dynamic_earthnet": "segmentation",
+    "flair2": "segmentation",
+    "fotw": "segmentation",
+    "kuro_siwo": "segmentation",
+    "pastis": "segmentation",
+    "spacenet2": "segmentation",
+    "spacenet7": "segmentation",
+}
+
+
+def _get_v2_class_name(dataset_name: str) -> str:
+    """Helper to convert dataset snake_case name to CamelCase class name."""
+    if dataset_name == "benv2":
+        return "GeoBenchBENV2"
+    if dataset_name == "so2sat":
+        return "GeoBenchSo2Sat"
+    if dataset_name == "flair2":
+        return "GeoBenchFLAIR2"
+
+    camel_name = "".join(x.title() for x in dataset_name.split("_"))
+    return f"GeoBench{camel_name}"
+
+def _get_datasets_v2(
+    dataset_name: str,
+    partition_name: str,
+    batch_size: int,
+    return_val: bool,
+    only_return_datasets: bool,
+    root: str,
+    num_workers: int,
+    bands: tuple,
+    transform: Optional[Callable],
+    normalization: str,
+):
+    """Handles loading logic for V2 datasets."""
+    if not HAS_V2:
+        raise ImportError(
+            f"Cannot load V2 dataset '{dataset_name}': geobench_v2 package not found."
+        )
+
+    if partition_name != "default":
+        warnings.warn(
+            f"Partitions are not supported in GeoBench V2. Ignoring partition '{partition_name}'.",
+            UserWarning,
+        )
+
+    class_name = _get_v2_class_name(dataset_name)
+    dataset_cls = getattr(gb_v2, class_name, None)
+    if dataset_cls is None:
+        raise ValueError(f"Could not find V2 dataset class '{class_name}' in geobench_v2.datasets.")
+
+    # currently only support mean-stdev normalization for V2, which happens by default
+    def load_split(split):
+        import pdb
+        pdb.set_trace()
+        ds = dataset_cls(
+            root=os.path.join(root, dataset_name),
+            split=split,
+            transforms=transform,
+            band_order=bands,
+        )
+        ds.task_type = V2_TASK_TYPES.get(dataset_name, "segmentation")
+        return ds
+
+    train_dataset = load_split("train")
+    valid_dataset = load_split("val")
+    test_dataset = load_split("test")
+
+    train_loader = DataLoader(
+        train_dataset, batch_size=batch_size, shuffle=True, num_workers=num_workers, pin_memory=True
+    )
+    val_loader = DataLoader(
+        valid_dataset,
+        batch_size=batch_size,
+        shuffle=False,
+        num_workers=num_workers,
+        pin_memory=True,
+    )
+    test_loader = DataLoader(
+        test_dataset, batch_size=batch_size, shuffle=False, num_workers=num_workers, pin_memory=True
+    )
+
+    if only_return_datasets:
+        return (
+            (train_dataset, valid_dataset, test_dataset)
+            if return_val
+            else (train_dataset, test_dataset)
+        )
+    if return_val:
+        return train_dataset, train_loader, val_loader, test_loader
+    return train_dataset, train_loader, test_loader
+
+
+def _get_datasets_v1(
+    dataset_name: str,
+    partition_name: str,
+    batch_size: int,
+    return_val: bool,
+    only_return_datasets: bool,
+    root: str,
+    num_workers: int,
+    bands: tuple,
+    transform: Optional[Callable],
+    normalize_arg: Union[bool, str],
+):
+    """Handles loading logic for V1 datasets."""
+
+    train_dataset = GeoBenchDataset(
+        root=root,
+        dataset_name=dataset_name,
+        split="train",
+        partition=partition_name,
+        bands=bands,
+        normalize=normalize_arg,
+        transform=transform,
+    )
+
+    valid_dataset = GeoBenchDataset(
+        root=root,
+        dataset_name=dataset_name,
+        split="valid",
+        partition="default",
+        bands=bands,
+        normalize=normalize_arg,
+        transform=transform,
+    )
+
+    test_dataset = GeoBenchDataset(
+        root=root,
+        dataset_name=dataset_name,
+        split="test",
+        partition="default",
+        bands=bands,
+        normalize=normalize_arg,
+        transform=transform,
+    )
+
+    train_loader = DataLoader(
+        train_dataset, batch_size=batch_size, shuffle=True, num_workers=num_workers, pin_memory=True
+    )
+    val_loader = DataLoader(
+        valid_dataset,
+        batch_size=batch_size,
+        shuffle=False,
+        num_workers=num_workers,
+        pin_memory=True,
+    )
+    test_loader = DataLoader(
+        test_dataset, batch_size=batch_size, shuffle=False, num_workers=num_workers, pin_memory=True
+    )
+
+    if only_return_datasets:
+        return (
+            (train_dataset, valid_dataset, test_dataset)
+            if return_val
+            else (train_dataset, test_dataset)
+        )
+    if return_val:
+        return train_dataset, train_loader, val_loader, test_loader
+    return train_dataset, train_loader, test_loader
 
 
 def get_datasets(
@@ -42,42 +249,25 @@ def get_datasets(
     return_val: bool = False,
     only_return_datasets: bool = False,
     geobench_root: str | None = None,
+    geobench_v2_root: str | None = None,
     num_workers: int = 8,
     image_size: int | None = None,
     interpolation: str = "bicubic",
 ):
-    """Load GeoBench dataset splits and dataloaders.
+    """Load GeoBench dataset splits and dataloaders (supports V1 and V2)."""
 
-    Args:
-        dataset_name: Dataset identifier (e.g., 'm-eurosat', 'm-forestnet')
-        partition_name: Partition to use (e.g., 'default', '0.01x_train')
-        batch_size: Batch size for dataloaders
-        normalization: Normalization method ('mean_stdev', 'min_max', 'percentile_2_98', or 'none')
-        return_val: If True, return 4-tuple including validation split
-        only_return_datasets: If True, return only datasets without dataloaders
-        geobench_root: Path to classification_v1.0 directory (uses DEFAULT if None)
-        num_workers: Number of dataloader workers
-
-    Returns:
-        If return_val=True: (train_dataset, train_loader, val_loader, test_loader)
-        If return_val=False: (train_dataset, train_loader, test_loader)
-    """
     if geobench_root is None:
-        import os
-
         geobench_root = os.getenv("GEOBENCH_ROOT", DEFAULT_GEOBENCH_ROOT)
 
-    # Map normalization argument
+    if geobench_v2_root is None:
+        geobench_v2_root = os.getenv("GEOBENCH_V2_ROOT", DEFAULT_GEOBENCH_V2_ROOT)
     if normalization == "mean_stdev":
-        normalize = True
-    elif normalization == "min_max":
-        normalize = "min_max"
-    elif normalization == "percentile_2_98":
-        normalize = "percentile_2_98"
+        normalize_v1 = True
+    elif normalization in ["min_max", "percentile_2_98"]:
+        normalize_v1 = normalization
     else:
-        normalize = False
+        normalize_v1 = False
 
-    # Optional resize transform
     resize_transform = None
     if image_size is not None:
         interp_mode = {
@@ -90,7 +280,6 @@ def get_datasets(
             img: torch.Tensor = sample["image"]
             h, w = img.shape[-2], img.shape[-1]
             if h != image_size or w != image_size:
-                # Use float32 already; add batch dim for F.interpolate
                 img = img.unsqueeze(0)
                 img = F.interpolate(
                     img,
@@ -103,70 +292,31 @@ def get_datasets(
 
         resize_transform = _resize
 
-    # Compose transform(s) if needed (currently single resize)
-    transform_callable = resize_transform
-    train_dataset = GeoBenchDataset(
-        root=geobench_root,
-        dataset_name=dataset_name,
-        split="train",
-        partition=partition_name,
-        bands=("red", "green", "blue"),
-        normalize=normalize,
-        transform=transform_callable,
-    )
+    bands = ("red", "green", "blue")
 
-    valid_dataset = GeoBenchDataset(
-        root=geobench_root,
-        dataset_name=dataset_name,
-        split="valid",
-        partition="default",  # validation always uses default partition
-        bands=("red", "green", "blue"),
-        normalize=normalize,
-        transform=transform_callable,
-    )
-
-    test_dataset = GeoBenchDataset(
-        root=geobench_root,
-        dataset_name=dataset_name,
-        split="test",
-        partition="default",  # test always uses default partition
-        bands=("red", "green", "blue"),
-        normalize=normalize,
-        transform=transform_callable,
-    )
-
-    # Create dataloaders
-    train_dataloader = DataLoader(
-        train_dataset,
-        batch_size=batch_size,
-        shuffle=True,
-        num_workers=num_workers,
-        pin_memory=True,
-    )
-
-    val_dataloader = DataLoader(
-        valid_dataset,
-        batch_size=batch_size,
-        shuffle=False,
-        num_workers=num_workers,
-        pin_memory=True,
-    )
-
-    test_dataloader = DataLoader(
-        test_dataset,
-        batch_size=batch_size,
-        shuffle=False,
-        num_workers=num_workers,
-        pin_memory=True,
-    )
-
-    if only_return_datasets:
-        if return_val:
-            return train_dataset, valid_dataset, test_dataset
-        else:
-            return train_dataset, test_dataset
-
-    if return_val:
-        return train_dataset, train_dataloader, val_dataloader, test_dataloader
+    if dataset_name in V2_DATASETS:
+        return _get_datasets_v2(
+            dataset_name=dataset_name,
+            partition_name=partition_name,
+            batch_size=batch_size,
+            return_val=return_val,
+            only_return_datasets=only_return_datasets,
+            root=geobench_v2_root,
+            num_workers=num_workers,
+            bands=bands,
+            transform=resize_transform,
+            normalization=normalization,
+        )
     else:
-        return train_dataset, train_dataloader, test_dataloader
+        return _get_datasets_v1(
+            dataset_name=dataset_name,
+            partition_name=partition_name,
+            batch_size=batch_size,
+            return_val=return_val,
+            only_return_datasets=only_return_datasets,
+            root=geobench_root,
+            num_workers=num_workers,
+            bands=bands,
+            transform=resize_transform,
+            normalize_arg=normalize_v1,  # V1 uses mapped bool/string
+        )

--- a/src/datasets.py
+++ b/src/datasets.py
@@ -132,8 +132,6 @@ def _get_datasets_v2(
 
     # currently only support mean-stdev normalization for V2, which happens by default
     def load_split(split):
-        import pdb
-        pdb.set_trace()
         ds = dataset_cls(
             root=os.path.join(root, dataset_name),
             split=split,
@@ -277,6 +275,7 @@ def get_datasets(
         }.get(interpolation, "bicubic")
 
         def _resize(sample: dict) -> dict:
+            """Resize image in sample to desired size."""
             img: torch.Tensor = sample["image"]
             h, w = img.shape[-2], img.shape[-1]
             if h != image_size or w != image_size:
@@ -288,6 +287,18 @@ def get_datasets(
                     align_corners=False if interp_mode in ("bicubic", "bilinear") else None,
                 )
                 sample["image"] = img.squeeze(0)
+            if "mask" in sample:
+                # assuming mask is single-channel with class indices
+                mask: torch.Tensor = sample["mask"]
+                h_m, w_m = mask.shape[-2], mask.shape[-1]
+                if h_m != image_size or w_m != image_size:
+                    mask = mask.unsqueeze(0).unsqueeze(0)
+                    mask = F.interpolate(
+                        mask,
+                        size=(image_size, image_size),
+                        mode="nearest",
+                    )
+                    sample["mask"] = mask.squeeze(0).squeeze(0)
             return sample
 
         resize_transform = _resize

--- a/tests/test_geobench_v2_datasets.py
+++ b/tests/test_geobench_v2_datasets.py
@@ -1,0 +1,122 @@
+"""Tests for the geobenchV2 dataset in datasets.py module and get_datasets function."""
+
+import pytest
+import torch
+from unittest.mock import MagicMock, patch
+from torch.utils.data import DataLoader
+
+from src.datasets import get_datasets
+
+
+class MockV2Dataset:
+    def __init__(self, root, split, transforms=None, data_normalizer=None, band_order=None):
+        self.root = root
+        self.split = split
+        self.transforms = transforms
+        self.data_normalizer = data_normalizer
+        self.band_order = band_order
+
+        # Determine channels based on bands
+        self.c = len(band_order) if band_order else 3
+        self.h, self.w = 32, 32
+
+    def __len__(self):
+        return 10
+
+    def __getitem__(self, idx):
+        img = torch.randn(self.c, self.h, self.w)
+        sample = {"image": img}
+
+        if self.transforms:
+            sample = self.transforms(sample)
+
+        if getattr(self, "task_type", None) == "segmentation":
+            sample["mask"] = torch.randint(0, 2, (self.h, self.w))
+        else:
+            sample["label"] = torch.tensor(1)
+
+        return sample
+
+
+@pytest.fixture
+def mock_v2_env():
+    with patch("src.datasets.HAS_V2", True), patch("src.datasets.gb_v2") as mock_pkg:
+        # Side_effect ensures we get fresh instances
+        mock_pkg.GeoBenchBENV2 = MagicMock(side_effect=MockV2Dataset)
+        mock_pkg.GeoBenchBiomassters = MagicMock(side_effect=MockV2Dataset)
+        mock_pkg.GeoBenchSo2Sat = MagicMock(side_effect=MockV2Dataset)
+
+        yield mock_pkg
+
+
+class TestV2Loading:
+    def test_benv2_classification(self, mock_v2_env):
+        ds, train_dl, val_dl, test_dl = get_datasets(
+            dataset_name="benv2",
+            return_val=True,
+            batch_size=4,
+            num_workers=0,
+            geobench_v2_root="/tmp/dummy",
+        )
+
+        assert isinstance(train_dl, DataLoader)
+        assert len(ds) == 10
+        assert ds.task_type == "classification"
+
+        batch = next(iter(train_dl))
+        assert batch["image"].shape == (4, 3, 32, 32)  # B, C, H, W
+        assert "label" in batch
+
+    def test_biomassters_segmentation(self, mock_v2_env):
+        ds, train_dl, test_dl = get_datasets(
+            dataset_name="biomassters",
+            batch_size=2,
+            return_val=False,
+            num_workers=0,
+            geobench_v2_root="/tmp/dummy",
+        )
+
+        assert ds.task_type == "segmentation"
+
+        batch = next(iter(train_dl))
+        assert "mask" in batch
+        assert batch["image"].shape[0] == 2
+
+    def test_partition_warning(self, mock_v2_env):
+        with pytest.warns(UserWarning, match="Partitions are not supported in GeoBench V2"):
+            get_datasets(
+                dataset_name="benv2",
+                partition_name="0.10x_train",
+                geobench_v2_root="/tmp/dummy",
+                num_workers=0,
+            )
+
+    def test_resize_transform(self, mock_v2_env):
+        target = 64
+        ds, _, _ = get_datasets(
+            dataset_name="benv2",
+            image_size=target,
+            batch_size=4,
+            num_workers=0,
+            geobench_v2_root="/tmp/dummy",
+        )
+
+        assert ds.transforms is not None
+
+        dl = DataLoader(ds, batch_size=1)
+        batch = next(iter(dl))
+        assert batch["image"].shape[-1] == target
+
+    def test_missing_pkg_error(self):
+        with patch("src.datasets.HAS_V2", False):
+            # Matches strict string in src/datasets.py
+            with pytest.raises(ImportError, match="geobench_v2 package not found"):
+                get_datasets(dataset_name="benv2")
+
+    def test_bad_dataset_name(self, mock_v2_env):
+        mock_v2_env.GeoBenchPhantomDataset = None
+
+        with patch("src.datasets.V2_DATASETS", {"phantom_dataset"}):
+            # Matches strict string in src/datasets.py
+            with pytest.raises(ValueError, match="Could not find V2 dataset class"):
+                get_datasets(dataset_name="phantom_dataset", geobench_v2_root="/tmp")


### PR DESCRIPTION
This PR is part of adding the segmentation solver, but since we wanted to use some V2 datasets for segmentation, I thought it would be better to separate the PRs. Therefore this PR adds:
- specifying the geobenchv2 dataset names similar to the download and then dynamically loading the correct V2 class to load the data
- use the same resize transform
- currently only support mean/std normalization, it would probably be cleaner to add Min/Max and Percentile Normalization classes to the GeoBenchV2 code itself
- simple test script with mock dataset, could also add one for the case when actual V2 datasets are present
- implementation is likely to change a bit once we run actual segmentation probe experiments