### PR TITLE
Add core segmentation benchmarking pipeline

### DIFF
--- a/METHODOLOGY.md
+++ b/METHODOLOGY.md
@@ -145,6 +145,64 @@ Identical to the linear segmentation probe:
 
 ---
 
+## Segmentation FPN Probe
+
+**Method name:** `seg-fpn` (config: `eval.segmentation.head_type: "fpn"`)
+
+A Feature Pyramid Network-style decoder that fuses multi-scale feature maps top-down, matching the structure used in dense prediction literature.
+
+### Procedure
+
+1. Same hook-based feature extraction as the other segmentation probes. **Layers must be supplied in coarse-to-fine order** (deepest / lowest-resolution first, e.g. `["layer4", "layer3", "layer2", "layer1"]` for a ResNet).
+2. Each layer's feature map is projected to `hidden_dim` channels via a lateral 1×1 conv.
+3. A **top-down pathway** accumulates context: starting from the coarsest scale, each level is upsampled 2× and added to the next finer lateral output.
+4. Each merged level is refined with a 3×3 conv.
+5. All refined levels are upsampled to the finest spatial resolution, **concatenated**, and passed through a 1×1 conv to produce per-pixel class logits.
+6. Logits are bilinearly upsampled to the original input resolution.
+
+### Training & Evaluation
+
+Identical to the other segmentation probes (AdamW, CrossEntropyLoss, mIoU).
+
+---
+
+## Segmentation Probe Options
+
+All options are set under `eval.segmentation` in `conf/config.yaml` (global defaults) or in a model's config yaml (per-model override via `eval.segmentation`).
+
+### Head type
+
+| `head_type` | Description |
+|---|---|
+| `linear` | Per-layer BN + 1×1 conv → upsample. Multiple layers are fused with learned scalar weights. |
+| `conv_block` | Per-layer 1×1 proj to `hidden_dim` → upsample + concat → 1×1 head. |
+| `fpn` | FPN top-down pathway (see above). Layers must be coarse-to-fine. |
+| `dpt` | DPT-style reassemble + fusion transformer decoder. |
+
+### Training knobs
+
+| Option | Default | Description |
+|---|---|---|
+| `layers` | *(per model)* | List of backbone layer names to hook. For FPN, deepest layer first. |
+| `epochs` | `10` | Training epochs for the probe head. |
+| `lr` | `1e-3` | Initial learning rate (AdamW). |
+| `lr_scheduler` | `cosine` | `cosine` (CosineAnnealingLR to 1e-6) or `none` (constant). |
+| `loss` | `ce` | `ce` (CrossEntropyLoss) or `bce` (binary CE over one-hot targets). |
+| `hidden_dim` | `256` | Projection dimension for `conv_block` and `fpn` heads. |
+| `batch_size` | `64` | Batch size when training the probe head. |
+
+### Feature caching
+
+| Option | Default | Description |
+|---|---|---|
+| `cache_features` | `true` | Pre-extract backbone features once per split into RAM. Features are stored layer-first as contiguous `(N, C, H, W)` float16 tensors (`CachedFeaturesDataset`). GPU transfer is a single memcpy per layer. Eliminates backbone re-runs across epochs — the dominant speedup. |
+| `cache_dtype` | `float16` | Storage dtype for cached features. `float16` halves RAM; autocast upcasts during the head forward pass. |
+
+---
+| `loss_delta` | `initial_loss − final_loss`; near 0 means the optimizer made no progress (bad LR or detached graph) |
+
+---
+
 ## Common Configuration
 
 All tasks share these settings (configurable via Hydra):

--- a/METHODOLOGY.md
+++ b/METHODOLOGY.md
@@ -187,7 +187,7 @@ All options are set under `eval.segmentation` in `conf/config.yaml` (global defa
 | `epochs` | `10` | Training epochs for the probe head. |
 | `lr` | `1e-3` | Initial learning rate (AdamW). |
 | `lr_scheduler` | `cosine` | `cosine` (CosineAnnealingLR to 1e-6) or `none` (constant). |
-| `loss` | `ce` | `ce` (CrossEntropyLoss) or `bce` (binary CE over one-hot targets). |
+| `criterion` | `torch.nn.CrossEntropyLoss` | Instantiable loss criterion for probe-head training. Alternative criteria can be provided via the Hydra `criterion` block. |
 | `hidden_dim` | `256` | Projection dimension for `conv_block` and `fpn` heads. |
 | `batch_size` | `64` | Batch size when training the probe head. |
 

--- a/README.md
+++ b/README.md
@@ -436,7 +436,7 @@ pytest tests/test_geobench_dataset.py -k "m-eurosat" -v
 torchgeo-bench run dataset.names=[m-eurosat] eval.bootstrap=10 output=test.csv
 ```
 
-**Note:** The test suite expects the GeoBench dataset to be available in the default directory `data/`. If your data is located elsewhere, sprecify the root in the config through the keys "dataset.geobench_root" and "dataset.geobench_v2_root".
+**Note:** The test suite expects the GeoBench dataset to be available in the default directory `data/`. If your data is located elsewhere, specify the root in the config through the keys "dataset.geobench_root" and "dataset.geobench_v2_root".
 
 If the dataset is not found, relevant tests will be skipped.
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ torchgeo-bench download --version v2 --datasets caffe
 
 Available GeoBench v2 datasets: `benv2`, `biomassters`, `burn_scars`, `caffe`, `cloudsen12`, `dynamic_earthnet`, `everwatch`, `flair2`, `fotw`, `kuro_siwo`, `pastis`, `spacenet2`, `spacenet7`, `substation`, `treesatai`, `wind_turbine`, `so2sat`, `forestnet`
 
+Alternatively, you can still use the standalone script:
+
+```bash
+python torchgeo_bench_download.py --version v1
+python torchgeo_bench_download.py --version v2 --datasets forestnet
+```
+
 ## Overview
 
 `torchgeo-bench` provides:
@@ -429,23 +436,14 @@ pytest tests/test_geobench_dataset.py -k "m-eurosat" -v
 torchgeo-bench run dataset.names=[m-eurosat] eval.bootstrap=10 output=test.csv
 ```
 
-**Note:** The test suite expects the GeoBench dataset to be available in the default directory `data/`. If your data is located elsewhere, configure the paths in `conf/config.yaml` or use command-line overrides:
-
-```bash
-# Command-line override
-torchgeo-bench run dataset.geobench_root=/your/path/to/classification_v1.0
-
-# Or set environment variable (for tests)
-export GEOBENCH_ROOT=/your/path/to/classification_v1.0
-pytest
-```
+**Note:** The test suite expects the GeoBench dataset to be available in the default directory `data/`. If your data is located elsewhere, sprecify the root in the config through the keys "dataset.geobench_root" and "dataset.geobench_v2_root".
 
 If the dataset is not found, relevant tests will be skipped.
 
 The test suite includes:
 - **58 tests** covering all datasets, splits, and normalizations
 - **27 comparison tests** validating against reference implementation
-- All tests use small `0.01x_train` partitions for fast execution
+- All tests use small `0.01x_train` partitions for fast execution on GeoBenchV1
 
 ### Adding a New Model
 
@@ -501,7 +499,10 @@ Contributions welcome! Please:
 
 ### "Dataset directory not found"
 
-Ensure `GEOBENCH_ROOT` points to `classification_v1.0` directory containing dataset folders (e.g., `m-eurosat/`, `m-forestnet/`).
+Ensure the correct root is set for the dataset version you are using:
+
+- `GEOBENCH_ROOT` for GeoBench v1 (directory containing folders like `m-eurosat/`, `m-forestnet/`)
+- `GEOBENCH_V2_ROOT` for GeoBench v2 (directory containing v2 dataset folders)
 
 ### "Module 'geobench' not found"
 

--- a/docs/segmentation_layers.md
+++ b/docs/segmentation_layers.md
@@ -1,0 +1,161 @@
+# Segmentation Probe Layer Names
+
+This document records how the `eval.segmentation.layers` values were determined for each model family, and serves as a reference when adding new models.
+
+## Background
+
+`SegmentationProbe` hooks into named PyTorch modules via `backbone.named_modules()`. The layer names in each model config must exactly match these module names. Layers should be listed **deepest first** (coarsest feature map first) for the FPN head. For ASPP, only the last (deepest) entry is used.
+
+## How Layer Names Were Discovered
+
+Layer names were found by:
+1. Instantiating each timm model with `pretrained=False, num_classes=0`
+2. Running a dummy 224×224 input through the model with forward hooks on candidate layers
+3. Recording the output spatial size of each layer
+
+Discovery script:
+
+```python
+import timm, torch
+
+model = timm.create_model("resnet50", pretrained=False, num_classes=0)
+model.eval()
+x = torch.zeros(1, 3, 224, 224)
+shapes = {}
+handles = []
+
+for name in ["layer1", "layer2", "layer3", "layer4"]:
+    module = dict(model.named_modules())[name]
+    def hook(n):
+        def fn(m, inp, out): shapes[n] = out.shape
+        return fn
+    handles.append(module.register_forward_hook(hook(name)))
+
+with torch.no_grad():
+    model(x)
+for h in handles:
+    h.remove()
+
+print(shapes)
+```
+
+## Layer Names by Family
+
+All spatial sizes are for a 224×224 input image.
+
+### ResNet (resnet18, resnet34, resnet50, resnet101)
+
+| Layer | Spatial size | Channels (resnet50) |
+|---|---|---|
+| `layer4` | 7×7 | 2048 |
+| `layer3` | 14×14 | 1024 |
+| `layer2` | 28×28 | 512 |
+| `layer1` | 56×56 | 256 |
+
+Config: `layers: ["layer4", "layer3", "layer2", "layer1"]`
+
+### DenseNet (densenet121, densenet161)
+
+| Layer | Spatial size | Channels (densenet121) |
+|---|---|---|
+| `features.denseblock4` | 7×7 | 1024 |
+| `features.denseblock3` | 14×14 | 1024 |
+| `features.denseblock2` | 28×28 | 512 |
+| `features.denseblock1` | 56×56 | 256 |
+
+Config: `layers: ["features.denseblock4", "features.denseblock3", "features.denseblock2", "features.denseblock1"]`
+
+Note: `features.transition1/2/3` downsample between denseblocks. Using the denseblocks (before downsampling) gives richer features.
+
+### VGG16
+
+| Layer | Spatial size | Description |
+|---|---|---|
+| `features.30` | 7×7 | After pool5 |
+| `features.23` | 14×14 | After pool4 |
+| `features.16` | 28×28 | After pool3 |
+| `features.9` | 56×56 | After pool2 |
+
+Config: `layers: ["features.30", "features.23", "features.16", "features.9"]`
+
+### VGG19
+
+| Layer | Spatial size | Description |
+|---|---|---|
+| `features.36` | 7×7 | After pool5 |
+| `features.27` | 14×14 | After pool4 |
+| `features.18` | 28×28 | After pool3 |
+| `features.9` | 56×56 | After pool2 |
+
+Config: `layers: ["features.36", "features.27", "features.18", "features.9"]`
+
+Note: VGG19 has more conv layers per stage than VGG16, so the MaxPool indices differ.
+
+### EfficientNet (efficientnet_b0, b1, b2, b3)
+
+| Layer | Spatial size | Channels (b0) |
+|---|---|---|
+| `blocks.6` | 7×7 | 320 |
+| `blocks.5` | 7×7 | 192 |
+| `blocks.3` | 14×14 | 80 |
+| `blocks.1` | 56×56 | 24 |
+
+Config: `layers: ["blocks.6", "blocks.5", "blocks.3", "blocks.1"]`
+
+**Note:** `blocks.4`, `blocks.5`, and `blocks.6` all operate at 7×7 (EfficientNet uses multiple MBConv stages at the same stride). We include `blocks.5` to get 4 layers, though it shares spatial size with `blocks.6`. If 3 distinct pyramid levels are preferred, use `["blocks.6", "blocks.3", "blocks.1"]`.
+
+### ConvNeXt (convnext_tiny, small, base, large, large_dinov3)
+
+| Layer | Spatial size | Channels (tiny) |
+|---|---|---|
+| `stages.3` | 7×7 | 768 |
+| `stages.2` | 14×14 | 384 |
+| `stages.1` | 28×28 | 192 |
+| `stages.0` | 56×56 | 96 |
+
+Config: `layers: ["stages.3", "stages.2", "stages.1", "stages.0"]`
+
+### MobileNetV3-Large (mobilenetv3_large_100)
+
+| Layer | Spatial size | Channels |
+|---|---|---|
+| `blocks.6` | 7×7 | 960 |
+| `blocks.5` | 7×7 | 160 |
+| `blocks.3` | 14×14 | 80 |
+| `blocks.1` | 56×56 | 24 |
+
+Config: `layers: ["blocks.6", "blocks.5", "blocks.3", "blocks.1"]`
+
+**Note:** `blocks.5` and `blocks.6` share 7×7 (same as EfficientNet note above).
+
+### MobileNetV3-Small (mobilenetv3_small_100)
+
+| Layer | Spatial size | Channels |
+|---|---|---|
+| `blocks.5` | 7×7 | 576 |
+| `blocks.4` | 7×7 | 96 |
+| `blocks.2` | 14×14 | 40 |
+| `blocks.1` | 28×28 | 24 |
+
+Config: `layers: ["blocks.5", "blocks.4", "blocks.2", "blocks.1"]`
+
+Note: MobileNetV3-Small only has 6 blocks (0–5), unlike the Large variant which has 7 (0–6). The shallowest useful stage is 28×28 (no 56×56 stage).
+
+### RegNet (regnetx_002, regnetx_008, regnety_002, regnety_008)
+
+| Layer | Spatial size | Channels (regnetx_002) |
+|---|---|---|
+| `s4` | 7×7 | 368 |
+| `s3` | 14×14 | 152 |
+| `s2` | 28×28 | 56 |
+| `s1` | 56×56 | 24 |
+
+Config: `layers: ["s4", "s3", "s2", "s1"]`
+
+## Adding a New Model
+
+1. Instantiate the model with `timm.create_model(name, pretrained=False, num_classes=0)`
+2. Print top-level modules: `[name for name, _ in model.named_children()]`
+3. Run the discovery script above to confirm spatial sizes
+4. Add to the model config in coarse-to-fine order (deepest first)
+5. Note any stages that share spatial size (common in EfficientNet/MobileNet)

--- a/docs/segmentation_layers.md
+++ b/docs/segmentation_layers.md
@@ -4,7 +4,7 @@ This document records how the `eval.segmentation.layers` values were determined 
 
 ## Background
 
-`SegmentationProbe` hooks into named PyTorch modules via `backbone.named_modules()`. The layer names in each model config must exactly match these module names. Layers should be listed **deepest first** (coarsest feature map first) for the FPN head. For ASPP, only the last (deepest) entry is used.
+`SegmentationProbe` hooks into named PyTorch modules via `backbone.named_modules()`. The layer names in each model config must exactly match these module names. Layers should be listed **deepest first** (coarsest feature map first) for the FPN head.
 
 ## How Layer Names Were Discovered
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,9 @@ urls.Issues = "https://github.com/calebrob6/torchgeo-bench/issues"
 urls.Repository = "https://github.com/calebrob6/torchgeo-bench"
 scripts.torchgeo-bench = "torchgeo_bench.cli:main"
 
+[tool.hatch]
+build.targets.wheel.packages = [ "src/torchgeo_bench" ]
+
 [tool.ruff]
 target-version = "py312"
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ optional-dependencies.sam3 = [
 ]
 optional-dependencies.viz = [
   "matplotlib>=3.5",
-  "pillow>=9.0",
+  "pillow>=9",
 ]
 urls.Documentation = "https://github.com/calebrob6/torchgeo-bench/blob/main/README.md"
 urls.Homepage = "https://github.com/calebrob6/torchgeo-bench"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dependencies = [
 optional-dependencies.all = [
   "torchgeo-bench[dev]",
   "torchgeo-bench[sam3]",
+  "torchgeo-bench[viz]",
 ]
 optional-dependencies.dev = [
   "mdformat>=0.7.22",
@@ -66,6 +67,10 @@ optional-dependencies.olmoearth = [
 ]
 optional-dependencies.sam3 = [
   "transformers>=4.50",
+]
+optional-dependencies.viz = [
+  "matplotlib>=3.5",
+  "Pillow>=9.0",
 ]
 urls.Documentation = "https://github.com/calebrob6/torchgeo-bench/blob/main/README.md"
 urls.Homepage = "https://github.com/calebrob6/torchgeo-bench"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dependencies = [
 ]
 optional-dependencies.all = [
   "torchgeo-bench[dev]",
+  "torchgeo-bench[sam3]",
 ]
 optional-dependencies.dev = [
   "mdformat>=0.7.22",
@@ -62,6 +63,9 @@ optional-dependencies.dev = [
 ]
 optional-dependencies.olmoearth = [
   "olmoearth-pretrain-minimal>=0.0.2",
+]
+optional-dependencies.sam3 = [
+  "transformers>=4.50",
 ]
 urls.Documentation = "https://github.com/calebrob6/torchgeo-bench/blob/main/README.md"
 urls.Homepage = "https://github.com/calebrob6/torchgeo-bench"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ optional-dependencies.sam3 = [
 ]
 optional-dependencies.viz = [
   "matplotlib>=3.5",
-  "Pillow>=9.0",
+  "pillow>=9.0",
 ]
 urls.Documentation = "https://github.com/calebrob6/torchgeo-bench/blob/main/README.md"
 urls.Homepage = "https://github.com/calebrob6/torchgeo-bench"

--- a/src/torchgeo_bench/conf/config.yaml
+++ b/src/torchgeo_bench/conf/config.yaml
@@ -29,10 +29,21 @@ eval:
   skip_linear: false       # if true, skip LogisticRegression evaluation
 
   segmentation:
-    head_type: "linear"
+    head_type: "fpn"
     layers: []
     lr: 1e-3
-    epochs: 1
+    epochs: 10
+    criterion:
+      _target_: torch.nn.CrossEntropyLoss
+      ignore_index: 255
+    lr_scheduler: "cosine"  # "cosine" (CosineAnnealingLR) or "none"
+    # Feature caching: run frozen backbone once, cache features to RAM for head training
+    cache_features: true        # pre-extract backbone features (large speedup for ViT)
+    cache_dtype: "float16"      # storage dtype: "float16" (half RAM) or "float32"
+    # Visualization (opt-in)
+    save_viz: false            # set true to save prediction grids and confusion matrices
+    viz_dir: "viz"             # root output directory for visualizations
+    n_viz_samples: 8           # number of test samples shown in the sample grid
 
 hydra:
   run:

--- a/src/torchgeo_bench/conf/model/sam3_encoder.yaml
+++ b/src/torchgeo_bench/conf/model/sam3_encoder.yaml
@@ -1,0 +1,39 @@
+# SAM3 vision encoder (ViT-H + FPN neck) — frozen backbone probe
+#
+# Architecture:
+#   - ViT-H backbone: 32 layers, hidden size 1024, patch size 14
+#   - FPN neck: 4 scale levels, all with 256 channels
+#   - Input: RGB only (3 channels); arbitrary resolution supported.
+#     RoPE embeddings are reset on the first forward pass to match the
+#     actual dataset image size (cropped to nearest multiple of 14).
+#
+# Hooked FPN layers (coarse-to-fine for FPN/DPT head).
+# Spatial dims scale with input resolution; at 252×252 (18×18 tokens):
+#   neck.fpn_layers.3:  9× 9, 256 ch  (scale 0.5× patch grid)
+#   neck.fpn_layers.2: 18×18, 256 ch  (scale 1×)
+#   neck.fpn_layers.1: 36×36, 256 ch  (scale 2×)
+#   neck.fpn_layers.0: 72×72, 256 ch  (scale 4×)
+#
+# Run with:
+#   torchgeo-bench run model=sam3_encoder dataset.bands=[red,green,blue]
+#
+# Local checkpoint (recommended — avoids gated-repo authentication):
+#   Set checkpoint_path to the directory containing model.safetensors + config.json.
+
+_target_: torchgeo_bench.models.SAM3Encoder
+num_channels: 3
+checkpoint_path: checkpoints/sam3
+name: sam3_encoder
+
+eval:
+  segmentation:
+    # Coarse-to-fine order required by FPN/DPT heads
+    layers:
+      - "neck.fpn_layers.3"
+      - "neck.fpn_layers.2"
+      - "neck.fpn_layers.1"
+      - "neck.fpn_layers.0"
+    head_type: fpn
+    # Cache in float16 to save RAM
+    cache_dtype: float16
+    cache_features: true

--- a/src/torchgeo_bench/conf/model/timm/convnext_base.yaml
+++ b/src/torchgeo_bench/conf/model/timm/convnext_base.yaml
@@ -8,3 +8,7 @@ pretrained: true
 global_pool: avg
 seed: null
 name: convnext_base
+eval:
+  segmentation:
+    # Layers in coarse-to-fine order (deepest first) for FPN head.
+    layers: ["stages.3", "stages.2", "stages.1", "stages.0"]

--- a/src/torchgeo_bench/conf/model/timm/convnext_large.yaml
+++ b/src/torchgeo_bench/conf/model/timm/convnext_large.yaml
@@ -4,3 +4,7 @@ pretrained: true
 global_pool: avg
 seed: null
 name: convnext_large
+eval:
+  segmentation:
+    # Layers in coarse-to-fine order (deepest first) for FPN head.
+    layers: ["stages.3", "stages.2", "stages.1", "stages.0"]

--- a/src/torchgeo_bench/conf/model/timm/convnext_large_dinov3.yaml
+++ b/src/torchgeo_bench/conf/model/timm/convnext_large_dinov3.yaml
@@ -3,3 +3,7 @@ model_name: convnext_large.dinov3_lvd1689m
 pretrained: true
 global_pool: avg
 name: convnext_large_dinov3
+eval:
+  segmentation:
+    # Layers in coarse-to-fine order (deepest first) for FPN head.
+    layers: ["stages.3", "stages.2", "stages.1", "stages.0"]

--- a/src/torchgeo_bench/conf/model/timm/convnext_small.yaml
+++ b/src/torchgeo_bench/conf/model/timm/convnext_small.yaml
@@ -8,3 +8,7 @@ pretrained: true
 global_pool: avg
 seed: null
 name: convnext_small
+eval:
+  segmentation:
+    # Layers in coarse-to-fine order (deepest first) for FPN head.
+    layers: ["stages.3", "stages.2", "stages.1", "stages.0"]

--- a/src/torchgeo_bench/conf/model/timm/convnext_tiny.yaml
+++ b/src/torchgeo_bench/conf/model/timm/convnext_tiny.yaml
@@ -8,3 +8,7 @@ pretrained: true
 global_pool: avg
 seed: null
 name: convnext_tiny
+eval:
+  segmentation:
+    # Layers in coarse-to-fine order (deepest first) for FPN head.
+    layers: ["stages.3", "stages.2", "stages.1", "stages.0"]

--- a/src/torchgeo_bench/conf/model/timm/densenet121.yaml
+++ b/src/torchgeo_bench/conf/model/timm/densenet121.yaml
@@ -8,3 +8,7 @@ pretrained: true
 global_pool: avg
 seed: null
 name: densenet121
+eval:
+  segmentation:
+    # Layers in coarse-to-fine order (deepest first) for FPN head.
+    layers: ["features.denseblock4", "features.denseblock3", "features.denseblock2", "features.denseblock1"]

--- a/src/torchgeo_bench/conf/model/timm/densenet161.yaml
+++ b/src/torchgeo_bench/conf/model/timm/densenet161.yaml
@@ -8,3 +8,7 @@ pretrained: true
 global_pool: avg
 seed: null
 name: densenet161
+eval:
+  segmentation:
+    # Layers in coarse-to-fine order (deepest first) for FPN head.
+    layers: ["features.denseblock4", "features.denseblock3", "features.denseblock2", "features.denseblock1"]

--- a/src/torchgeo_bench/conf/model/timm/efficientnet_b0.yaml
+++ b/src/torchgeo_bench/conf/model/timm/efficientnet_b0.yaml
@@ -8,3 +8,8 @@ pretrained: true
 global_pool: avg
 seed: null
 name: efficientnet_b0
+eval:
+  segmentation:
+    # Layers in coarse-to-fine order (deepest first) for FPN head.
+    # Spatial sizes (224px input): 7, 7, 14, 56. Note blocks.5/6 share 7×7.
+    layers: ["blocks.6", "blocks.5", "blocks.3", "blocks.1"]

--- a/src/torchgeo_bench/conf/model/timm/efficientnet_b1.yaml
+++ b/src/torchgeo_bench/conf/model/timm/efficientnet_b1.yaml
@@ -8,4 +8,9 @@ pretrained: true
 global_pool: avg
 seed: null
 name: efficientnet_b1
+eval:
+  segmentation:
+    # Layers in coarse-to-fine order (deepest first) for FPN head.
+    # Spatial sizes (224px input): 7, 7, 14, 56. Note blocks.5/6 share 7×7.
+    layers: ["blocks.6", "blocks.5", "blocks.3", "blocks.1"]
 auto_resize: true

--- a/src/torchgeo_bench/conf/model/timm/efficientnet_b2.yaml
+++ b/src/torchgeo_bench/conf/model/timm/efficientnet_b2.yaml
@@ -8,4 +8,9 @@ pretrained: true
 global_pool: avg
 seed: null
 name: efficientnet_b2
+eval:
+  segmentation:
+    # Layers in coarse-to-fine order (deepest first) for FPN head.
+    # Spatial sizes (224px input): 7, 7, 14, 56. Note blocks.5/6 share 7×7.
+    layers: ["blocks.6", "blocks.5", "blocks.3", "blocks.1"]
 auto_resize: true

--- a/src/torchgeo_bench/conf/model/timm/efficientnet_b3.yaml
+++ b/src/torchgeo_bench/conf/model/timm/efficientnet_b3.yaml
@@ -8,4 +8,9 @@ pretrained: true
 global_pool: avg
 seed: null
 name: efficientnet_b3
+eval:
+  segmentation:
+    # Layers in coarse-to-fine order (deepest first) for FPN head.
+    # Spatial sizes (224px input): 7, 7, 14, 56. Note blocks.5/6 share 7×7.
+    layers: ["blocks.6", "blocks.5", "blocks.3", "blocks.1"]
 auto_resize: true

--- a/src/torchgeo_bench/conf/model/timm/maxvit_tiny_tf_224.yaml
+++ b/src/torchgeo_bench/conf/model/timm/maxvit_tiny_tf_224.yaml
@@ -8,3 +8,7 @@ pretrained: true
 global_pool: avg
 seed: null
 name: maxvit_tiny_tf_224
+eval:
+  segmentation:
+    # Coarse-to-fine: stages.3 (7×7, 512ch) → stages.0 (56×56, 64ch)
+    layers: ["stages.3", "stages.2", "stages.1", "stages.0"]

--- a/src/torchgeo_bench/conf/model/timm/mobilenetv3_large_100.yaml
+++ b/src/torchgeo_bench/conf/model/timm/mobilenetv3_large_100.yaml
@@ -8,3 +8,8 @@ pretrained: true
 global_pool: avg
 seed: null
 name: mobilenetv3_large_100
+eval:
+  segmentation:
+    # Layers in coarse-to-fine order (deepest first) for FPN head.
+    # Spatial sizes (224px input): 7, 7, 14, 56. Note blocks.5/6 share 7×7.
+    layers: ["blocks.6", "blocks.5", "blocks.3", "blocks.1"]

--- a/src/torchgeo_bench/conf/model/timm/mobilenetv3_small_100.yaml
+++ b/src/torchgeo_bench/conf/model/timm/mobilenetv3_small_100.yaml
@@ -8,3 +8,8 @@ pretrained: true
 global_pool: avg
 seed: null
 name: mobilenetv3_small_100
+eval:
+  segmentation:
+    # Layers in coarse-to-fine order (deepest first) for FPN head.
+    # Spatial sizes (224px input): 7, 7, 14, 28. Note blocks.4/5 share 7×7.
+    layers: ["blocks.5", "blocks.4", "blocks.2", "blocks.1"]

--- a/src/torchgeo_bench/conf/model/timm/regnetx_002.yaml
+++ b/src/torchgeo_bench/conf/model/timm/regnetx_002.yaml
@@ -8,3 +8,7 @@ pretrained: true
 global_pool: avg
 seed: null
 name: regnetx_002
+eval:
+  segmentation:
+    # Layers in coarse-to-fine order (deepest first) for FPN head.
+    layers: ["s4", "s3", "s2", "s1"]

--- a/src/torchgeo_bench/conf/model/timm/regnetx_008.yaml
+++ b/src/torchgeo_bench/conf/model/timm/regnetx_008.yaml
@@ -8,3 +8,7 @@ pretrained: true
 global_pool: avg
 seed: null
 name: regnetx_008
+eval:
+  segmentation:
+    # Layers in coarse-to-fine order (deepest first) for FPN head.
+    layers: ["s4", "s3", "s2", "s1"]

--- a/src/torchgeo_bench/conf/model/timm/regnety_002.yaml
+++ b/src/torchgeo_bench/conf/model/timm/regnety_002.yaml
@@ -8,3 +8,7 @@ pretrained: true
 global_pool: avg
 seed: null
 name: regnety_002
+eval:
+  segmentation:
+    # Layers in coarse-to-fine order (deepest first) for FPN head.
+    layers: ["s4", "s3", "s2", "s1"]

--- a/src/torchgeo_bench/conf/model/timm/regnety_008.yaml
+++ b/src/torchgeo_bench/conf/model/timm/regnety_008.yaml
@@ -8,3 +8,7 @@ pretrained: true
 global_pool: avg
 seed: null
 name: regnety_008
+eval:
+  segmentation:
+    # Layers in coarse-to-fine order (deepest first) for FPN head.
+    layers: ["s4", "s3", "s2", "s1"]

--- a/src/torchgeo_bench/conf/model/timm/resnet101.yaml
+++ b/src/torchgeo_bench/conf/model/timm/resnet101.yaml
@@ -8,3 +8,7 @@ pretrained: true
 global_pool: avg
 seed: null
 name: resnet101
+eval:
+  segmentation:
+    # Layers in coarse-to-fine order (deepest first) for FPN head.
+    layers: ["layer4", "layer3", "layer2", "layer1"]

--- a/src/torchgeo_bench/conf/model/timm/resnet18.yaml
+++ b/src/torchgeo_bench/conf/model/timm/resnet18.yaml
@@ -8,3 +8,7 @@ pretrained: true
 global_pool: avg
 seed: null
 name: resnet18
+eval:
+  segmentation:
+    # Layers in coarse-to-fine order (deepest first) for FPN head.
+    layers: ["layer4", "layer3", "layer2", "layer1"]

--- a/src/torchgeo_bench/conf/model/timm/resnet34.yaml
+++ b/src/torchgeo_bench/conf/model/timm/resnet34.yaml
@@ -8,3 +8,7 @@ pretrained: true
 global_pool: avg
 seed: null
 name: resnet34
+eval:
+  segmentation:
+    # Layers in coarse-to-fine order (deepest first) for FPN head.
+    layers: ["layer4", "layer3", "layer2", "layer1"]

--- a/src/torchgeo_bench/conf/model/timm/resnet50.yaml
+++ b/src/torchgeo_bench/conf/model/timm/resnet50.yaml
@@ -8,3 +8,7 @@ pretrained: true
 global_pool: avg
 seed: null
 name: resnet50
+eval:
+  segmentation:
+    # Layers in coarse-to-fine order (deepest first) for FPN head.
+    layers: ["layer4", "layer3", "layer2", "layer1"]

--- a/src/torchgeo_bench/conf/model/timm/vgg16.yaml
+++ b/src/torchgeo_bench/conf/model/timm/vgg16.yaml
@@ -8,3 +8,8 @@ pretrained: true
 global_pool: avg
 seed: null
 name: vgg16
+eval:
+  segmentation:
+    # Layers at MaxPool boundaries, coarse-to-fine (deepest first) for FPN head.
+    # Spatial sizes (224px input): 7, 14, 28, 56.
+    layers: ["features.30", "features.23", "features.16", "features.9"]

--- a/src/torchgeo_bench/conf/model/timm/vgg19.yaml
+++ b/src/torchgeo_bench/conf/model/timm/vgg19.yaml
@@ -8,3 +8,8 @@ pretrained: true
 global_pool: avg
 seed: null
 name: vgg19
+eval:
+  segmentation:
+    # Layers at MaxPool boundaries, coarse-to-fine (deepest first) for FPN head.
+    # Spatial sizes (224px input): 7, 14, 28, 56.
+    layers: ["features.36", "features.27", "features.18", "features.9"]

--- a/src/torchgeo_bench/conf/model/torchgeo/dofa_base.yaml
+++ b/src/torchgeo_bench/conf/model/torchgeo/dofa_base.yaml
@@ -10,3 +10,8 @@ auto_resize: true
 target_size: 224
 name: tgeo_dofa_base
 normalization: none
+eval:
+  segmentation:
+    # ViT-Base (12 blocks, 768ch). Coarse-to-fine: deepest block first.
+    # backbone.* prefix is stripped by SegmentationProbe automatically.
+    layers: ["blocks.11", "blocks.8", "blocks.5", "blocks.2"]

--- a/src/torchgeo_bench/conf/model/torchgeo/scalemae_large_fmow.yaml
+++ b/src/torchgeo_bench/conf/model/torchgeo/scalemae_large_fmow.yaml
@@ -9,3 +9,8 @@ auto_resize: true
 target_size: 224
 name: tgeo_scalemae_large_fmow
 normalization: none
+eval:
+  segmentation:
+    # ViT-Large (24 blocks, 1024ch). Coarse-to-fine: deepest block first.
+    # backbone.* prefix is stripped by SegmentationProbe automatically.
+    layers: ["blocks.23", "blocks.17", "blocks.11", "blocks.5"]

--- a/src/torchgeo_bench/conf/model/torchgeo/swinv2b_s2rgb_satlas_mi.yaml
+++ b/src/torchgeo_bench/conf/model/torchgeo/swinv2b_s2rgb_satlas_mi.yaml
@@ -9,3 +9,9 @@ auto_resize: true
 target_size: 256
 name: tgeo_swinv2b_s2rgb_satlas_mi
 normalization: none
+eval:
+  segmentation:
+    # SwinV2-B: 4 stages via backbone.features[1,3,5,7] (patch merging at 0,2,4,6).
+    # Coarse-to-fine: features.7 (8×8, 1024ch) → features.1 (64×64, 128ch).
+    # backbone.* prefix is stripped by SegmentationProbe automatically.
+    layers: ["features.7", "features.5", "features.3", "features.1"]

--- a/src/torchgeo_bench/datasets/caffe.py
+++ b/src/torchgeo_bench/datasets/caffe.py
@@ -16,7 +16,7 @@ class CaFFe(_V2Dataset):
     task = "segmentation"
     num_classes = 4
     multilabel = False
-    rgb_bands = ["gray"]
+    rgb_bands = ["gray", "gray", "gray"]
     split_sizes = {"train": 4000, "val": 1000, "test": 2000}
 
     # fmt: off

--- a/src/torchgeo_bench/main.py
+++ b/src/torchgeo_bench/main.py
@@ -14,7 +14,7 @@ import torch
 from hydra.utils import instantiate
 from omegaconf import DictConfig, OmegaConf
 from sklearn.metrics import accuracy_score, average_precision_score
-from torch.utils.data import DataLoader
+from torch.utils.data import ConcatDataset, DataLoader
 from torchgeo.datasets.errors import DatasetNotFoundError
 from tqdm import tqdm
 
@@ -26,8 +26,12 @@ from torchgeo_bench.datasets import (
 from torchgeo_bench.knn import KNNClassifier
 from torchgeo_bench.linear import LogisticRegression
 from torchgeo_bench.models.interface import BenchModel
-from torchgeo_bench.segmentation_probe import SegmentationProbe
-from torchgeo_bench.segmentation_task import SegmentationSolver
+from torchgeo_bench.segmentation_probe import (
+    CachedFeaturesDataset,
+    GPUTensorCache,
+    SegmentationProbe,
+)
+from torchgeo_bench.segmentation_task import SegmentationSolver, SegMetrics
 from torchgeo_bench.utils import extract_features
 
 logger = logging.getLogger(__name__)
@@ -146,13 +150,15 @@ class EvaluationResult:
     """Container for a single evaluation result row."""
 
     dataset: str
-    method: str  # 'knn5' or 'linear' seg_linear, seg_conv
-    metric_name: str  # 'accuracy' or 'mIoU'
+    method: str  # 'knn5', 'linear', or seg head type
+    metric_name: str  # 'accuracy', 'micro_mAP', or 'mIoU' (primary metric)
     metric_value: float
     ci_lower: float
     ci_upper: float
     feature_dim: int
     best_c: float | None
+    best_lr: float | None
+    best_batch_size: int | None
     n_train: int
     n_val: int
     n_test: int
@@ -169,6 +175,11 @@ class EvaluationResult:
     c_range_num: int
     merge_val: bool
     bootstrap: int
+    # Segmentation-only metrics (None for classification rows)
+    fw_iou: float | None = None
+    precision: float | None = None
+    recall: float | None = None
+    f1: float | None = None
 
     def to_row(self) -> dict:
         """Convert to a flat dictionary suitable for CSV/DataFrame export."""
@@ -332,6 +343,74 @@ def evaluate_logistic(
     return metric, lo, hi, float(best_c)
 
 
+def _make_seg_dataloaders(
+    train_dataset: torch.utils.data.Dataset,
+    val_dataset: torch.utils.data.Dataset,
+    test_loader: DataLoader,
+    batch_size: int,
+) -> tuple[DataLoader, DataLoader, DataLoader]:
+    """Build train, val, and train+val DataLoaders for a given batch size.
+
+    Args:
+        train_dataset: Training split dataset.
+        val_dataset: Validation split dataset.
+        test_loader: Pre-built test loader (reused as-is).
+        batch_size: Batch size for the new loaders.
+
+    Returns:
+        Tuple of (train_loader, val_loader, train_val_loader).
+    """
+    loader_kwargs = {
+        "batch_size": batch_size,
+        "num_workers": test_loader.num_workers,
+        "pin_memory": test_loader.pin_memory,
+    }
+    train_loader = DataLoader(train_dataset, shuffle=True, **loader_kwargs)
+    val_loader = DataLoader(val_dataset, shuffle=False, **loader_kwargs)
+    train_val_loader = DataLoader(
+        ConcatDataset([train_dataset, val_dataset]), shuffle=True, **loader_kwargs
+    )
+    return train_loader, val_loader, train_val_loader
+
+
+def _build_seg_probe_and_solver(
+    model: torch.nn.Module,
+    num_classes: int,
+    eval_cfg: DictConfig,
+    device: torch.device,
+    lr: float,
+) -> tuple[SegmentationProbe, SegmentationSolver]:
+    """Instantiate a fresh SegmentationProbe and SegmentationSolver.
+
+    Args:
+        model: Frozen backbone (shared across calls; only the head is re-created).
+        num_classes: Number of segmentation classes.
+        eval_cfg: Merged evaluation config with segmentation sub-config.
+        device: Target device.
+        lr: Learning rate for the solver optimizer.
+
+    Returns:
+        Tuple of (probe, solver).
+    """
+    probe = SegmentationProbe(
+        backbone=model,
+        layer_names=eval_cfg.segmentation.layers,
+        num_classes=num_classes,
+        head_type=eval_cfg.segmentation.head_type,
+        freeze_backbone=True,
+    )
+    criterion = instantiate(eval_cfg.segmentation.criterion)
+    solver = SegmentationSolver(
+        model=probe,
+        num_classes=num_classes,
+        lr=lr,
+        device=str(device),
+        criterion=criterion,
+        lr_scheduler=eval_cfg.segmentation.get("lr_scheduler", "cosine"),
+    )
+    return probe, solver
+
+
 def evaluate_segmentation(
     model: torch.nn.Module,
     train_loader: DataLoader,
@@ -340,41 +419,72 @@ def evaluate_segmentation(
     cfg: DictConfig,
     num_classes: int,
     device: torch.device,
-) -> tuple[float, int]:
-    """Evaluate segmentation performance using a segmentation probe and solver."""
-    # merge with model specific eval config if present
+    collect_preds: bool = False,
+) -> "tuple[SegMetrics, int, float | None, int | None, torch.Tensor | None]":
+    """Evaluate segmentation performance using a frozen-backbone segmentation probe.
+
+    Trains a lightweight segmentation head on top of the frozen backbone and
+    evaluates mIoU on the test split. Optionally pre-caches backbone features for
+    faster training across epochs.
+
+    Args:
+        model: Frozen backbone model.
+        train_loader: Training DataLoader.
+        val_loader: Validation DataLoader.
+        test_loader: Test DataLoader.
+        cfg: Full Hydra config.
+        num_classes: Number of segmentation classes.
+        device: Torch device.
+        collect_preds: If True, collect and return test predictions as (N, H, W) tensor.
+
+    Returns:
+        Tuple of (metrics_dict, feature_dim, None, None, preds_or_None).
+        ``preds_or_None`` is None when collect_preds is False.
+    """
+    # Merge model-specific eval config if present
     eval_cfg = cfg.eval
     if "eval" in cfg.model and cfg.model.eval is not None:
         eval_cfg = OmegaConf.merge(eval_cfg, cfg.model.eval)
     if "segmentation" not in eval_cfg:
         raise ValueError("Segmentation evaluation config missing for the model.")
 
-    probe = SegmentationProbe(
-        backbone=model,
-        layer_names=eval_cfg.segmentation.layers,
-        num_classes=num_classes,
-        head_type=eval_cfg.segmentation.head_type,
-        freeze_backbone=True,
+    seg_cfg = eval_cfg.segmentation
+    epochs = seg_cfg.epochs
+    use_cache = seg_cfg.get("cache_features", True)
+    cache_dtype_str = seg_cfg.get("cache_dtype", "float16")
+    cache_dtype = torch.float16 if cache_dtype_str == "float16" else torch.float32
+
+    probe, solver = _build_seg_probe_and_solver(
+        model, num_classes, eval_cfg, device, seg_cfg.lr
     )
+    if use_cache and probe.freeze_backbone:
+        logger.info("Caching backbone features for train and val splits...")
+        train_cache = probe.extract_all_features(train_loader, cache_dtype=cache_dtype)
+        val_cache = probe.extract_all_features(val_loader, cache_dtype=cache_dtype)
+        test_cache = probe.extract_all_features(test_loader, cache_dtype=cache_dtype)
+        solver.fit_cached(
+            train_cache=train_cache,
+            val_cache=val_cache,
+            batch_size=seg_cfg.get("batch_size", 64),
+            epochs=epochs,
+            verbose=cfg.verbose,
+        )
+        eval_result = solver.evaluate_cached(
+            test_cache,
+            batch_size=seg_cfg.get("batch_size", 64),
+            collect_preds=collect_preds,
+        )
+    else:
+        solver.fit(
+            train_loader=train_loader, val_loader=val_loader, epochs=epochs, verbose=cfg.verbose
+        )
+        eval_result = solver.evaluate(test_loader, collect_preds=collect_preds)
 
-    solver = SegmentationSolver(
-        model=probe,
-        num_classes=num_classes,
-        lr=eval_cfg.segmentation.lr,
-        device=str(device),
-    )
-
-    solver.fit(
-        train_loader=train_loader,
-        val_loader=val_loader,
-        epochs=eval_cfg.segmentation.epochs,
-        verbose=cfg.verbose,
-    )
-
-    miou = solver.evaluate(test_loader)
-    feature_dim = sum(probe.channels_list)
-
-    return miou, feature_dim
+    if collect_preds:
+        metrics, preds = eval_result
+    else:
+        metrics, preds = eval_result, None
+    return metrics, sum(probe.channels_list), None, None, preds
 
 
 # ---------------------------------------------------------------------------
@@ -593,24 +703,77 @@ def main(cfg: DictConfig) -> None:
         }
 
         if is_segmentation:
-            miou, feat_dim = evaluate_segmentation(
-                model, train_loader, val_loader, test_loader, cfg, num_classes, device
+            seg_cfg_merged = OmegaConf.merge(
+                cfg.eval,
+                cfg.model.eval if "eval" in cfg.model and cfg.model.eval is not None else {},
+            ).segmentation
+            save_viz = seg_cfg_merged.get("save_viz", False)
+            metrics, feat_dim, best_lr, best_bs, preds = evaluate_segmentation(
+                model,
+                train_loader,
+                val_loader,
+                test_loader,
+                cfg,
+                num_classes,
+                device,
+                collect_preds=save_viz,
             )
             all_rows.append(
                 EvaluationResult(
                     **common_meta,
                     method=seg_method,
                     metric_name="mIoU",
-                    metric_value=miou,
+                    metric_value=metrics.get("mIoU", float("nan")),
                     ci_lower=0.0,
                     ci_upper=0.0,
                     feature_dim=feat_dim,
                     best_c=None,
+                    best_lr=best_lr,
+                    best_batch_size=best_bs,
                     n_train=len(train_dataset),
                     n_val=len(val_loader.dataset),
                     n_test=len(test_loader.dataset),
+                    fw_iou=metrics.get("fw_IoU"),
+                    precision=metrics.get("precision"),
+                    recall=metrics.get("recall"),
+                    f1=metrics.get("f1"),
                 ).to_row()
             )
+            if save_viz and preds is not None:
+                from torchgeo_bench.segmentation_viz import save_segmentation_viz
+
+                rgb_indices = ds_cls().rgb_indices or [0, 1, 2]
+                # Collect images and GT masks from test_loader (cheap pass, no backbone)
+                test_imgs, test_gts = [], []
+                for _batch in test_loader:
+                    if isinstance(_batch, dict):
+                        test_imgs.append(_batch["image"])
+                        _m = _batch["mask"]
+                    else:
+                        test_imgs.append(_batch[0])
+                        _m = _batch[1]
+                    if _m.ndim == 4:
+                        _m = _m.squeeze(1)
+                    test_gts.append(_m.long())
+                test_imgs_t = torch.cat(test_imgs, dim=0)
+                test_gts_t = torch.cat(test_gts, dim=0)
+                ignore_idx = seg_cfg_merged.get("ignore_index", 255)
+                n_viz = seg_cfg_merged.get("n_viz_samples", 8)
+                viz_dir = seg_cfg_merged.get("viz_dir", "viz")
+                _class_names = list(getattr(train_dataset, "classes", None) or []) or None
+                save_segmentation_viz(
+                    out_dir=viz_dir,
+                    model_name=cfg.model.name,
+                    dataset_name=ds_name,
+                    images=test_imgs_t,
+                    gt_masks=test_gts_t,
+                    pred_masks=preds,
+                    num_classes=num_classes,
+                    rgb_indices=rgb_indices,
+                    ignore_index=ignore_idx,
+                    n_samples=n_viz,
+                    class_names=_class_names,
+                )
         else:
             # Classification (single-label or multi-label)
             metric_name = "micro_mAP" if is_multilabel else "accuracy"
@@ -648,6 +811,8 @@ def main(cfg: DictConfig) -> None:
                         ci_upper=knn_hi,
                         feature_dim=feature_dim,
                         best_c=None,
+                        best_lr=None,
+                        best_batch_size=None,
                         n_train=len(x_train),
                         n_val=len(x_val),
                         n_test=len(x_test),
@@ -679,6 +844,8 @@ def main(cfg: DictConfig) -> None:
                         ci_upper=lin_hi,
                         feature_dim=feature_dim,
                         best_c=best_c,
+                        best_lr=None,
+                        best_batch_size=None,
                         n_train=len(x_train),
                         n_val=len(x_val),
                         n_test=len(x_test),

--- a/src/torchgeo_bench/main.py
+++ b/src/torchgeo_bench/main.py
@@ -27,8 +27,6 @@ from torchgeo_bench.knn import KNNClassifier
 from torchgeo_bench.linear import LogisticRegression
 from torchgeo_bench.models.interface import BenchModel
 from torchgeo_bench.segmentation_probe import (
-    CachedFeaturesDataset,
-    GPUTensorCache,
     SegmentationProbe,
 )
 from torchgeo_bench.segmentation_task import SegmentationSolver, SegMetrics
@@ -455,9 +453,7 @@ def evaluate_segmentation(
     cache_dtype_str = seg_cfg.get("cache_dtype", "float16")
     cache_dtype = torch.float16 if cache_dtype_str == "float16" else torch.float32
 
-    probe, solver = _build_seg_probe_and_solver(
-        model, num_classes, eval_cfg, device, seg_cfg.lr
-    )
+    probe, solver = _build_seg_probe_and_solver(model, num_classes, eval_cfg, device, seg_cfg.lr)
     if use_cache and probe.freeze_backbone:
         logger.info("Caching backbone features for train and val splits...")
         train_cache = probe.extract_segmentation_features(train_loader, cache_dtype=cache_dtype)

--- a/src/torchgeo_bench/main.py
+++ b/src/torchgeo_bench/main.py
@@ -407,6 +407,7 @@ def _build_seg_probe_and_solver(
         device=str(device),
         criterion=criterion,
         lr_scheduler=eval_cfg.segmentation.get("lr_scheduler", "cosine"),
+        ignore_index=eval_cfg.segmentation.get("ignore_index", 255),
     )
     return probe, solver
 
@@ -459,9 +460,9 @@ def evaluate_segmentation(
     )
     if use_cache and probe.freeze_backbone:
         logger.info("Caching backbone features for train and val splits...")
-        train_cache = probe.extract_all_features(train_loader, cache_dtype=cache_dtype)
-        val_cache = probe.extract_all_features(val_loader, cache_dtype=cache_dtype)
-        test_cache = probe.extract_all_features(test_loader, cache_dtype=cache_dtype)
+        train_cache = probe.extract_segmentation_features(train_loader, cache_dtype=cache_dtype)
+        val_cache = probe.extract_segmentation_features(val_loader, cache_dtype=cache_dtype)
+        test_cache = probe.extract_segmentation_features(test_loader, cache_dtype=cache_dtype)
         solver.fit_cached(
             train_cache=train_cache,
             val_cache=val_cache,
@@ -618,11 +619,18 @@ def main(cfg: DictConfig) -> None:
             bands_value,
         )
 
+        # Merge model-specific eval config early so resume key and result rows
+        # reflect the actual head_type used, not the global default.
+        eval_cfg_merged = OmegaConf.merge(
+            cfg.eval,
+            cfg.model.eval if "eval" in cfg.model and cfg.model.eval is not None else {},
+        )
+
         # Check resume for standard methods
         knn_key = (ds_name, "knn5", cfg.model._target_, cfg.model.name, *config_tuple)
         linear_key = (ds_name, "linear", cfg.model._target_, cfg.model.name, *config_tuple)
 
-        seg_method = f"seg-{cfg.eval.segmentation.head_type}"
+        seg_method = f"seg-{eval_cfg_merged.segmentation.head_type}"
         seg_key = (ds_name, seg_method, cfg.model._target_, cfg.model.name, *config_tuple)
 
         try:

--- a/src/torchgeo_bench/models/__init__.py
+++ b/src/torchgeo_bench/models/__init__.py
@@ -4,6 +4,8 @@ from .image_stats import ImageStatsBench
 from .interface import BenchModel
 from .olmoearth import OlmoEarthBenchModel
 from .rcf import RCFBench
+from .sam3 import SAM3Encoder
+from .segmentation_heads import ConvBlockHead, DPTHead, FPNHead, LinearHead
 from .timm import TimmPatchBenchModel
 from .torchgeo_models import (
     TorchGeoDOFABench,
@@ -19,9 +21,14 @@ __all__: list[str] = [
     "ImageStatsBench",
     "TimmPatchBenchModel",
     "OlmoEarthBenchModel",
+    "SAM3Encoder",
     "TorchGeoDOFABench",
     "TorchGeoEarthLocBench",
     "TorchGeoResNetBench",
     "TorchGeoScaleMAEBench",
     "TorchGeoSwinBench",
+    "LinearHead",
+    "ConvBlockHead",
+    "FPNHead",
+    "DPTHead",
 ]

--- a/src/torchgeo_bench/models/sam3.py
+++ b/src/torchgeo_bench/models/sam3.py
@@ -1,0 +1,214 @@
+"""SAM3 image encoder wrapper for torchgeo-bench.
+
+Uses SAM3's ViT-H vision encoder (with built-in FPN neck) as a frozen backbone
+for dense segmentation probing. Only RGB (3-channel) input is supported.
+
+The vision encoder supports arbitrary input sizes. On the first forward pass the
+RoPE position embeddings are reset to match the actual image dimensions (rounded
+down to the nearest multiple of patch_size=14 if needed). Absolute position
+embeddings are already tiled dynamically by the transformers implementation.
+
+Checkpoint:
+    Load from a local HuggingFace-format directory (``model.safetensors`` +
+    ``config.json``) via the ``checkpoint_path`` config key, or pass
+    ``model_name_or_path="facebook/sam3"`` to download from the Hub (requires
+    authentication and access approval for the gated repo).
+
+Layer naming for SegmentationProbe:
+    The FPN neck produces 4 multi-scale feature maps, each with 256 channels.
+    Their spatial dimensions scale with the input resolution:
+    at 252×252 input (18×18 patch grid) the levels are:
+        neck.fpn_layers.3 — coarsest (scale 0.5×)
+        neck.fpn_layers.2 — medium   (scale 1×)
+        neck.fpn_layers.1 — fine     (scale 2×)
+        neck.fpn_layers.0 — finest   (scale 4×)
+    Use coarse-to-fine order for FPN/DPT heads.
+"""
+
+import logging
+
+import torch
+
+from .interface import BenchModel
+
+logger = logging.getLogger(__name__)
+
+_PATCH_SIZE = 14  # SAM3 ViT-H patch size (fixed by architecture)
+
+
+def _reset_sam3_rope(vision_encoder: torch.nn.Module, input_h: int, input_w: int) -> None:
+    """Recompute RoPE buffers in every ViT layer for a new input resolution.
+
+    Each ``Sam3ViTLayer`` owns a ``Sam3ViTRotaryEmbedding`` (``self.rotary_emb``)
+    with pre-computed ``rope_embeddings_cos / rope_embeddings_sin`` buffers sized
+    for the pretrain token grid (72×72 at 1008×1008 input).  We rebuild them for
+    the actual token grid derived from ``input_h × input_w``.
+
+    For windowed-attention layers the RoPE grid is always ``(window_size,
+    window_size)`` — identical to pretrain, so nothing changes there.  For global
+    attention layers the RoPE grid is ``(h_tokens, w_tokens)`` and the scale
+    factor is adjusted accordingly.
+    """
+    cfg = vision_encoder.config.backbone_config  # Sam3ViTConfig
+    patch_size: int = cfg.patch_size  # 14
+    window_size: int = cfg.window_size  # 24
+    global_attn_indexes: set[int] = set(cfg.global_attn_indexes)
+
+    h_tokens = input_h // patch_size
+    w_tokens = input_w // patch_size
+
+    logger.info(
+        f"SAM3: resetting RoPE embeddings for {input_h}×{input_w} "
+        f"({h_tokens}×{w_tokens} token grid)"
+    )
+
+    for i, layer in enumerate(vision_encoder.backbone.layers):
+        rotary_emb = layer.rotary_emb
+
+        if i in global_attn_indexes:
+            end_x, end_y = h_tokens, w_tokens
+            scale = window_size / h_tokens
+        else:
+            # Windowed layers: RoPE always covers one window — no change needed,
+            # but we recompute anyway to keep everything consistent.
+            end_x, end_y = window_size, window_size
+            scale = 1.0
+
+        dim: int = rotary_emb.dim
+        freqs = 1.0 / (
+            rotary_emb.rope_theta ** (torch.arange(0, dim, 4)[: (dim // 4)].float() / dim)
+        )
+        flat = torch.arange(end_x * end_y, dtype=torch.long)
+        x_pos = (flat % end_x).float() * scale
+        y_pos = torch.div(flat, end_x, rounding_mode="floor").float() * scale
+        inv_freq = torch.cat(
+            [torch.outer(x_pos, freqs), torch.outer(y_pos, freqs)], dim=-1
+        ).repeat_interleave(2, dim=-1)
+
+        device = rotary_emb.rope_embeddings_cos.device
+        dtype = rotary_emb.rope_embeddings_cos.dtype
+        rotary_emb.rope_embeddings_cos = inv_freq.cos().to(device=device, dtype=dtype)
+        rotary_emb.rope_embeddings_sin = inv_freq.sin().to(device=device, dtype=dtype)
+        rotary_emb.end_x = end_x
+        rotary_emb.end_y = end_y
+
+
+class SAM3Encoder(BenchModel):
+    """Frozen SAM3 vision encoder (ViT-H + FPN neck) as a benchmark backbone.
+
+    The full SAM3 model is loaded but only the vision encoder is retained.
+    The text encoder, geometry encoder, DETR encoder/decoder, and mask decoder
+    are discarded to save memory.
+
+    On the first forward pass the RoPE buffers are reset to match the actual
+    input resolution.  If the image dimensions are not multiples of
+    ``patch_size=14``, images are cropped to the nearest valid size and a warning
+    is logged.  Only 3-channel RGB input is supported.
+
+    Args:
+        num_channels: Number of input channels. Must be 3 (RGB only).
+        checkpoint_path: Path to a local HuggingFace-format checkpoint
+            directory containing ``model.safetensors`` and ``config.json``.
+        model_name_or_path: HuggingFace Hub model ID. Used only if
+            ``checkpoint_path`` is not set.
+    """
+
+    def __init__(
+        self,
+        num_channels: int,
+        checkpoint_path: str | None = None,
+        model_name_or_path: str = "facebook/sam3",
+        **_kwargs,
+    ) -> None:
+        super().__init__(num_channels=num_channels)
+
+        if num_channels != 3:
+            raise ValueError(
+                f"SAM3Encoder only supports 3-channel RGB input, got num_channels={num_channels}. "
+                "Run with dataset.bands=[red,green,blue] or skip this dataset."
+            )
+
+        from transformers import Sam3Model
+
+        source = checkpoint_path or model_name_or_path
+        logger.info(f"Loading SAM3 from {source!r} …")
+        full_model = Sam3Model.from_pretrained(
+            source,
+            local_files_only=(checkpoint_path is not None),
+        )
+
+        self.backbone = full_model.vision_encoder
+        del full_model
+
+        for param in self.backbone.parameters():
+            param.requires_grad = False
+        self.backbone.eval()
+
+        # RoPE is reset lazily on the first forward call for the actual input size.
+        self._rope_size: tuple[int, int] | None = None
+
+    def _maybe_reset_rope(self, H: int, W: int) -> None:
+        """Reset RoPE buffers the first time a new spatial size is seen."""
+        h = (H // _PATCH_SIZE) * _PATCH_SIZE
+        w = (W // _PATCH_SIZE) * _PATCH_SIZE
+        if (h, w) == self._rope_size:
+            return
+        if h != H or w != W:
+            logger.warning(
+                f"SAM3: input {H}×{W} is not a multiple of patch_size={_PATCH_SIZE}; "
+                f"images will be cropped to {h}×{w} before encoding."
+            )
+        _reset_sam3_rope(self.backbone, h, w)
+        self._rope_size = (h, w)
+
+    def _crop_to_patch_multiple(self, images: torch.Tensor) -> torch.Tensor:
+        """Crop spatial dims to the nearest multiple of ``_PATCH_SIZE``."""
+        H, W = images.shape[-2:]
+        h = (H // _PATCH_SIZE) * _PATCH_SIZE
+        w = (W // _PATCH_SIZE) * _PATCH_SIZE
+        if h == H and w == W:
+            return images
+        return images[..., :h, :w]
+
+    def forward(
+        self,
+        images: torch.Tensor,
+        bboxes: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Run the vision encoder.
+
+        Called by :class:`~torchgeo_bench.segmentation_probe.SegmentationProbe`
+        during feature extraction. Forward hooks on ``neck.fpn_layers.*`` capture
+        the multi-scale FPN outputs; the return value itself is not used by the
+        probe.
+
+        Args:
+            images: ``(B, 3, H, W)`` float tensor.
+            bboxes: Unused.
+
+        Returns:
+            Pooled image embedding ``(B, 256)`` (average of the coarsest FPN level).
+        """
+        del bboxes
+        images = self._crop_to_patch_multiple(images)
+        self._maybe_reset_rope(*images.shape[-2:])
+        with torch.no_grad():
+            out = self.backbone(pixel_values=images)
+        coarsest = out.fpn_hidden_states[-1]  # (B, 256, H', W')
+        return coarsest.mean(dim=[-2, -1])  # (B, 256)
+
+    def forward_patch_features(
+        self,
+        images: torch.Tensor,
+        bboxes: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Return a pooled image embedding for classification evaluation.
+
+        Args:
+            images: ``(B, 3, H, W)`` float tensor.
+            bboxes: Unused.
+
+        Returns:
+            Embeddings ``(B, 256)``.
+        """
+        return self.forward(images, bboxes)

--- a/src/torchgeo_bench/models/sam3.py
+++ b/src/torchgeo_bench/models/sam3.py
@@ -57,6 +57,12 @@ def _reset_sam3_rope(vision_encoder: torch.nn.Module, input_h: int, input_w: int
     h_tokens = input_h // patch_size
     w_tokens = input_w // patch_size
 
+    if h_tokens == 0 or w_tokens == 0:
+        raise ValueError(
+            f"Input size {input_h}×{input_w} is smaller than patch_size={patch_size}. "
+            "Images must be at least patch_size pixels in each spatial dimension."
+        )
+
     logger.info(
         f"SAM3: resetting RoPE embeddings for {input_h}×{input_w} "
         f"({h_tokens}×{w_tokens} token grid)"
@@ -168,8 +174,18 @@ class SAM3Encoder(BenchModel):
         self._rope_size = (h, w)
 
     def _crop_to_patch_multiple(self, images: torch.Tensor) -> torch.Tensor:
-        """Crop spatial dims to the nearest multiple of ``_PATCH_SIZE``."""
+        """Crop spatial dims to the nearest multiple of ``_PATCH_SIZE``.
+
+        Raises:
+            ValueError: If the input is smaller than one patch (H < _PATCH_SIZE
+                or W < _PATCH_SIZE), which would produce empty tensors.
+        """
         H, W = images.shape[-2:]
+        if H < _PATCH_SIZE or W < _PATCH_SIZE:
+            raise ValueError(
+                f"Input spatial size {H}×{W} is smaller than patch_size={_PATCH_SIZE}. "
+                "Images must be at least patch_size pixels in each spatial dimension."
+            )
         h = (H // _PATCH_SIZE) * _PATCH_SIZE
         w = (W // _PATCH_SIZE) * _PATCH_SIZE
         if h == H and w == W:

--- a/src/torchgeo_bench/models/sam3.py
+++ b/src/torchgeo_bench/models/sam3.py
@@ -128,7 +128,13 @@ class SAM3Encoder(BenchModel):
                 "Run with dataset.bands=[red,green,blue] or skip this dataset."
             )
 
-        from transformers import Sam3Model
+        try:
+            from transformers import Sam3Model
+        except ImportError as e:
+            raise ImportError(
+                "SAM3Encoder requires the 'transformers' package. "
+                "Install it with: pip install torchgeo-bench[sam3]"
+            ) from e
 
         source = checkpoint_path or model_name_or_path
         logger.info(f"Loading SAM3 from {source!r} …")

--- a/src/torchgeo_bench/models/segmentation_heads.py
+++ b/src/torchgeo_bench/models/segmentation_heads.py
@@ -30,6 +30,7 @@ class LinearHead(nn.Module):
             self.scale_weights = nn.Parameter(torch.ones(len(channels_list)))
 
     def forward(self, features: list[torch.Tensor], input_h: int, input_w: int) -> torch.Tensor:
+        """Upsample and sum per-layer logits."""
         total_logits: torch.Tensor | int = 0
         for idx, (feat, head) in enumerate(zip(features, self.heads)):
             logits = head(feat)
@@ -71,6 +72,7 @@ class ConvBlockHead(nn.Module):
         self.head = nn.Conv2d(hidden_dim * len(channels_list), num_classes, kernel_size=1)
 
     def forward(self, features: list[torch.Tensor], input_h: int, input_w: int) -> torch.Tensor:
+        """Project, upsample, concat, and classify features."""
         proj_feats = [proj(f) for f, proj in zip(features, self.projectors)]
 
         target_h, target_w = 0, 0
@@ -187,6 +189,7 @@ class ChannelLayerNorm(nn.Module):
         self.norm = nn.LayerNorm(num_channels)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Apply layer norm over channels."""
         # x: (B, C, H, W) → permute to (B, H, W, C) → LN → back
         return self.norm(x.permute(0, 2, 3, 1)).permute(0, 3, 1, 2).contiguous()
 
@@ -205,6 +208,7 @@ class ResidualConvUnit(nn.Module):
         )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Apply residual conv block."""
         return self.conv(x) + x
 
 
@@ -219,6 +223,7 @@ class FeatureFusionBlock(nn.Module):
         self.resConfUnit2 = ResidualConvUnit(features, kernel_size)
 
     def forward(self, x: torch.Tensor, skip_x: torch.Tensor | None = None) -> torch.Tensor:
+        """Fuse skip connection and refine features."""
         if skip_x is not None:
             if skip_x.shape[-2:] != x.shape[-2:]:
                 skip_x = F.interpolate(

--- a/src/torchgeo_bench/models/segmentation_heads.py
+++ b/src/torchgeo_bench/models/segmentation_heads.py
@@ -1,0 +1,317 @@
+"""Segmentation decoder heads for use with SegmentationProbe."""
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class LinearHead(nn.Module):
+    """Per-layer BN + 1×1 conv heads with learned scale-weighted fusion.
+
+    For a single layer the output is returned directly. For multiple layers,
+    each head's logits are upsampled to the input resolution and combined via
+    learned scalar weights.
+
+    Args:
+        channels_list: Channel count for each hooked feature layer.
+        num_classes: Number of segmentation output classes.
+    """
+
+    def __init__(self, channels_list: list[int], num_classes: int) -> None:
+        super().__init__()
+        self.num_classes = num_classes
+        self.heads = nn.ModuleList(
+            [
+                nn.Sequential(nn.BatchNorm2d(c), nn.Conv2d(c, num_classes, kernel_size=1))
+                for c in channels_list
+            ]
+        )
+        if len(channels_list) > 1:
+            self.scale_weights = nn.Parameter(torch.ones(len(channels_list)))
+
+    def forward(self, features: list[torch.Tensor], input_h: int, input_w: int) -> torch.Tensor:
+        total_logits: torch.Tensor | int = 0
+        for idx, (feat, head) in enumerate(zip(features, self.heads)):
+            logits = head(feat)
+            if logits.shape[-2:] != (input_h, input_w):
+                logits = F.interpolate(
+                    logits, size=(input_h, input_w), mode="bilinear", align_corners=False
+                )
+            if len(self.heads) == 1:
+                return logits
+            total_logits = total_logits + logits * self.scale_weights[idx]
+        return total_logits  # type: ignore[return-value]
+
+
+class ConvBlockHead(nn.Module):
+    """Per-layer 1×1 projection to hidden_dim, aligned concat, 1×1 classification head.
+
+    All feature maps are projected to the same channel count, upsampled to the
+    finest spatial resolution in the batch, concatenated, and classified with a
+    single 1×1 conv.
+
+    Args:
+        channels_list: Channel count for each hooked feature layer.
+        num_classes: Number of segmentation output classes.
+        hidden_dim: Projection dimension (default 256).
+    """
+
+    def __init__(self, channels_list: list[int], num_classes: int, hidden_dim: int = 256) -> None:
+        super().__init__()
+        self.projectors = nn.ModuleList(
+            [
+                nn.Sequential(
+                    nn.Conv2d(c, hidden_dim, kernel_size=1, bias=False),
+                    nn.BatchNorm2d(hidden_dim),
+                    nn.SiLU(inplace=True),
+                )
+                for c in channels_list
+            ]
+        )
+        self.head = nn.Conv2d(hidden_dim * len(channels_list), num_classes, kernel_size=1)
+
+    def forward(self, features: list[torch.Tensor], input_h: int, input_w: int) -> torch.Tensor:
+        proj_feats = [proj(f) for f, proj in zip(features, self.projectors)]
+
+        target_h, target_w = 0, 0
+        for f in proj_feats:
+            if f.shape[-2] > target_h:
+                target_h, target_w = f.shape[-2:]
+        if target_h <= 1:
+            target_h, target_w = 16, 16
+
+        aligned = []
+        for f in proj_feats:
+            if f.shape[-2:] != (target_h, target_w):
+                f = F.interpolate(
+                    f, size=(target_h, target_w), mode="bilinear", align_corners=False
+                )
+            aligned.append(f)
+
+        logits = self.head(torch.cat(aligned, dim=1))
+        if logits.shape[-2:] != (input_h, input_w):
+            logits = F.interpolate(
+                logits, size=(input_h, input_w), mode="bilinear", align_corners=False
+            )
+        return logits
+
+
+class FPNHead(nn.Module):
+    """Feature Pyramid Network decoder head.
+
+    Applies lateral 1×1 convs, a top-down merging pathway, 3×3 refinement
+    convs, then upsamples all levels to the finest resolution, concatenates,
+    and classifies with a 1×1 conv.
+
+    Layers must be provided in **coarse-to-fine order** (deepest / lowest-
+    resolution first). Example for ResNet:
+    ``["layer4", "layer3", "layer2", "layer1"]``.
+
+    Args:
+        channels_list: Channel count for each hooked feature layer (coarse-to-fine).
+        num_classes: Number of segmentation output classes.
+        hidden_dim: Feature dimension used throughout the FPN (default 256).
+    """
+
+    def __init__(self, channels_list: list[int], num_classes: int, hidden_dim: int = 256) -> None:
+        super().__init__()
+        # Normalise raw CNN features before projection. BN is appropriate here:
+        # CNN channels have per-filter semantics and batch stats are stable.
+        self.input_norms = nn.ModuleList([nn.BatchNorm2d(c) for c in channels_list])
+        self.laterals = nn.ModuleList(
+            [nn.Conv2d(c, hidden_dim, kernel_size=1, bias=False) for c in channels_list]
+        )
+        self.fpn_convs = nn.ModuleList(
+            [
+                nn.Sequential(
+                    nn.Conv2d(hidden_dim, hidden_dim, kernel_size=3, padding=1, bias=False),
+                    nn.BatchNorm2d(hidden_dim),
+                    nn.ReLU(inplace=True),
+                )
+                for _ in channels_list
+            ]
+        )
+        self.fpn_head = nn.Conv2d(hidden_dim * len(channels_list), num_classes, kernel_size=1)
+
+    def forward(self, features: list[torch.Tensor], input_h: int, input_w: int) -> torch.Tensor:
+        """Top-down FPN forward pass.
+
+        Args:
+            features: Feature maps in coarse-to-fine order (index 0 = coarsest).
+            input_h: Target output height (input image height).
+            input_w: Target output width (input image width).
+        """
+        laterals = [lat(norm(f)) for f, norm, lat in zip(features, self.input_norms, self.laterals)]
+
+        # Top-down merging: from coarsest (0) to finest (-1)
+        for i in range(len(laterals) - 1):
+            target_size = laterals[i + 1].shape[-2:]
+            laterals[i + 1] = laterals[i + 1] + F.interpolate(
+                laterals[i], size=target_size, mode="bilinear", align_corners=False
+            )
+
+        fpn_outs = [conv(p) for p, conv in zip(laterals, self.fpn_convs)]
+
+        finest_size = fpn_outs[-1].shape[-2:]
+        aligned = []
+        for f in fpn_outs:
+            if f.shape[-2:] != finest_size:
+                f = F.interpolate(f, size=finest_size, mode="bilinear", align_corners=False)
+            aligned.append(f)
+
+        logits = self.fpn_head(torch.cat(aligned, dim=1))
+        if logits.shape[-2:] != (input_h, input_w):
+            logits = F.interpolate(
+                logits, size=(input_h, input_w), mode="bilinear", align_corners=False
+            )
+        return logits
+
+
+# ---------------------------------------------------------------------------
+# DPT helper modules (adapted from probe3d — mbanani/probe3d)
+# ---------------------------------------------------------------------------
+
+
+class ChannelLayerNorm(nn.Module):
+    """LayerNorm over the channel dimension of a (B, C, H, W) feature map.
+
+    Normalises each spatial position independently across channels — equivalent
+    to the LayerNorm inside a ViT block.  This is the natural choice before
+    projecting ViT intermediate features, where residual-stream outliers can
+    cause large inter-layer scale differences that BatchNorm handles poorly
+    (sample-wise norm is immune to per-batch outlier corruption).
+    """
+
+    def __init__(self, num_channels: int) -> None:
+        super().__init__()
+        self.norm = nn.LayerNorm(num_channels)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # x: (B, C, H, W) → permute to (B, H, W, C) → LN → back
+        return self.norm(x.permute(0, 2, 3, 1)).permute(0, 3, 1, 2).contiguous()
+
+
+class ResidualConvUnit(nn.Module):
+    """Two conv+ReLU layers with a residual skip connection."""
+
+    def __init__(self, features: int, kernel_size: int = 3) -> None:
+        super().__init__()
+        padding = kernel_size // 2
+        self.conv = nn.Sequential(
+            nn.Conv2d(features, features, kernel_size, padding=padding),
+            nn.ReLU(inplace=True),
+            nn.Conv2d(features, features, kernel_size, padding=padding),
+            nn.ReLU(inplace=True),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.conv(x) + x
+
+
+class FeatureFusionBlock(nn.Module):
+    """Fuses a feature map with an optional skip connection via residual conv units."""
+
+    def __init__(self, features: int, kernel_size: int = 3, with_skip: bool = True) -> None:
+        super().__init__()
+        self.with_skip = with_skip
+        if with_skip:
+            self.resConfUnit1 = ResidualConvUnit(features, kernel_size)
+        self.resConfUnit2 = ResidualConvUnit(features, kernel_size)
+
+    def forward(self, x: torch.Tensor, skip_x: torch.Tensor | None = None) -> torch.Tensor:
+        if skip_x is not None:
+            if skip_x.shape[-2:] != x.shape[-2:]:
+                skip_x = F.interpolate(
+                    skip_x, size=x.shape[-2:], mode="bilinear", align_corners=False
+                )
+            x = self.resConfUnit1(x) + skip_x
+        return self.resConfUnit2(x)
+
+
+class DPTHead(nn.Module):
+    """DPT-style decoder head (adapted from probe3d — mbanani/probe3d, single-view).
+
+    Requires exactly **4** feature layers in **coarse-to-fine order** (same
+    convention as FPN, e.g. ``["layer4", "layer3", "layer2", "layer1"]`` for
+    ResNet). The forward pass processes features from coarsest to finest
+    through a cascade of :class:`FeatureFusionBlock`s.
+
+    Upsampling chain (mirroring probe3d):
+      1. 1×1 project each map to ``hidden_dim``
+      2. 2× upsample all projected maps
+      3. Top-down fusion cascade (coarse → fine)
+      4. 4× upsample the fused result
+      5. 3×3 → ReLU → 3×3 output conv to ``num_classes``
+      6. Final resize to input resolution
+
+    Args:
+        channels_list: Channel count for each hooked feature layer (coarse-to-fine).
+            Must have exactly 4 entries.
+        num_classes: Number of segmentation output classes.
+        hidden_dim: Hidden channel dimension (default 256).
+        kernel_size: Conv kernel size for residual units (default 3).
+    """
+
+    def __init__(
+        self,
+        channels_list: list[int],
+        num_classes: int,
+        hidden_dim: int = 256,
+        kernel_size: int = 3,
+    ) -> None:
+        super().__init__()
+        if len(channels_list) != 4:
+            raise ValueError(
+                f"DPTHead requires exactly 4 feature layers, got {len(channels_list)}. "
+                "Specify exactly 4 layer names in coarse-to-fine order in the model config."
+            )
+        # Normalise ViT residual-stream features before projection. LayerNorm
+        # over channels (per spatial position) matches the ViT's own internal
+        # normalisation and is sample-wise — robust to the per-layer outlier
+        # activations common in specialist ViTs (e.g. DOFA).
+        self.input_norms = nn.ModuleList([ChannelLayerNorm(c) for c in channels_list])
+        # 1×1 projection — index 0 = coarsest
+        self.convs = nn.ModuleList(
+            [nn.Conv2d(c, hidden_dim, kernel_size=1, padding=0) for c in channels_list]
+        )
+        # Fusion blocks: index 0 = coarsest (no skip), 1-3 receive skip from previous level
+        self.ref = nn.ModuleList(
+            [
+                FeatureFusionBlock(hidden_dim, kernel_size, with_skip=False),  # coarsest
+                FeatureFusionBlock(hidden_dim, kernel_size),
+                FeatureFusionBlock(hidden_dim, kernel_size),
+                FeatureFusionBlock(hidden_dim, kernel_size),  # finest
+            ]
+        )
+        self.out_conv = nn.Sequential(
+            nn.Conv2d(hidden_dim, hidden_dim, kernel_size=3, padding=1),
+            nn.ReLU(inplace=True),
+            nn.Conv2d(hidden_dim, num_classes, kernel_size=3, padding=1),
+        )
+
+    def forward(self, features: list[torch.Tensor], input_h: int, input_w: int) -> torch.Tensor:
+        """DPT forward pass.
+
+        Args:
+            features: Feature maps in coarse-to-fine order (index 0 = coarsest).
+            input_h: Target output height.
+            input_w: Target output width.
+        """
+        # Normalise → project → 2× upsample
+        projected = [
+            F.interpolate(conv(norm(f)), scale_factor=2, mode="bilinear", align_corners=True)
+            for norm, conv, f in zip(self.input_norms, self.convs, features)
+        ]
+
+        # Top-down cascade: coarsest (0) → finest (3)
+        out = self.ref[0](projected[0], None)
+        out = self.ref[1](projected[1], out)
+        out = self.ref[2](projected[2], out)
+        out = self.ref[3](projected[3], out)
+
+        # 4× upsample → output conv → resize to input resolution
+        out = F.interpolate(out, scale_factor=4, mode="bilinear", align_corners=True)
+        out = self.out_conv(out)
+        if out.shape[-2:] != (input_h, input_w):
+            out = F.interpolate(out, size=(input_h, input_w), mode="bilinear", align_corners=False)
+        return out

--- a/src/torchgeo_bench/segmentation_probe.py
+++ b/src/torchgeo_bench/segmentation_probe.py
@@ -215,8 +215,18 @@ class SegmentationProbe(nn.Module):
 
         return hook
 
+    def _backbone_device(self) -> torch.device:
+        """Return the device of the backbone, falling back to CPU for parameterless backbones."""
+        p = next(self.backbone.parameters(), None)
+        if p is not None:
+            return p.device
+        b = next(self.backbone.buffers(), None)
+        if b is not None:
+            return b.device
+        return torch.device("cpu")
+
     def _dry_run_channels(self) -> list[int]:
-        device = next(self.backbone.parameters()).device
+        device = self._backbone_device()
         dummy = torch.randn(1, 3, 224, 224, device=device)
         if not self.layer_names:
             self.layer_names = ["backbone_output"]
@@ -278,7 +288,7 @@ class SegmentationProbe(nn.Module):
     # ------------------------------------------------------------------
 
     @torch.no_grad()
-    def extract_all_features(
+    def extract_segmentation_features(
         self,
         dataloader: "torch.utils.data.DataLoader",
         cache_dtype: torch.dtype = torch.float16,
@@ -299,7 +309,7 @@ class SegmentationProbe(nn.Module):
         # This avoids N individual per-sample allocations during GPU transfer.
         batches_per_layer: list[list[torch.Tensor]] = [[] for _ in self.layer_names]
         all_masks: list[torch.Tensor] = []
-        device = next(self.backbone.parameters()).device
+        device = self._backbone_device()
 
         for batch in dataloader:
             if isinstance(batch, dict):

--- a/src/torchgeo_bench/segmentation_probe.py
+++ b/src/torchgeo_bench/segmentation_probe.py
@@ -1,25 +1,161 @@
 """Segmentation Probe Module."""
 
 import logging
+import math
+from collections.abc import Iterator
 from typing import Any
 
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
-from torchmetrics.classification import MulticlassJaccardIndex
+from torch.utils.data import Dataset
+
+from torchgeo_bench.models.segmentation_heads import (
+    ConvBlockHead,
+    DPTHead,
+    FPNHead,
+    LinearHead,
+)
 
 logger = logging.getLogger(__name__)
 
 
+class CachedFeaturesDataset(Dataset):
+    """In-RAM cache of pre-extracted backbone features and masks.
+
+    Stores data layer-first: ``layer_tensors[li]`` is a ``(N, C, H, W)``
+    float16 tensor for layer *li*, and ``masks`` is an ``(N, H, W)`` long
+    tensor.  This contiguous layout eliminates per-sample Python iteration
+    during :meth:`GPUTensorCache.from_cached` — the GPU transfer becomes a
+    single ``Tensor.to(device)`` call per layer.
+
+    Each ``__getitem__`` returns a ``(features, mask)`` tuple.
+    """
+
+    def __init__(
+        self,
+        layer_tensors: list[torch.Tensor],
+        masks: torch.Tensor,
+    ) -> None:
+        self.layer_tensors = layer_tensors  # list of (N, C, H, W)
+        self.masks = masks  # (N, H, W)
+
+    def __len__(self) -> int:
+        return self.masks.shape[0]
+
+    def __getitem__(self, i: int) -> tuple[list[torch.Tensor], torch.Tensor]:
+        return [t[i] for t in self.layer_tensors], self.masks[i]
+
+
+def _estimate_cache_bytes(cache: "CachedFeaturesDataset") -> int:
+    """Estimate total bytes occupied by a CachedFeaturesDataset."""
+    if not cache.layer_tensors:
+        return 0
+    return (
+        sum(t.numel() * t.element_size() for t in cache.layer_tensors)
+        + cache.masks.numel() * cache.masks.element_size()
+    )
+
+
+class GPUTensorCache:
+    """All cached features pre-stacked and moved to GPU as contiguous tensors.
+
+    Eliminates per-batch CPU→GPU transfers and per-batch ``torch.stack`` calls
+    in the training loop.  Use :meth:`from_cached` to build from a
+    :class:`CachedFeaturesDataset`, then iterate with :meth:`shuffled_batches`
+    (training) or :meth:`ordered_batches` (evaluation).
+
+    Args:
+        layer_tensors: One ``(N, C, H, W)`` float16 tensor per hooked layer,
+            already on the target device.
+        masks: ``(N, H, W)`` long tensor on the target device.
+        device: The device these tensors live on.
+    """
+
+    def __init__(
+        self,
+        layer_tensors: list[torch.Tensor],
+        masks: torch.Tensor,
+        device: torch.device | str,
+    ) -> None:
+        self.layer_tensors = layer_tensors
+        self.masks = masks
+        self.device = device
+
+    def __len__(self) -> int:
+        return self.masks.shape[0]
+
+    @classmethod
+    def from_cached(
+        cls,
+        cache: "CachedFeaturesDataset",
+        device: torch.device | str,
+    ) -> "GPUTensorCache":
+        """Stack and move all features + masks to *device* in one shot.
+
+        Args:
+            cache: CPU-resident cached features.
+            device: Target device (must be CUDA for the speedup to be useful).
+
+        Returns:
+            A :class:`GPUTensorCache` with all data on *device*.
+        """
+        target_device = torch.device(device)
+        # Keep float32 on CPU (no autocast); use float16 on CUDA for AMP efficiency.
+        dtype = torch.float16 if target_device.type == "cuda" else torch.float32
+        layer_tensors = [t.to(target_device, dtype=dtype) for t in cache.layer_tensors]
+        masks = cache.masks.to(target_device, dtype=torch.long)
+        return cls(layer_tensors, masks, target_device)
+
+    def shuffled_batches(
+        self, batch_size: int
+    ) -> Iterator[tuple[list[torch.Tensor], torch.Tensor]]:
+        """Yield *(features, masks)* mini-batches in random order.
+
+        All tensors are already on the GPU — zero host→device transfer per batch.
+        """
+        idx = torch.randperm(len(self), device=self.device)
+        for start in range(0, len(self), batch_size):
+            b = idx[start : start + batch_size]
+            yield [t[b] for t in self.layer_tensors], self.masks[b]
+
+    def ordered_batches(self, batch_size: int) -> Iterator[tuple[list[torch.Tensor], torch.Tensor]]:
+        """Yield *(features, masks)* mini-batches in sequential order."""
+        for start in range(0, len(self), batch_size):
+            s = slice(start, start + batch_size)
+            yield [t[s] for t in self.layer_tensors], self.masks[s]
+
+
 class SegmentationProbe(nn.Module):
-    """Multi-scale segmentation probe that hooks into backbone feature layers."""
+    """Multi-scale segmentation probe that hooks into backbone feature layers.
+
+    Backbone layers are tapped via forward hooks. Features are passed to a
+    decoder head (``LinearHead``, ``ConvBlockHead``, ``FPNHead``, or
+    ``DPTHead``) that produces per-pixel class logits.
+
+    Layer ordering convention (applies to all head types):
+      - **Coarse-to-fine** — deepest / lowest-resolution layer first.
+      - Example for ResNet: ``["layer4", "layer3", "layer2", "layer1"]``.
+      - For ``DPTHead`` this means index 0 = coarsest, which is also what the
+        DPT cascade expects.
+
+    Args:
+        backbone: Feature extractor. May be a raw backbone or a ``BenchModel``
+            wrapper (``backbone.*`` prefixes are stripped automatically).
+        layer_names: Ordered list of layer names to hook (coarse-to-fine).
+        num_classes: Number of segmentation output classes.
+        freeze_backbone: If ``True`` (default), backbone parameters are frozen
+            and the backbone runs in eval mode during inference.
+        head_type: Decoder architecture — one of ``"linear"``, ``"conv_block"``,
+            ``"fpn"``, ``"dpt"``.
+        hidden_dim: Hidden channel dimension for ``conv_block``, ``fpn``, and
+            ``dpt`` heads (default 256).
+    """
 
     def __init__(
         self,
         backbone: nn.Module,
         layer_names: list[str],
         num_classes: int,
-        input_size: int | None = None,
         freeze_backbone: bool = True,
         head_type: str = "linear",
         hidden_dim: int | None = None,
@@ -28,9 +164,7 @@ class SegmentationProbe(nn.Module):
         self.backbone = backbone
         self.layer_names = layer_names
         self.freeze_backbone = freeze_backbone
-        self.input_size = input_size
         self.head_type = head_type
-
         self.effective_classes = num_classes
 
         self._features: dict[str, torch.Tensor] = {}
@@ -38,7 +172,6 @@ class SegmentationProbe(nn.Module):
 
         found_layers = set()
         for name, module in self.backbone.named_modules():
-            # remove starting "backbone." if present
             if name.startswith("backbone."):
                 name = name.replace("backbone.", "", 1)
             if name in self.layer_names:
@@ -55,39 +188,24 @@ class SegmentationProbe(nn.Module):
             self.backbone.eval()
 
         self.channels_list = self._dry_run_channels()
+        hdim = hidden_dim or 256
 
         if head_type == "linear":
-            self.heads = nn.ModuleList()
-            for c in self.channels_list:
-                self.heads.append(
-                    nn.Sequential(
-                        nn.BatchNorm2d(c), nn.Conv2d(c, self.effective_classes, kernel_size=1)
-                    )
-                )
-
-            if len(self.layer_names) > 1:
-                self.scale_weights = nn.Parameter(torch.ones(len(self.layer_names)))
-
+            self.head = LinearHead(self.channels_list, num_classes)
         elif head_type == "conv_block":
-            embed_dim = hidden_dim or 256
-            self.projectors = nn.ModuleList(
-                [
-                    nn.Sequential(
-                        nn.Conv2d(c, embed_dim, kernel_size=1, bias=False),
-                        nn.BatchNorm2d(embed_dim),
-                        nn.SiLU(inplace=True),
-                    )
-                    for c in self.channels_list
-                ]
-            )
-            self.head = nn.Conv2d(
-                embed_dim * len(self.hooks), self.effective_classes, kernel_size=1
+            self.head = ConvBlockHead(self.channels_list, num_classes, hidden_dim=hdim)
+        elif head_type == "fpn":
+            self.head = FPNHead(self.channels_list, num_classes, hidden_dim=hdim)
+        elif head_type == "dpt":
+            self.head = DPTHead(self.channels_list, num_classes, hidden_dim=hdim)
+        else:
+            raise ValueError(
+                f"Unknown head_type: {head_type!r}. Choose from: linear, conv_block, fpn, dpt"
             )
 
-        # Metric
-        self.miou_metric = MulticlassJaccardIndex(
-            num_classes=self.effective_classes,
-        )
+    # ------------------------------------------------------------------
+    # Hook / dry-run helpers
+    # ------------------------------------------------------------------
 
     def _hook_fn(self, name: str):
         """Return a forward hook that captures the output of the named layer."""
@@ -112,13 +230,8 @@ class SegmentationProbe(nn.Module):
 
         channels = []
         for name in self.layer_names:
-            feat = self._features[name]
-            if feat.ndim == 2:
-                channels.append(feat.shape[1])
-            elif feat.ndim == 3:
-                channels.append(feat.shape[2])
-            else:
-                channels.append(feat.shape[1])
+            feat = self._process_feature(self._features[name])
+            channels.append(feat.shape[1])
         self.backbone.train(was_training)
         return channels
 
@@ -126,11 +239,94 @@ class SegmentationProbe(nn.Module):
         if feat.ndim == 2:
             return feat.view(feat.shape[0], feat.shape[1], 1, 1)
         if feat.ndim == 3:
-            B, L, C = feat.shape
-            H = int(L**0.5)
-            if H * H == L:
-                return feat.permute(0, 2, 1).reshape(B, C, H, H)
+            # Handle transformer token features in either (B, L, C) or (B, C, L) layout.
+            # Prefer exact square token grids; if L-1 is square, drop CLS token.
+            bsz, d1, d2 = feat.shape
+
+            # Try (B, L, C)
+            side = math.isqrt(d1)
+            if side * side == d1:
+                return feat.permute(0, 2, 1).reshape(bsz, d2, side, side)
+            side_no_cls = math.isqrt(d1 - 1) if d1 > 1 else 0
+            if side_no_cls * side_no_cls == d1 - 1:
+                return feat[:, 1:, :].permute(0, 2, 1).reshape(bsz, d2, side_no_cls, side_no_cls)
+
+            # Try (B, C, L)
+            side = math.isqrt(d2)
+            if side * side == d2:
+                return feat.reshape(bsz, d1, side, side)
+            side_no_cls = math.isqrt(d2 - 1) if d2 > 1 else 0
+            if side_no_cls * side_no_cls == d2 - 1:
+                return feat[:, :, 1:].reshape(bsz, d1, side_no_cls, side_no_cls)
+
+            raise ValueError(
+                "Could not reshape 3D feature map to 2D grid. "
+                f"Got shape={tuple(feat.shape)}. Expected tokens with L=s^2 or L=s^2+1 (CLS)."
+            )
+        # 4D tensor: NCHW (standard) or NHWC (Swin-family).
+        # Detect NHWC: spatial dims are square (H==W) and channel dim (last) is
+        # larger than the spatial dims — the opposite of typical NCHW feature maps.
+        if feat.ndim == 4:
+            _, d1, d2, d3 = feat.shape
+            if d1 == d2 and d3 > d1:
+                # NHWC → NCHW
+                return feat.permute(0, 3, 1, 2).contiguous()
         return feat
+
+    # ------------------------------------------------------------------
+    # Feature caching
+    # ------------------------------------------------------------------
+
+    @torch.no_grad()
+    def extract_all_features(
+        self,
+        dataloader: "torch.utils.data.DataLoader",
+        cache_dtype: torch.dtype = torch.float16,
+    ) -> "CachedFeaturesDataset":
+        """Run the frozen backbone once over *dataloader* and cache features.
+
+        Args:
+            dataloader: DataLoader that yields ``dict`` or ``(image, mask)`` batches.
+            cache_dtype: Storage dtype for cached feature tensors. Use
+                ``torch.float16`` (default) to halve RAM, or ``torch.float32``
+                for full precision.
+
+        Returns:
+            A :class:`CachedFeaturesDataset` with one entry per sample.
+        """
+        self.backbone.eval()
+        # Accumulate per-batch tensors layer-wise, then cat once at the end.
+        # This avoids N individual per-sample allocations during GPU transfer.
+        batches_per_layer: list[list[torch.Tensor]] = [[] for _ in self.layer_names]
+        all_masks: list[torch.Tensor] = []
+        device = next(self.backbone.parameters()).device
+
+        for batch in dataloader:
+            if isinstance(batch, dict):
+                images = batch["image"].to(device)
+                masks = batch["mask"]
+            else:
+                images, masks = batch[0].to(device), batch[1]
+
+            if masks.ndim == 4:
+                masks = masks.squeeze(1)
+            masks = masks.long()
+            self._features.clear()
+            _ = self.backbone(images)
+
+            for li, n in enumerate(self.layer_names):
+                feat = self._process_feature(self._features[n]).to(dtype=cache_dtype, device="cpu")
+                batches_per_layer[li].append(feat)
+            all_masks.append(masks.cpu())
+
+        layer_tensors = [torch.cat(batches) for batches in batches_per_layer]
+        masks_tensor = torch.cat(all_masks)
+        logger.info(f"Cached features for {masks_tensor.shape[0]} samples.")
+        return CachedFeaturesDataset(layer_tensors, masks_tensor)
+
+    # ------------------------------------------------------------------
+    # Forward
+    # ------------------------------------------------------------------
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Compute segmentation logits from input images.
@@ -145,59 +341,11 @@ class SegmentationProbe(nn.Module):
 
         if self.freeze_backbone:
             self.backbone.eval()
-            with torch.no_grad():
+            use_amp = x.device.type == "cuda"
+            with torch.no_grad(), torch.autocast(device_type="cuda", enabled=use_amp):
                 _ = self.backbone(x)
         else:
             _ = self.backbone(x)
 
         features = [self._process_feature(self._features[n]) for n in self.layer_names]
-
-        if self.head_type == "linear":
-            total_logits = 0
-            for idx, (feat, head) in enumerate(zip(features, self.heads)):
-                # get logits at low resolution to avoid OOM
-                logits = head(feat)
-
-                # upsample to Input Resolution
-                if logits.shape[-2:] != (input_h, input_w):
-                    logits = F.interpolate(
-                        logits, size=(input_h, input_w), mode="bilinear", align_corners=False
-                    )
-                if len(self.layer_names) == 1:
-                    return logits
-                else:
-                    total_logits = total_logits + (logits * self.scale_weights[idx])
-            return total_logits
-
-        else:
-            # project extrated features to embed dim
-            proj_feats = [proj(f) for f, proj in zip(features, self.projectors)]
-
-            # find a common spatial feature size
-            target_h, target_w = 0, 0
-            for f in proj_feats:
-                if f.shape[-2] > target_h:
-                    target_h, target_w = f.shape[-2:]
-            if target_h == 1:
-                target_h, target_w = 16, 16
-
-            # align features
-            aligned_feats = []
-            for f in proj_feats:
-                if f.shape[-2:] != (target_h, target_w):
-                    f = F.interpolate(
-                        f, size=(target_h, target_w), mode="bilinear", align_corners=False
-                    )
-                aligned_feats.append(f)
-
-            x_fused = torch.cat(aligned_feats, dim=1)
-
-            logits = self.head(x_fused)
-
-            # upsample to target size
-            if logits.shape[-2:] != (input_h, input_w):
-                logits = F.interpolate(
-                    logits, size=(input_h, input_w), mode="bilinear", align_corners=False
-                )
-
-            return logits
+        return self.head(features, input_h, input_w)

--- a/src/torchgeo_bench/segmentation_task.py
+++ b/src/torchgeo_bench/segmentation_task.py
@@ -1,23 +1,32 @@
 """Segmentation Training Task Logic."""
 
 import logging
+import math
 
 import torch
 import torch.nn as nn
 from torch.utils.data import DataLoader
-from torchmetrics.classification import MulticlassJaccardIndex
+from torchmetrics.classification import (
+    MulticlassF1Score,
+    MulticlassJaccardIndex,
+    MulticlassPrecision,
+    MulticlassRecall,
+)
 from tqdm import tqdm
 
-from .segmentation_probe import SegmentationProbe
+from .segmentation_probe import (
+    CachedFeaturesDataset,
+    GPUTensorCache,
+    SegmentationProbe,
+)
 
 logger = logging.getLogger(__name__)
+
+SegMetrics = dict[str, float]
 
 
 class SegmentationSolver:
     """A lightweight trainer for the SegmentationProbe."""
-
-    # Common ignore index values used in segmentation datasets
-    IGNORE_INDEX = 255
 
     def __init__(
         self,
@@ -27,6 +36,7 @@ class SegmentationSolver:
         weight_decay: float = 0.0,
         device: str = "cuda",
         criterion: nn.Module | None = None,
+        lr_scheduler: str = "cosine",
         ignore_index: int = 255,
     ) -> None:
         """Initialize the SegmentationSolver.
@@ -37,12 +47,15 @@ class SegmentationSolver:
             lr: Learning rate for the optimizer.
             weight_decay: Weight decay for the optimizer.
             device: Device to run training on ('cuda' or 'cpu').
-            criterion: Loss function to use. If None, defaults to CrossEntropyLoss.
+            criterion: Loss module. Defaults to CrossEntropyLoss with ignore_index.
+            lr_scheduler: LR schedule: "cosine" (CosineAnnealingLR) or "none" (constant LR).
             ignore_index: Label value to ignore in loss and metrics (default: 255).
         """
         self.model = model.to(device)
         self.num_classes = num_classes
         self.device = device
+        self.lr_scheduler_type = lr_scheduler
+
         self.ignore_index = ignore_index
         # parameters can either be heads for linear probe or projectors + head for conv_block probe
         self.optimizer = torch.optim.AdamW(
@@ -60,15 +73,55 @@ class SegmentationSolver:
         self.metric = MulticlassJaccardIndex(
             num_classes=self.num_classes,
             ignore_index=self.ignore_index,
+            average="macro",
         )
+        self.metric_fw_iou = MulticlassJaccardIndex(
+            num_classes=self.num_classes,
+            ignore_index=self.ignore_index,
+            average="weighted",
+        )
+        self.metric_precision = MulticlassPrecision(
+            num_classes=self.num_classes,
+            ignore_index=self.ignore_index,
+            average="macro",
+        )
+        self.metric_recall = MulticlassRecall(
+            num_classes=self.num_classes,
+            ignore_index=self.ignore_index,
+            average="macro",
+        )
+        self.metric_f1 = MulticlassF1Score(
+            num_classes=self.num_classes,
+            ignore_index=self.ignore_index,
+            average="macro",
+        )
+        self._all_metrics = [
+            self.metric,
+            self.metric_fw_iou,
+            self.metric_precision,
+            self.metric_recall,
+            self.metric_f1,
+        ]
+
+        self.use_amp = device.startswith("cuda") and torch.cuda.is_available()
+        self.scaler = torch.amp.GradScaler("cuda", enabled=self.use_amp)
+        self.device_type = torch.device(device).type
+
+    def _make_scheduler(self, epochs: int) -> torch.optim.lr_scheduler.LRScheduler | None:
+        """Return a CosineAnnealingLR scheduler, or None for constant LR."""
+        if self.lr_scheduler_type == "cosine":
+            return torch.optim.lr_scheduler.CosineAnnealingLR(
+                self.optimizer, T_max=epochs, eta_min=1e-6
+            )
+        return None
 
     def fit(
         self,
         train_loader: DataLoader,
         val_loader: DataLoader | None = None,
-        epochs: int = 5,
+        epochs: int = 10,
         verbose: bool = True,
-    ) -> None:
+    ) -> float | None:
         """Train the segmentation probe.
 
         Args:
@@ -76,7 +129,13 @@ class SegmentationSolver:
             val_loader: Optional validation data loader for per-epoch mIoU logging.
             epochs: Number of training epochs.
             verbose: Whether to show progress bars and epoch logs.
+
+        Returns:
+            Val mIoU from the final epoch if val_loader is given, else None.
         """
+        scheduler = self._make_scheduler(epochs)
+        last_val_miou: float | None = None
+
         for epoch in range(epochs):
             self.model.train()
             if self.model.freeze_backbone:
@@ -96,32 +155,50 @@ class SegmentationSolver:
                     masks = masks.squeeze(1)
 
                 self.optimizer.zero_grad()
-                logits = self.model(images)
-                loss = self.criterion(logits, masks)
-                loss.backward()
-                self.optimizer.step()
+                with torch.autocast(device_type="cuda", enabled=self.use_amp):
+                    logits = self.model(images)
+                    loss = self.criterion(logits, masks)
+
+                self.scaler.scale(loss).backward()
+                self.scaler.step(self.optimizer)
+                self.scaler.update()
 
                 total_loss += loss.item()
                 pbar.set_postfix({"loss": f"{loss.item():.4f}"})
 
-            if val_loader and verbose:
-                miou = self.evaluate(val_loader)
-                logger.info(f"Epoch {epoch + 1} Val mIoU: {miou:.4f}")
+            if scheduler is not None:
+                scheduler.step()
+
+            if val_loader:
+                val_metrics = self.evaluate(val_loader)
+                last_val_miou = val_metrics["mIoU"]
+                if verbose:
+                    logger.info(f"Epoch {epoch + 1} Val mIoU: {last_val_miou:.4f}")
+
+        return last_val_miou
 
     @torch.no_grad()
-    def evaluate(self, dataloader: DataLoader) -> float:
-        """Evaluate the model on a dataloader and return mean IoU.
+    def evaluate(
+        self,
+        dataloader: DataLoader,
+        collect_preds: bool = False,
+    ) -> "SegMetrics | tuple[SegMetrics, torch.Tensor]":
+        """Evaluate the model on a dataloader and return segmentation metrics.
 
         Args:
             dataloader: Evaluation data loader.
+            collect_preds: If True, also return predicted class maps (N, H, W) int64.
 
         Returns:
-            Mean Intersection-over-Union (mIoU) score.
+            Dict of metric name → value, or (metrics_dict, preds_tensor) when
+            collect_preds=True.
         """
         self.model.eval()
-        self.metric.reset()
+        for m in self._all_metrics:
+            m.reset()
+            m.to(self.device)
 
-        self.metric.to(self.device)
+        pred_list: list[torch.Tensor] = []
 
         for batch in dataloader:
             if isinstance(batch, dict):
@@ -135,10 +212,166 @@ class SegmentationSolver:
                 masks = masks.squeeze(1)
             masks = masks.long()
 
-            logits = self.model(images)
+            with torch.autocast(device_type="cuda", enabled=self.use_amp):
+                logits = self.model(images)
 
-            self.metric.update(logits, masks)
+            for m in self._all_metrics:
+                m.update(logits, masks)
 
-        # Compute final score
-        miou = self.metric.compute().item()
-        return miou
+            if collect_preds:
+                pred_list.append(logits.argmax(dim=1).cpu())
+
+        metrics = self._compute_metrics()
+        if collect_preds:
+            return metrics, torch.cat(pred_list, dim=0)
+        return metrics
+
+    def fit_cached(
+        self,
+        train_cache: CachedFeaturesDataset,
+        val_cache: CachedFeaturesDataset | None = None,
+        batch_size: int = 64,
+        epochs: int = 10,
+        verbose: bool = True,
+        gpu_train: "GPUTensorCache | None" = None,
+        gpu_val: "GPUTensorCache | None" = None,
+    ) -> float | None:
+        """Train the segmentation head on pre-cached backbone features.
+
+        The backbone is **not** called during training — cached features are fed
+        directly to ``self.model.head``, which is the only component that runs
+        a forward/backward pass.
+
+        The entire feature cache is pre-moved to the GPU as contiguous tensors
+        (:class:`GPUTensorCache`), eliminating per-batch CPU→GPU DMA transfers
+        and ``torch.stack`` calls.
+
+        If ``gpu_train`` is provided, that pre-built cache is used directly,
+        allowing callers (e.g. an HPO loop) to transfer the cache once and
+        reuse it across many calls.
+
+        Args:
+            train_cache: Pre-extracted training features from
+                :meth:`SegmentationProbe.extract_all_features`.
+            val_cache: Optional validation cache for per-epoch mIoU logging.
+            batch_size: Batch size for iterating over cached data.
+            epochs: Number of training epochs.
+            verbose: Whether to show progress bars and epoch logs.
+            gpu_train: Optional pre-built GPU cache for training. If provided,
+                the GPU transfer is skipped.
+            gpu_val: Optional pre-built GPU cache for validation. Used only
+                when ``gpu_train`` is also provided.
+
+        Returns:
+            Val mIoU from the final epoch if val_cache is given, else None.
+        """
+        if gpu_train is None:
+            gpu_train = GPUTensorCache.from_cached(train_cache, self.device)
+            if val_cache is not None:
+                gpu_val = GPUTensorCache.from_cached(val_cache, self.device)
+
+        # Fast path: GPU tensor cache — no DataLoader, no host→device transfer per batch
+        scheduler = self._make_scheduler(epochs)
+
+        input_hw: tuple[int, int] = (gpu_train.masks.shape[-2], gpu_train.masks.shape[-1])
+        last_val_miou: float | None = None
+        num_batches = math.ceil(len(gpu_train) / batch_size)
+
+        for epoch in range(epochs):
+            self.model.train()
+            if self.model.freeze_backbone:
+                self.model.backbone.eval()
+
+            total_loss = 0.0
+            pbar = tqdm(
+                gpu_train.shuffled_batches(batch_size),
+                total=num_batches,
+                desc=f"Epoch {epoch + 1}/{epochs}",
+                disable=not verbose,
+            )
+            for features, masks in pbar:
+                self.optimizer.zero_grad()
+                with torch.autocast(device_type=self.device_type, enabled=self.use_amp):
+                    logits = self.model.head(features, *input_hw)
+                    loss = self.criterion(logits, masks)
+
+                self.scaler.scale(loss).backward()
+                self.scaler.step(self.optimizer)
+                self.scaler.update()
+
+                total_loss += loss.item()
+                pbar.set_postfix({"loss": f"{loss.item():.4f}"})
+
+            if scheduler is not None:
+                scheduler.step()
+
+            if gpu_val is not None:
+                val_metrics = self._evaluate_gpu_cache(gpu_val, batch_size)
+                last_val_miou = val_metrics["mIoU"]
+                if verbose:
+                    logger.info(f"Epoch {epoch + 1} Val mIoU: {last_val_miou:.4f}")
+
+        return last_val_miou
+
+    def evaluate_cached(
+        self,
+        cache: CachedFeaturesDataset,
+        batch_size: int = 64,
+        collect_preds: bool = False,
+    ) -> "SegMetrics | tuple[SegMetrics, torch.Tensor]":
+        """Evaluate on a CachedFeaturesDataset.
+
+        The cache is moved to GPU as a :class:`GPUTensorCache` for zero
+        per-batch host→device transfers.
+
+        Args:
+            cache: Pre-extracted features (output of
+                :meth:`SegmentationProbe.extract_all_features`).
+            batch_size: Batch size for iterating over the cache.
+            collect_preds: If True, also return predicted class maps (N, H, W) int64.
+
+        Returns:
+            Dict of metric name → value, or (metrics_dict, preds_tensor) when
+            collect_preds=True.
+        """
+        gpu_cache = GPUTensorCache.from_cached(cache, self.device)
+        return self._evaluate_gpu_cache(gpu_cache, batch_size, collect_preds=collect_preds)
+
+    def _compute_metrics(self) -> "SegMetrics":
+        """Compute and return all metrics as a dict."""
+        return {
+            "mIoU": self.metric.compute().item(),
+            "fw_IoU": self.metric_fw_iou.compute().item(),
+            "precision": self.metric_precision.compute().item(),
+            "recall": self.metric_recall.compute().item(),
+            "f1": self.metric_f1.compute().item(),
+        }
+
+    @torch.no_grad()
+    def _evaluate_gpu_cache(
+        self,
+        gpu_cache: GPUTensorCache,
+        batch_size: int,
+        collect_preds: bool = False,
+    ) -> "SegMetrics | tuple[SegMetrics, torch.Tensor]":
+        """Evaluate on a :class:`GPUTensorCache` and return segmentation metrics."""
+        self.model.eval()
+        for m in self._all_metrics:
+            m.reset()
+            m.to(self.device)
+
+        pred_list: list[torch.Tensor] = []
+
+        input_hw = (gpu_cache.masks.shape[-2], gpu_cache.masks.shape[-1])
+        for features, masks in gpu_cache.ordered_batches(batch_size):
+            with torch.autocast(device_type=self.device_type, enabled=self.use_amp):
+                logits = self.model.head(features, *input_hw)
+            for m in self._all_metrics:
+                m.update(logits, masks)
+            if collect_preds:
+                pred_list.append(logits.argmax(dim=1).cpu())
+
+        metrics = self._compute_metrics()
+        if collect_preds:
+            return metrics, torch.cat(pred_list, dim=0)
+        return metrics

--- a/src/torchgeo_bench/segmentation_task.py
+++ b/src/torchgeo_bench/segmentation_task.py
@@ -113,7 +113,11 @@ class SegmentationSolver:
             return torch.optim.lr_scheduler.CosineAnnealingLR(
                 self.optimizer, T_max=epochs, eta_min=1e-6
             )
-        return None
+        if self.lr_scheduler_type == "none":
+            return None
+        raise ValueError(
+            f"Unknown lr_scheduler {self.lr_scheduler_type!r}. Expected 'cosine' or 'none'."
+        )
 
     def fit(
         self,
@@ -155,7 +159,7 @@ class SegmentationSolver:
                     masks = masks.squeeze(1)
 
                 self.optimizer.zero_grad()
-                with torch.autocast(device_type="cuda", enabled=self.use_amp):
+                with torch.autocast(device_type=self.device_type, enabled=self.use_amp):
                     logits = self.model(images)
                     loss = self.criterion(logits, masks)
 
@@ -212,7 +216,7 @@ class SegmentationSolver:
                 masks = masks.squeeze(1)
             masks = masks.long()
 
-            with torch.autocast(device_type="cuda", enabled=self.use_amp):
+            with torch.autocast(device_type=self.device_type, enabled=self.use_amp):
                 logits = self.model(images)
 
             for m in self._all_metrics:
@@ -252,7 +256,7 @@ class SegmentationSolver:
 
         Args:
             train_cache: Pre-extracted training features from
-                :meth:`SegmentationProbe.extract_all_features`.
+                :meth:`SegmentationProbe.extract_segmentation_features`.
             val_cache: Optional validation cache for per-epoch mIoU logging.
             batch_size: Batch size for iterating over cached data.
             epochs: Number of training epochs.
@@ -326,7 +330,7 @@ class SegmentationSolver:
 
         Args:
             cache: Pre-extracted features (output of
-                :meth:`SegmentationProbe.extract_all_features`).
+                :meth:`SegmentationProbe.extract_segmentation_features`).
             batch_size: Batch size for iterating over the cache.
             collect_preds: If True, also return predicted class maps (N, H, W) int64.
 

--- a/src/torchgeo_bench/segmentation_viz.py
+++ b/src/torchgeo_bench/segmentation_viz.py
@@ -13,18 +13,48 @@ logger = logging.getLogger(__name__)
 # Fixed palette: tab20 (20 colours) concatenated with tab20b (20 more) for up to 40 classes.
 # Index 0 is black (background / class 0). 255 (ignore) is rendered as white.
 _TAB20_COLORS: list[tuple[int, int, int]] = [
-    (31, 119, 180), (174, 199, 232), (255, 127, 14), (255, 187, 120),
-    (44, 160, 44), (152, 223, 138), (214, 39, 40), (255, 152, 150),
-    (148, 103, 189), (197, 176, 213), (140, 86, 75), (196, 156, 148),
-    (227, 119, 194), (247, 182, 210), (127, 127, 127), (199, 199, 199),
-    (188, 189, 34), (219, 219, 141), (23, 190, 207), (158, 218, 229),
+    (31, 119, 180),
+    (174, 199, 232),
+    (255, 127, 14),
+    (255, 187, 120),
+    (44, 160, 44),
+    (152, 223, 138),
+    (214, 39, 40),
+    (255, 152, 150),
+    (148, 103, 189),
+    (197, 176, 213),
+    (140, 86, 75),
+    (196, 156, 148),
+    (227, 119, 194),
+    (247, 182, 210),
+    (127, 127, 127),
+    (199, 199, 199),
+    (188, 189, 34),
+    (219, 219, 141),
+    (23, 190, 207),
+    (158, 218, 229),
 ]
 _TAB20B_COLORS: list[tuple[int, int, int]] = [
-    (57, 59, 121), (82, 84, 163), (107, 110, 207), (156, 158, 222),
-    (99, 121, 57), (140, 162, 82), (181, 207, 107), (206, 219, 156),
-    (140, 109, 49), (189, 158, 57), (231, 186, 82), (231, 203, 148),
-    (132, 60, 57), (173, 73, 74), (214, 97, 107), (231, 150, 156),
-    (123, 65, 115), (165, 81, 148), (206, 109, 189), (222, 158, 214),
+    (57, 59, 121),
+    (82, 84, 163),
+    (107, 110, 207),
+    (156, 158, 222),
+    (99, 121, 57),
+    (140, 162, 82),
+    (181, 207, 107),
+    (206, 219, 156),
+    (140, 109, 49),
+    (189, 158, 57),
+    (231, 186, 82),
+    (231, 203, 148),
+    (132, 60, 57),
+    (173, 73, 74),
+    (214, 97, 107),
+    (231, 150, 156),
+    (123, 65, 115),
+    (165, 81, 148),
+    (206, 109, 189),
+    (222, 158, 214),
 ]
 _PALETTE: list[tuple[int, int, int]] = _TAB20_COLORS + _TAB20B_COLORS  # 40 entries
 
@@ -82,19 +112,21 @@ def render_error_map(gt: np.ndarray, pred: np.ndarray, ignore_index: int = 255) 
     out = np.zeros((h, w, 3), dtype=np.uint8)
     valid = gt != ignore_index
     correct = valid & (gt == pred)
-    fn = valid & (gt != pred) & (pred == 0)    # model missed the class (predicted background)
-    fp = valid & (gt != pred) & (gt == 0)       # model hallucinated (GT is background)
-    other = valid & (gt != pred) & ~fn & ~fp    # class-to-class confusion
+    fn = valid & (gt != pred) & (pred == 0)  # model missed the class (predicted background)
+    fp = valid & (gt != pred) & (gt == 0)  # model hallucinated (GT is background)
+    other = valid & (gt != pred) & ~fn & ~fp  # class-to-class confusion
 
-    out[correct] = (80, 200, 80)    # green
-    out[fn] = (220, 50, 50)         # red
-    out[fp] = (50, 100, 220)        # blue
-    out[other] = (220, 160, 50)     # orange — class confusion
-    out[~valid] = (255, 255, 255)   # white for ignore
+    out[correct] = (80, 200, 80)  # green
+    out[fn] = (220, 50, 50)  # red
+    out[fp] = (50, 100, 220)  # blue
+    out[other] = (220, 160, 50)  # orange — class confusion
+    out[~valid] = (255, 255, 255)  # white for ignore
     return out
 
 
-def _make_header_row(col_width: int, num_cols: int, labels: list[str], height: int = 24) -> np.ndarray:
+def _make_header_row(
+    col_width: int, num_cols: int, labels: list[str], height: int = 24
+) -> np.ndarray:
     """Return a (height, num_cols*col_width, 3) uint8 header banner with centered column labels."""
     try:
         from PIL import Image, ImageDraw
@@ -148,8 +180,8 @@ def render_sample_grid(
     panels: list[np.ndarray] = []
 
     for idx in indices:
-        img = images[idx].cpu().numpy()    # (C, H, W)
-        gt = gt_masks[idx].cpu().numpy()   # (H, W)
+        img = images[idx].cpu().numpy()  # (C, H, W)
+        gt = gt_masks[idx].cpu().numpy()  # (H, W)
         pred = pred_masks[idx].cpu().numpy()  # (H, W)
 
         # RGB image: pick channels, transpose to (H, W, 3)
@@ -193,6 +225,7 @@ def render_confusion_matrix(
     """
     try:
         import matplotlib
+
         matplotlib.use("Agg")
         import matplotlib.pyplot as plt
     except ImportError as e:
@@ -237,8 +270,9 @@ def render_confusion_matrix(
         for col in range(num_classes):
             val = cm_norm[row, col]
             color = "white" if val > 0.5 else "black"
-            ax.text(col, row, f"{val:.0%}", ha="center", va="center",
-                    fontsize=font_size, color=color)
+            ax.text(
+                col, row, f"{val:.0%}", ha="center", va="center", fontsize=font_size, color=color
+            )
 
     ax.set_xlabel("Predicted class")
     ax.set_ylabel("True class")

--- a/src/torchgeo_bench/segmentation_viz.py
+++ b/src/torchgeo_bench/segmentation_viz.py
@@ -1,0 +1,294 @@
+"""Visualization utilities for segmentation probe evaluation."""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import numpy as np
+import torch
+
+logger = logging.getLogger(__name__)
+
+# Fixed palette: tab20 (20 colours) concatenated with tab20b (20 more) for up to 40 classes.
+# Index 0 is black (background / class 0). 255 (ignore) is rendered as white.
+_TAB20_COLORS: list[tuple[int, int, int]] = [
+    (31, 119, 180), (174, 199, 232), (255, 127, 14), (255, 187, 120),
+    (44, 160, 44), (152, 223, 138), (214, 39, 40), (255, 152, 150),
+    (148, 103, 189), (197, 176, 213), (140, 86, 75), (196, 156, 148),
+    (227, 119, 194), (247, 182, 210), (127, 127, 127), (199, 199, 199),
+    (188, 189, 34), (219, 219, 141), (23, 190, 207), (158, 218, 229),
+]
+_TAB20B_COLORS: list[tuple[int, int, int]] = [
+    (57, 59, 121), (82, 84, 163), (107, 110, 207), (156, 158, 222),
+    (99, 121, 57), (140, 162, 82), (181, 207, 107), (206, 219, 156),
+    (140, 109, 49), (189, 158, 57), (231, 186, 82), (231, 203, 148),
+    (132, 60, 57), (173, 73, 74), (214, 97, 107), (231, 150, 156),
+    (123, 65, 115), (165, 81, 148), (206, 109, 189), (222, 158, 214),
+]
+_PALETTE: list[tuple[int, int, int]] = _TAB20_COLORS + _TAB20B_COLORS  # 40 entries
+
+
+def _build_colormap(num_classes: int) -> np.ndarray:
+    """Return (num_classes+1, 3) uint8 array; index num_classes → white for ignore."""
+    colors = np.zeros((num_classes + 1, 3), dtype=np.uint8)
+    for i in range(num_classes):
+        colors[i] = _PALETTE[i % len(_PALETTE)]
+    colors[num_classes] = (255, 255, 255)  # ignore index placeholder
+    return colors
+
+
+def colorize_mask(mask: np.ndarray, num_classes: int, ignore_index: int = 255) -> np.ndarray:
+    """Map a (H, W) integer mask to an (H, W, 3) uint8 RGB image.
+
+    Args:
+        mask: Integer class map, shape (H, W).
+        num_classes: Total number of classes (defines colormap size).
+        ignore_index: Pixels with this value are rendered white.
+
+    Returns:
+        RGB image, shape (H, W, 3), uint8.
+    """
+    colormap = _build_colormap(num_classes)
+    # Clamp ignore_index values to the last slot (white).
+    idx = mask.copy()
+    idx[idx == ignore_index] = num_classes
+    idx = np.clip(idx, 0, num_classes)
+    return colormap[idx]
+
+
+def _denorm_image(img: np.ndarray) -> np.ndarray:
+    """Stretch a (H, W, 3) float array to uint8 via per-channel min-max normalisation."""
+    out = np.zeros_like(img, dtype=np.float32)
+    for c in range(img.shape[2]):
+        lo, hi = img[:, :, c].min(), img[:, :, c].max()
+        if hi > lo:
+            out[:, :, c] = (img[:, :, c] - lo) / (hi - lo)
+        else:
+            out[:, :, c] = 0.0
+    return (out * 255).clip(0, 255).astype(np.uint8)
+
+
+def render_error_map(gt: np.ndarray, pred: np.ndarray, ignore_index: int = 255) -> np.ndarray:
+    """Return an (H, W, 3) uint8 error map.
+
+    Colour coding:
+      - Green  : correct prediction
+      - Red    : false negative (GT has class, pred is different)
+      - Blue   : false positive (pred has class, GT is different)
+      - White  : ignored pixel
+    """
+    h, w = gt.shape
+    out = np.zeros((h, w, 3), dtype=np.uint8)
+    valid = gt != ignore_index
+    correct = valid & (gt == pred)
+    fn = valid & (gt != pred) & (pred == 0)    # model missed the class (predicted background)
+    fp = valid & (gt != pred) & (gt == 0)       # model hallucinated (GT is background)
+    other = valid & (gt != pred) & ~fn & ~fp    # class-to-class confusion
+
+    out[correct] = (80, 200, 80)    # green
+    out[fn] = (220, 50, 50)         # red
+    out[fp] = (50, 100, 220)        # blue
+    out[other] = (220, 160, 50)     # orange — class confusion
+    out[~valid] = (255, 255, 255)   # white for ignore
+    return out
+
+
+def _make_header_row(col_width: int, num_cols: int, labels: list[str], height: int = 24) -> np.ndarray:
+    """Return a (height, num_cols*col_width, 3) uint8 header banner with centered column labels."""
+    from PIL import Image, ImageDraw
+
+    header_pil = Image.new("RGB", (num_cols * col_width, height), color=(40, 40, 40))
+    draw = ImageDraw.Draw(header_pil)
+    for i, label in enumerate(labels):
+        x_center = i * col_width + col_width // 2
+        bbox = draw.textbbox((0, 0), label)
+        tw, th = bbox[2] - bbox[0], bbox[3] - bbox[1]
+        x = x_center - tw // 2
+        y = height // 2 - th // 2
+        draw.text((x, y), label, fill=(220, 220, 220))
+    return np.asarray(header_pil)
+
+
+def render_sample_grid(
+    images: torch.Tensor,
+    gt_masks: torch.Tensor,
+    pred_masks: torch.Tensor,
+    num_classes: int,
+    rgb_indices: list[int],
+    n_samples: int = 8,
+    ignore_index: int = 255,
+) -> np.ndarray:
+    """Build a visualization grid for up to n_samples test samples.
+
+    Each row shows: [RGB image | GT mask | Pred mask | Error map]
+
+    Args:
+        images: (N, C, H, W) float tensor, normalized (will be min-max stretched).
+        gt_masks: (N, H, W) int64 tensor.
+        pred_masks: (N, H, W) int64 tensor.
+        num_classes: Number of segmentation classes.
+        rgb_indices: Channel indices [R, G, B] into the C dimension.
+        n_samples: Maximum number of samples to visualise.
+        ignore_index: Label value treated as ignore.
+
+    Returns:
+        (H_grid, W_grid, 3) uint8 numpy array.
+    """
+    n = min(n_samples, len(images))
+    # Deterministic sample selection: evenly spaced across the test set
+    indices = np.linspace(0, len(images) - 1, n, dtype=int)
+
+    panels: list[np.ndarray] = []
+
+    for idx in indices:
+        img = images[idx].cpu().numpy()    # (C, H, W)
+        gt = gt_masks[idx].cpu().numpy()   # (H, W)
+        pred = pred_masks[idx].cpu().numpy()  # (H, W)
+
+        # RGB image: pick channels, transpose to (H, W, 3)
+        ri = [min(c, img.shape[0] - 1) for c in rgb_indices]
+        rgb = img[ri, :, :].transpose(1, 2, 0)  # (H, W, 3)
+        rgb_u8 = _denorm_image(rgb)
+
+        gt_u8 = colorize_mask(gt, num_classes, ignore_index)
+        pred_u8 = colorize_mask(pred, num_classes, ignore_index)
+        err_u8 = render_error_map(gt, pred, ignore_index)
+
+        row = np.concatenate([rgb_u8, gt_u8, pred_u8, err_u8], axis=1)  # (H, 4*W, 3)
+        panels.append(row)
+
+    grid = np.concatenate(panels, axis=0)  # (n*H, 4*W, 3)
+
+    # Prepend a header row with column labels
+    col_width = images.shape[-1]  # W dimension
+    header = _make_header_row(col_width, 4, ["Image", "Ground Truth", "Prediction", "Error Map"])
+    return np.concatenate([header, grid], axis=0)
+
+
+def render_confusion_matrix(
+    preds: torch.Tensor,
+    targets: torch.Tensor,
+    num_classes: int,
+    ignore_index: int = 255,
+    class_names: list[str] | None = None,
+) -> np.ndarray:
+    """Build a normalised confusion matrix as a (H, W, 3) uint8 heatmap image.
+
+    Args:
+        preds: (N, H, W) int64 predicted class maps.
+        targets: (N, H, W) int64 ground truth class maps.
+        num_classes: Number of classes.
+        ignore_index: Label value to exclude.
+        class_names: Optional list of class name strings for axis labels.
+
+    Returns:
+        (H_img, W_img, 3) uint8 heatmap rendered with matplotlib Blues colormap.
+    """
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    # Flatten and mask out ignored pixels
+    p = preds.reshape(-1).numpy()
+    t = targets.reshape(-1).numpy()
+    valid = t != ignore_index
+    p, t = p[valid], t[valid]
+
+    # Clamp predictions to valid range
+    p = np.clip(p, 0, num_classes - 1)
+    t = np.clip(t, 0, num_classes - 1)
+
+    cm = np.zeros((num_classes, num_classes), dtype=np.int64)
+    np.add.at(cm, (t, p), 1)
+
+    # Row-normalise (true-class frequencies)
+    row_sums = cm.sum(axis=1, keepdims=True).astype(np.float64)
+    row_sums = np.where(row_sums == 0, 1, row_sums)
+    cm_norm = cm.astype(np.float64) / row_sums
+
+    fig_size = max(6, num_classes * 0.4)
+    fig, ax = plt.subplots(figsize=(fig_size, fig_size))
+    im = ax.imshow(cm_norm, cmap="Blues", vmin=0, vmax=1)
+    plt.colorbar(im, ax=ax, fraction=0.046, pad=0.04)
+
+    # Integer-only ticks; use class names when available
+    ax.set_xticks(range(num_classes))
+    ax.set_yticks(range(num_classes))
+    if class_names and len(class_names) == num_classes:
+        ax.set_xticklabels(class_names, rotation=45, ha="right")
+        ax.set_yticklabels(class_names)
+
+    # Annotate each cell with the percentage value
+    font_size = max(5, min(9, 72 // num_classes))
+    for row in range(num_classes):
+        for col in range(num_classes):
+            val = cm_norm[row, col]
+            color = "white" if val > 0.5 else "black"
+            ax.text(col, row, f"{val:.0%}", ha="center", va="center",
+                    fontsize=font_size, color=color)
+
+    ax.set_xlabel("Predicted class")
+    ax.set_ylabel("True class")
+    ax.set_title("Confusion matrix (row-normalised)")
+    plt.tight_layout()
+
+    # Render to numpy array (tostring_rgb removed in matplotlib ≥ 3.8; use buffer_rgba)
+    fig.canvas.draw()
+    buf = np.frombuffer(fig.canvas.buffer_rgba(), dtype=np.uint8)
+    w, h = fig.canvas.get_width_height()
+    arr = buf.reshape(h, w, 4)[:, :, :3].copy()  # drop alpha
+    plt.close(fig)
+    return arr
+
+
+def save_segmentation_viz(
+    out_dir: str,
+    model_name: str,
+    dataset_name: str,
+    images: torch.Tensor,
+    gt_masks: torch.Tensor,
+    pred_masks: torch.Tensor,
+    num_classes: int,
+    rgb_indices: list[int],
+    ignore_index: int = 255,
+    n_samples: int = 8,
+    class_names: list[str] | None = None,
+) -> None:
+    """Save a sample grid PNG and a confusion matrix PNG.
+
+    Files are written to ``{out_dir}/{model_name}/``:
+      - ``{dataset_name}_samples.png``
+      - ``{dataset_name}_confusion.png``
+
+    Args:
+        out_dir: Root visualization output directory.
+        model_name: Model name (used as sub-directory).
+        dataset_name: Dataset name (used in filenames).
+        images: (N, C, H, W) float tensor.
+        gt_masks: (N, H, W) int64 ground truth.
+        pred_masks: (N, H, W) int64 predictions.
+        num_classes: Number of segmentation classes.
+        rgb_indices: Channel indices [R, G, B] for image rendering.
+        ignore_index: Label value to exclude from metrics/confusion.
+        n_samples: Number of sample rows in the grid image.
+        class_names: Optional class name strings for confusion matrix axis labels.
+    """
+    from PIL import Image
+
+    dest = os.path.join(out_dir, model_name)
+    os.makedirs(dest, exist_ok=True)
+
+    # Sample grid
+    grid = render_sample_grid(
+        images, gt_masks, pred_masks, num_classes, rgb_indices, n_samples, ignore_index
+    )
+    grid_path = os.path.join(dest, f"{dataset_name}_samples.png")
+    Image.fromarray(grid).save(grid_path)
+    logger.info(f"Saved sample grid → {grid_path}")
+
+    # Confusion matrix
+    cm_arr = render_confusion_matrix(pred_masks, gt_masks, num_classes, ignore_index, class_names)
+    cm_path = os.path.join(dest, f"{dataset_name}_confusion.png")
+    Image.fromarray(cm_arr).save(cm_path)
+    logger.info(f"Saved confusion matrix → {cm_path}")

--- a/src/torchgeo_bench/segmentation_viz.py
+++ b/src/torchgeo_bench/segmentation_viz.py
@@ -96,7 +96,13 @@ def render_error_map(gt: np.ndarray, pred: np.ndarray, ignore_index: int = 255) 
 
 def _make_header_row(col_width: int, num_cols: int, labels: list[str], height: int = 24) -> np.ndarray:
     """Return a (height, num_cols*col_width, 3) uint8 header banner with centered column labels."""
-    from PIL import Image, ImageDraw
+    try:
+        from PIL import Image, ImageDraw
+    except ImportError as e:
+        raise ImportError(
+            "Pillow is required for segmentation visualization. "
+            "Install it with: pip install torchgeo-bench[viz]"
+        ) from e
 
     header_pil = Image.new("RGB", (num_cols * col_width, height), color=(40, 40, 40))
     draw = ImageDraw.Draw(header_pil)
@@ -185,9 +191,15 @@ def render_confusion_matrix(
     Returns:
         (H_img, W_img, 3) uint8 heatmap rendered with matplotlib Blues colormap.
     """
-    import matplotlib
-    matplotlib.use("Agg")
-    import matplotlib.pyplot as plt
+    try:
+        import matplotlib
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+    except ImportError as e:
+        raise ImportError(
+            "matplotlib is required for segmentation visualization. "
+            "Install it with: pip install torchgeo-bench[viz]"
+        ) from e
 
     # Flatten and mask out ignored pixels
     p = preds.reshape(-1).numpy()
@@ -274,8 +286,13 @@ def save_segmentation_viz(
         n_samples: Number of sample rows in the grid image.
         class_names: Optional class name strings for confusion matrix axis labels.
     """
-    from PIL import Image
-
+    try:
+        from PIL import Image
+    except ImportError as e:
+        raise ImportError(
+            "Pillow is required for segmentation visualization. "
+            "Install it with: pip install torchgeo-bench[viz]"
+        ) from e
     dest = os.path.join(out_dir, model_name)
     os.makedirs(dest, exist_ok=True)
 

--- a/src/torchgeo_bench/utils.py
+++ b/src/torchgeo_bench/utils.py
@@ -34,7 +34,11 @@ def extract_features(
 
     for _i, batch in enumerator:
         images = batch["image"].to(device)
-        labels = batch["label"].numpy()
+        if "label" not in batch:
+            # segmentation datasets use "mask" instead of "label"
+            labels = batch["mask"].numpy()
+        else:
+            labels = batch["label"].numpy()
 
         if transforms is not None:
             images = transforms(images)

--- a/src/torchgeo_bench/utils.py
+++ b/src/torchgeo_bench/utils.py
@@ -35,10 +35,12 @@ def extract_features(
     for _i, batch in enumerator:
         images = batch["image"].to(device)
         if "label" not in batch:
-            # segmentation datasets use "mask" instead of "label"
-            labels = batch["mask"].numpy()
-        else:
-            labels = batch["label"].numpy()
+            raise KeyError(
+                "Batch is missing 'label' key. extract_features() is a classification "
+                "utility; for segmentation use "
+                "SegmentationProbe.extract_segmentation_features() instead."
+            )
+        labels = batch["label"].numpy()
 
         if transforms is not None:
             images = transforms(images)

--- a/tests/test_segmentation.py
+++ b/tests/test_segmentation.py
@@ -3,8 +3,13 @@ import torch
 import torch.nn as nn
 from torch.utils.data import DataLoader, TensorDataset
 
-from torchgeo_bench.segmentation_probe import SegmentationProbe
+from torchgeo_bench.segmentation_probe import (
+    CachedFeaturesDataset,
+    SegmentationProbe,
+)
 from torchgeo_bench.segmentation_task import SegmentationSolver
+
+NUM_CLASSES = 5
 
 
 class MockBackbone(nn.Module):
@@ -23,6 +28,33 @@ class MockBackbone(nn.Module):
         return x
 
 
+class WrappedBackbone(nn.Module):
+    """Backbone whose layers are nested under a 'backbone' attribute, as in BenchModel wrappers."""
+
+    def __init__(self):
+        super().__init__()
+        self.backbone = MockBackbone()
+
+    def forward(self, x):
+        return self.backbone(x)
+
+
+class ViTBackbone(nn.Module):
+    """Backbone that emits (B, L, C) tokens from an intermediate layer, mimicking a ViT patch encoder."""
+
+    def __init__(self):
+        super().__init__()
+        self.patch_embed = nn.Conv2d(3, 16, kernel_size=16, stride=16)
+        self.blocks = nn.Identity()
+
+    def forward(self, x):
+        x = self.patch_embed(x)  # (B, 16, H/16, W/16)
+        B, C, H, W = x.shape
+        x = x.flatten(2).transpose(1, 2)  # (B, H*W, C) = (B, L, C)
+        x = self.blocks(x)
+        return x
+
+
 @pytest.fixture
 def mock_backbone():
     return MockBackbone()
@@ -33,18 +65,43 @@ def dummy_data():
     # Batch=2, Channels=3, H=64, W=64
     images = torch.randn(2, 3, 64, 64)
     # Batch=2, H=64, W=64 (values 0-4)
-    masks = torch.randint(0, 5, (2, 64, 64))
+    masks = torch.randint(0, NUM_CLASSES, (2, 64, 64))
     return {"image": images, "mask": masks}
 
 
-def test_probe_unknown_head_type(mock_backbone):
-    """Test that invalid head_type does not create head modules."""
-    probe = SegmentationProbe(
-        backbone=mock_backbone, layer_names=["layer1"], num_classes=2, head_type="invalid_type"
+def make_probe(backbone, layers, head_type="linear", freeze=True, hidden_dim=None):
+    return SegmentationProbe(
+        backbone=backbone,
+        layer_names=layers,
+        num_classes=NUM_CLASSES,
+        freeze_backbone=freeze,
+        head_type=head_type,
+        hidden_dim=hidden_dim,
     )
-    # Unknown head_type skips both branches, so neither 'heads' nor 'head' is created
-    assert not hasattr(probe, "heads")
-    assert not hasattr(probe, "head")
+
+
+def make_loader(images, masks, as_dict=False, mask_4d=False):
+    if mask_4d:
+        masks = masks.unsqueeze(1)
+    if as_dict:
+
+        class DictDataset(torch.utils.data.Dataset):
+            def __len__(self):
+                return len(images)
+
+            def __getitem__(self, idx):
+                return {"image": images[idx], "mask": masks[idx]}
+
+        return DataLoader(DictDataset(), batch_size=2)
+    return DataLoader(TensorDataset(images, masks), batch_size=2)
+
+
+def test_probe_unknown_head_type(mock_backbone):
+    """Test that an invalid head_type raises a ValueError."""
+    with pytest.raises(ValueError, match="Unknown head_type"):
+        SegmentationProbe(
+            backbone=mock_backbone, layer_names=["layer1"], num_classes=2, head_type="invalid_type"
+        )
 
 
 def test_probe_dry_run_exception_handling():
@@ -85,7 +142,7 @@ def test_segmentation_probe_initialization(mock_backbone, dummy_data):
     for param in probe.backbone.parameters():
         assert param.requires_grad is False
 
-    for param in probe.heads.parameters():
+    for param in probe.head.parameters():
         assert param.requires_grad is True
 
 
@@ -104,10 +161,12 @@ def test_segmentation_probe_conv_block_head(mock_backbone, dummy_data):
 
     logits = probe(data["image"])
     assert logits.shape == (2, num_classes, 64, 64)
-    # conv_block head uses projectors + a final Conv2d head
-    assert hasattr(probe, "projectors")
-    assert hasattr(probe, "head")
-    assert isinstance(probe.head, nn.Conv2d)
+    # conv_block head is a ConvBlockHead with projectors + a final Conv2d
+    from torchgeo_bench.models.segmentation_heads import ConvBlockHead
+
+    assert isinstance(probe.head, ConvBlockHead)
+    assert hasattr(probe.head, "projectors")
+    assert isinstance(probe.head.head, nn.Conv2d)
 
 
 def test_solver_fit_and_evaluate(mock_backbone, dummy_data):
@@ -116,16 +175,394 @@ def test_solver_fit_and_evaluate(mock_backbone, dummy_data):
     dataset = TensorDataset(data["image"], data["mask"])
     loader = DataLoader(dataset, batch_size=2)
 
-    num_classes = 5
     probe = SegmentationProbe(
-        backbone=mock_backbone, layer_names=["layer1", "layer2"], num_classes=num_classes
+        backbone=mock_backbone, layer_names=["layer1", "layer2"], num_classes=NUM_CLASSES
     )
 
-    solver = SegmentationSolver(model=probe, num_classes=num_classes, lr=1e-3, device="cpu")
+    solver = SegmentationSolver(model=probe, num_classes=NUM_CLASSES, lr=1e-3, device="cpu")
 
     solver.fit(loader, epochs=1, verbose=True)
 
-    miou = solver.evaluate(loader)
+    metrics = solver.evaluate(loader)
 
-    assert isinstance(miou, float)
-    assert 0.0 <= miou <= 1.0
+    assert isinstance(metrics, dict)
+    assert set(metrics.keys()) == {"mIoU", "fw_IoU", "precision", "recall", "f1"}
+    assert 0.0 <= metrics["mIoU"] <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# Probe: FPN head
+# ---------------------------------------------------------------------------
+
+
+def test_probe_fpn_head(mock_backbone, dummy_data):
+    """FPN head forward pass produces correct output shape and has expected attributes."""
+    from torchgeo_bench.models.segmentation_heads import FPNHead
+
+    probe = make_probe(mock_backbone, ["layer2", "layer1"], head_type="fpn", hidden_dim=16)
+
+    assert isinstance(probe.head, FPNHead)
+    assert hasattr(probe.head, "laterals")
+    assert hasattr(probe.head, "fpn_convs")
+    assert hasattr(probe.head, "fpn_head")
+
+    logits = probe(dummy_data["image"])
+    assert logits.shape == (2, NUM_CLASSES, 64, 64)
+
+
+# ---------------------------------------------------------------------------
+# Probe: backbone.* layer name stripping
+# ---------------------------------------------------------------------------
+
+
+def test_probe_backbone_prefix_stripping(dummy_data):
+    """Layer names prefixed with 'backbone.' are correctly resolved in wrapped models."""
+    backbone = WrappedBackbone()
+    # The inner layers are at backbone.layer1 / backbone.layer2 inside the wrapper,
+    # but SegmentationProbe should strip the leading 'backbone.' prefix so that
+    # specifying ["layer1"] still works.
+    probe = make_probe(backbone, ["layer1", "layer2"])
+    logits = probe(dummy_data["image"])
+    assert logits.shape == (2, NUM_CLASSES, 64, 64)
+
+
+# ---------------------------------------------------------------------------
+# Probe: single-layer linear
+# ---------------------------------------------------------------------------
+
+
+def test_probe_linear_single_layer(mock_backbone, dummy_data):
+    """Single-layer linear probe returns logits without scale_weights."""
+    probe = make_probe(mock_backbone, ["layer1"], head_type="linear")
+    assert not hasattr(probe, "scale_weights")
+    logits = probe(dummy_data["image"])
+    assert logits.shape == (2, NUM_CLASSES, 64, 64)
+
+
+# ---------------------------------------------------------------------------
+# Probe: multi-layer linear
+# ---------------------------------------------------------------------------
+
+
+def test_probe_linear_multi_layer_weighted(mock_backbone, dummy_data):
+    """Multi-layer linear probe uses scale_weights and returns correct shape."""
+    probe = make_probe(mock_backbone, ["layer1", "layer2"], head_type="linear")
+    assert hasattr(probe.head, "scale_weights")
+    logits = probe(dummy_data["image"])
+    assert logits.shape == (2, NUM_CLASSES, 64, 64)
+
+
+# ---------------------------------------------------------------------------
+# Probe: conv_block with multiple layers
+# ---------------------------------------------------------------------------
+
+
+def test_probe_conv_block_multi_layer(mock_backbone, dummy_data):
+    """conv_block with two layers at different resolutions triggers interpolation alignment."""
+    probe = make_probe(mock_backbone, ["layer1", "layer2"], head_type="conv_block", hidden_dim=16)
+    logits = probe(dummy_data["image"])
+    assert logits.shape == (2, NUM_CLASSES, 64, 64)
+
+
+# ---------------------------------------------------------------------------
+# Probe: unfrozen backbone forward path
+# ---------------------------------------------------------------------------
+
+
+def test_probe_unfrozen_backbone(mock_backbone, dummy_data):
+    """With freeze_backbone=False the backbone runs in train mode and grads flow."""
+    probe = make_probe(mock_backbone, ["layer1"], freeze=False)
+    for param in probe.backbone.parameters():
+        assert param.requires_grad is True
+    logits = probe(dummy_data["image"])
+    assert logits.shape == (2, NUM_CLASSES, 64, 64)
+
+
+# ---------------------------------------------------------------------------
+# Probe: ViT-style (B, L, C) token features via _process_feature
+# ---------------------------------------------------------------------------
+
+
+def test_probe_vit_token_features():
+    """ViT backbone emitting (B, L, C) tokens is correctly reshaped to (B, C, H, H)."""
+    backbone = ViTBackbone()
+    # 'blocks' is an Identity that passes through (B, L, C); hook it directly
+    probe = make_probe(backbone, ["blocks"], head_type="linear")
+    images = torch.randn(2, 3, 64, 64)
+    logits = probe(images)
+    assert logits.shape == (2, NUM_CLASSES, 64, 64)
+
+
+# ---------------------------------------------------------------------------
+# Solver: no LR scheduler path
+# ---------------------------------------------------------------------------
+
+
+def test_solver_no_lr_scheduler(mock_backbone, dummy_data):
+    """lr_scheduler='none' runs without a scheduler and completes training."""
+    images, masks = dummy_data["image"], dummy_data["mask"]
+    loader = make_loader(images, masks)
+    probe = make_probe(mock_backbone, ["layer1"])
+    solver = SegmentationSolver(
+        model=probe, num_classes=NUM_CLASSES, lr=1e-3, device="cpu", lr_scheduler="none"
+    )
+    result = solver.fit(loader, epochs=1, verbose=False)
+    assert result is None  # no val_loader → returns None
+
+
+# ---------------------------------------------------------------------------
+# Solver: dict-format batches in fit and evaluate
+# ---------------------------------------------------------------------------
+
+
+def test_solver_dict_batches(mock_backbone, dummy_data):
+    """fit and evaluate both handle dict-format batches {"image": ..., "mask": ...}."""
+    images, masks = dummy_data["image"], dummy_data["mask"]
+    loader = make_loader(images, masks, as_dict=True)
+    probe = make_probe(mock_backbone, ["layer1"])
+    solver = SegmentationSolver(model=probe, num_classes=NUM_CLASSES, lr=1e-3, device="cpu")
+    solver.fit(loader, epochs=1, verbose=False)
+    metrics = solver.evaluate(loader)
+    assert 0.0 <= metrics["mIoU"] <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# Solver: 4D mask squeezing in fit and evaluate
+# ---------------------------------------------------------------------------
+
+
+def test_solver_4d_masks(mock_backbone, dummy_data):
+    """fit and evaluate both squeeze (B, 1, H, W) masks to (B, H, W)."""
+    images, masks = dummy_data["image"], dummy_data["mask"]
+    loader = make_loader(images, masks, mask_4d=True)
+    probe = make_probe(mock_backbone, ["layer1"])
+    solver = SegmentationSolver(model=probe, num_classes=NUM_CLASSES, lr=1e-3, device="cpu")
+    solver.fit(loader, epochs=1, verbose=False)
+    metrics = solver.evaluate(loader)
+    assert 0.0 <= metrics["mIoU"] <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# Solver: val_loader passed to fit returns mIoU
+# ---------------------------------------------------------------------------
+
+
+def test_solver_fit_with_val_loader(mock_backbone, dummy_data):
+    """fit returns the final epoch val mIoU when a val_loader is provided."""
+    images, masks = dummy_data["image"], dummy_data["mask"]
+    train_loader = make_loader(images, masks)
+    val_loader = make_loader(images, masks)
+    probe = make_probe(mock_backbone, ["layer1"])
+    solver = SegmentationSolver(model=probe, num_classes=NUM_CLASSES, lr=1e-3, device="cpu")
+    val_miou = solver.fit(train_loader, val_loader=val_loader, epochs=1, verbose=False)
+    assert isinstance(val_miou, float)
+    assert 0.0 <= val_miou <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# Probe: DPT head
+# ---------------------------------------------------------------------------
+
+
+class MockBackbone4Layer(nn.Module):
+    """CNN backbone with 4 strided layers to provide multi-scale features for DPT."""
+
+    def __init__(self):
+        super().__init__()
+        self.layer1 = nn.Sequential(nn.Conv2d(3, 8, kernel_size=3, padding=1, stride=1), nn.ReLU())
+        self.layer2 = nn.Sequential(nn.Conv2d(8, 16, kernel_size=3, padding=1, stride=2), nn.ReLU())
+        self.layer3 = nn.Sequential(
+            nn.Conv2d(16, 32, kernel_size=3, padding=1, stride=2), nn.ReLU()
+        )
+        self.layer4 = nn.Sequential(
+            nn.Conv2d(32, 64, kernel_size=3, padding=1, stride=2), nn.ReLU()
+        )
+
+    def forward(self, x):
+        x = self.layer1(x)
+        x = self.layer2(x)
+        x = self.layer3(x)
+        x = self.layer4(x)
+        return x
+
+
+def test_probe_dpt_head_forward():
+    """DPT head with 4 coarse-to-fine layers produces correct output shape."""
+    from torchgeo_bench.models.segmentation_heads import DPTHead
+
+    backbone = MockBackbone4Layer()
+    # Coarse-to-fine order (same convention as FPN)
+    probe = make_probe(
+        backbone,
+        layers=["layer4", "layer3", "layer2", "layer1"],
+        head_type="dpt",
+        hidden_dim=16,
+    )
+
+    assert isinstance(probe.head, DPTHead)
+    assert hasattr(probe.head, "convs")
+    assert hasattr(probe.head, "ref")
+    assert hasattr(probe.head, "out_conv")
+    assert len(probe.head.convs) == 4
+    assert len(probe.head.ref) == 4
+
+    images = torch.randn(2, 3, 64, 64)
+    logits = probe(images)
+    assert logits.shape == (2, NUM_CLASSES, 64, 64)
+
+
+def test_probe_dpt_wrong_num_layers():
+    """DPT head raises ValueError when not exactly 4 layers are specified."""
+    backbone = MockBackbone()  # only has layer1, layer2
+    with pytest.raises(ValueError, match="DPTHead requires exactly 4 feature layers"):
+        make_probe(backbone, layers=["layer1", "layer2"], head_type="dpt", hidden_dim=16)
+
+
+# ---------------------------------------------------------------------------
+# Feature caching: extract_all_features + CachedFeaturesDataset
+# ---------------------------------------------------------------------------
+
+
+def test_extract_all_features_returns_cached_dataset(mock_backbone, dummy_data):
+    """extract_all_features produces a CachedFeaturesDataset with correct length and dtypes."""
+    images, masks = dummy_data["image"], dummy_data["mask"]
+    loader = make_loader(images, masks)
+    probe = make_probe(mock_backbone, ["layer1", "layer2"])
+
+    cache = probe.extract_all_features(loader, cache_dtype=torch.float16)
+
+    assert isinstance(cache, CachedFeaturesDataset)
+    assert len(cache) == len(images)
+    feats, mask = cache[0]
+    assert len(feats) == 2  # two hooked layers
+    assert feats[0].dtype == torch.float16
+    assert mask.dtype == torch.int64
+
+
+def test_cached_features_dataset_indexing(mock_backbone, dummy_data):
+    """CachedFeaturesDataset returns correct per-sample features and masks."""
+    images, masks = dummy_data["image"], dummy_data["mask"]
+    loader = make_loader(images, masks)
+    probe = make_probe(mock_backbone, ["layer1", "layer2"])
+    cache = probe.extract_all_features(loader, cache_dtype=torch.float32)
+
+    feats, mask = cache[0]
+    assert len(feats) == 2  # two layers
+    assert mask.shape == (64, 64)
+
+
+def test_solver_fit_cached(mock_backbone, dummy_data):
+    """fit_cached trains the head on cached features and evaluate_cached returns a valid mIoU."""
+    images, masks = dummy_data["image"], dummy_data["mask"]
+    loader = make_loader(images, masks)
+    probe = make_probe(mock_backbone, ["layer1", "layer2"])
+    solver = SegmentationSolver(model=probe, num_classes=NUM_CLASSES, lr=1e-3, device="cpu")
+
+    train_cache = probe.extract_all_features(loader, cache_dtype=torch.float32)
+    val_cache = probe.extract_all_features(loader, cache_dtype=torch.float32)
+
+    val_miou = solver.fit_cached(
+        train_cache, val_cache=val_cache, batch_size=2, epochs=1, verbose=False
+    )
+    assert isinstance(val_miou, float)
+    assert 0.0 <= val_miou <= 1.0
+
+    metrics = solver.evaluate_cached(val_cache, batch_size=2)
+    assert isinstance(metrics, dict)
+    assert 0.0 <= metrics["mIoU"] <= 1.0
+
+
+def test_extract_all_features_dict_batches(mock_backbone, dummy_data):
+    """extract_all_features handles dict-format batches {"image": ..., "mask": ...}."""
+    images, masks = dummy_data["image"], dummy_data["mask"]
+    loader = make_loader(images, masks, as_dict=True)
+    probe = make_probe(mock_backbone, ["layer1"])
+    cache = probe.extract_all_features(loader, cache_dtype=torch.float32)
+    assert len(cache) == len(images)
+
+
+# ---------------------------------------------------------------------------
+# GPUTensorCache
+# ---------------------------------------------------------------------------
+
+
+from torchgeo_bench.segmentation_probe import GPUTensorCache, _estimate_cache_bytes
+
+
+def _make_cpu_cache(mock_backbone, dummy_data):
+    """Helper: extract a CachedFeaturesDataset on CPU."""
+    images, masks = dummy_data["image"], dummy_data["mask"]
+    loader = make_loader(images, masks)
+    probe = make_probe(mock_backbone, ["layer1", "layer2"])
+    return probe.extract_all_features(loader, cache_dtype=torch.float16)
+
+
+def test_estimate_cache_bytes(mock_backbone, dummy_data):
+    """_estimate_cache_bytes returns a positive integer for a non-empty cache."""
+    cache = _make_cpu_cache(mock_backbone, dummy_data)
+    size = _estimate_cache_bytes(cache)
+    assert size > 0
+    assert isinstance(size, int)
+
+
+def test_estimate_cache_bytes_empty():
+    """_estimate_cache_bytes returns 0 for an empty cache."""
+    empty = CachedFeaturesDataset([], [])
+    assert _estimate_cache_bytes(empty) == 0
+
+
+def test_gpu_tensor_cache_from_cached_cpu(mock_backbone, dummy_data):
+    """GPUTensorCache.from_cached builds correct tensors on CPU device."""
+    cache = _make_cpu_cache(mock_backbone, dummy_data)
+    gpu_cache = GPUTensorCache.from_cached(cache, device="cpu")
+
+    assert len(gpu_cache) == len(cache)
+    assert len(gpu_cache.layer_tensors) == 2  # two hooked layers
+    assert gpu_cache.layer_tensors[0].dtype == torch.float32  # CPU path uses float32
+    assert gpu_cache.masks.dtype == torch.long
+    # Spatial dims should match the mask dims in the original cache
+    assert gpu_cache.masks.shape == (len(cache), 64, 64)
+
+
+def test_gpu_tensor_cache_shuffled_batches(mock_backbone, dummy_data):
+    """shuffled_batches yields all samples exactly once with correct shapes."""
+    cache = _make_cpu_cache(mock_backbone, dummy_data)
+    gpu_cache = GPUTensorCache.from_cached(cache, device="cpu")
+
+    all_masks = []
+    for feats, masks in gpu_cache.shuffled_batches(batch_size=1):
+        assert len(feats) == 2
+        assert feats[0].shape[0] == masks.shape[0]  # batch dim matches
+        all_masks.append(masks)
+
+    total = sum(m.shape[0] for m in all_masks)
+    assert total == len(cache)
+
+
+def test_gpu_tensor_cache_ordered_batches(mock_backbone, dummy_data):
+    """ordered_batches yields samples in order with correct total count."""
+    cache = _make_cpu_cache(mock_backbone, dummy_data)
+    gpu_cache = GPUTensorCache.from_cached(cache, device="cpu")
+
+    total = 0
+    for feats, masks in gpu_cache.ordered_batches(batch_size=1):
+        total += masks.shape[0]
+    assert total == len(cache)
+
+
+def test_solver_fit_cached_uses_gpu_cache_path(mock_backbone, dummy_data):
+    """fit_cached falls back gracefully to DataLoader path on CPU (no CUDA available in CI)."""
+    images, masks = dummy_data["image"], dummy_data["mask"]
+    loader = make_loader(images, masks)
+    probe = make_probe(mock_backbone, ["layer1", "layer2"])
+    solver = SegmentationSolver(model=probe, num_classes=NUM_CLASSES, lr=1e-3, device="cpu")
+
+    train_cache = probe.extract_all_features(loader, cache_dtype=torch.float32)
+    val_cache = probe.extract_all_features(loader, cache_dtype=torch.float32)
+
+    # On CPU, use_amp=False so GPUTensorCache path is skipped; DataLoader fallback runs.
+    val_miou = solver.fit_cached(
+        train_cache, val_cache=val_cache, batch_size=2, epochs=1, verbose=False
+    )
+    assert isinstance(val_miou, float)
+    assert 0.0 <= val_miou <= 1.0

--- a/tests/test_segmentation.py
+++ b/tests/test_segmentation.py
@@ -488,7 +488,6 @@ def test_extract_segmentation_features_dict_batches(mock_backbone, dummy_data):
 # ---------------------------------------------------------------------------
 
 
-
 def _make_cpu_cache(mock_backbone, dummy_data):
     """Helper: extract a CachedFeaturesDataset on CPU."""
     images, masks = dummy_data["image"], dummy_data["mask"]

--- a/tests/test_segmentation.py
+++ b/tests/test_segmentation.py
@@ -419,17 +419,17 @@ def test_probe_dpt_wrong_num_layers():
 
 
 # ---------------------------------------------------------------------------
-# Feature caching: extract_all_features + CachedFeaturesDataset
+# Feature caching: extract_segmentation_features + CachedFeaturesDataset
 # ---------------------------------------------------------------------------
 
 
-def test_extract_all_features_returns_cached_dataset(mock_backbone, dummy_data):
-    """extract_all_features produces a CachedFeaturesDataset with correct length and dtypes."""
+def test_extract_segmentation_features_returns_cached_dataset(mock_backbone, dummy_data):
+    """extract_segmentation_features produces a CachedFeaturesDataset with correct length and dtypes."""
     images, masks = dummy_data["image"], dummy_data["mask"]
     loader = make_loader(images, masks)
     probe = make_probe(mock_backbone, ["layer1", "layer2"])
 
-    cache = probe.extract_all_features(loader, cache_dtype=torch.float16)
+    cache = probe.extract_segmentation_features(loader, cache_dtype=torch.float16)
 
     assert isinstance(cache, CachedFeaturesDataset)
     assert len(cache) == len(images)
@@ -444,7 +444,7 @@ def test_cached_features_dataset_indexing(mock_backbone, dummy_data):
     images, masks = dummy_data["image"], dummy_data["mask"]
     loader = make_loader(images, masks)
     probe = make_probe(mock_backbone, ["layer1", "layer2"])
-    cache = probe.extract_all_features(loader, cache_dtype=torch.float32)
+    cache = probe.extract_segmentation_features(loader, cache_dtype=torch.float32)
 
     feats, mask = cache[0]
     assert len(feats) == 2  # two layers
@@ -458,8 +458,8 @@ def test_solver_fit_cached(mock_backbone, dummy_data):
     probe = make_probe(mock_backbone, ["layer1", "layer2"])
     solver = SegmentationSolver(model=probe, num_classes=NUM_CLASSES, lr=1e-3, device="cpu")
 
-    train_cache = probe.extract_all_features(loader, cache_dtype=torch.float32)
-    val_cache = probe.extract_all_features(loader, cache_dtype=torch.float32)
+    train_cache = probe.extract_segmentation_features(loader, cache_dtype=torch.float32)
+    val_cache = probe.extract_segmentation_features(loader, cache_dtype=torch.float32)
 
     val_miou = solver.fit_cached(
         train_cache, val_cache=val_cache, batch_size=2, epochs=1, verbose=False
@@ -472,12 +472,12 @@ def test_solver_fit_cached(mock_backbone, dummy_data):
     assert 0.0 <= metrics["mIoU"] <= 1.0
 
 
-def test_extract_all_features_dict_batches(mock_backbone, dummy_data):
-    """extract_all_features handles dict-format batches {"image": ..., "mask": ...}."""
+def test_extract_segmentation_features_dict_batches(mock_backbone, dummy_data):
+    """extract_segmentation_features handles dict-format batches {"image": ..., "mask": ...}."""
     images, masks = dummy_data["image"], dummy_data["mask"]
     loader = make_loader(images, masks, as_dict=True)
     probe = make_probe(mock_backbone, ["layer1"])
-    cache = probe.extract_all_features(loader, cache_dtype=torch.float32)
+    cache = probe.extract_segmentation_features(loader, cache_dtype=torch.float32)
     assert len(cache) == len(images)
 
 
@@ -494,7 +494,7 @@ def _make_cpu_cache(mock_backbone, dummy_data):
     images, masks = dummy_data["image"], dummy_data["mask"]
     loader = make_loader(images, masks)
     probe = make_probe(mock_backbone, ["layer1", "layer2"])
-    return probe.extract_all_features(loader, cache_dtype=torch.float16)
+    return probe.extract_segmentation_features(loader, cache_dtype=torch.float16)
 
 
 def test_estimate_cache_bytes(mock_backbone, dummy_data):
@@ -557,8 +557,8 @@ def test_solver_fit_cached_uses_gpu_cache_path(mock_backbone, dummy_data):
     probe = make_probe(mock_backbone, ["layer1", "layer2"])
     solver = SegmentationSolver(model=probe, num_classes=NUM_CLASSES, lr=1e-3, device="cpu")
 
-    train_cache = probe.extract_all_features(loader, cache_dtype=torch.float32)
-    val_cache = probe.extract_all_features(loader, cache_dtype=torch.float32)
+    train_cache = probe.extract_segmentation_features(loader, cache_dtype=torch.float32)
+    val_cache = probe.extract_segmentation_features(loader, cache_dtype=torch.float32)
 
     # On CPU, use_amp=False so GPUTensorCache path is skipped; DataLoader fallback runs.
     val_miou = solver.fit_cached(

--- a/tests/test_segmentation.py
+++ b/tests/test_segmentation.py
@@ -5,7 +5,9 @@ from torch.utils.data import DataLoader, TensorDataset
 
 from torchgeo_bench.segmentation_probe import (
     CachedFeaturesDataset,
+    GPUTensorCache,
     SegmentationProbe,
+    _estimate_cache_bytes,
 )
 from torchgeo_bench.segmentation_task import SegmentationSolver
 
@@ -486,8 +488,6 @@ def test_extract_segmentation_features_dict_batches(mock_backbone, dummy_data):
 # ---------------------------------------------------------------------------
 
 
-from torchgeo_bench.segmentation_probe import GPUTensorCache, _estimate_cache_bytes
-
 
 def _make_cpu_cache(mock_backbone, dummy_data):
     """Helper: extract a CachedFeaturesDataset on CPU."""
@@ -545,7 +545,7 @@ def test_gpu_tensor_cache_ordered_batches(mock_backbone, dummy_data):
     gpu_cache = GPUTensorCache.from_cached(cache, device="cpu")
 
     total = 0
-    for feats, masks in gpu_cache.ordered_batches(batch_size=1):
+    for _feats, masks in gpu_cache.ordered_batches(batch_size=1):
         total += masks.shape[0]
     assert total == len(cache)
 


### PR DESCRIPTION
Splitting the large PR #9 into separate smaller ones.

- SegmentationProbe with forward hooks for multi-scale feature extraction
- CachedFeaturesDataset / GPUTensorCache for fast feature caching (run backbone once, store layer-first float16 tensors, single GPU memcpy)
- SegmentationSolver with AMP training and cosine LR scheduler
- LinearHead, ConvBlockHead, FPNHead, DPTHead decoder architectures
- SegmentationViz for optional prediction/error grid output (off by default)
- SAM3 ViT-H encoder wrapper and config
- eval.segmentation.layers added to all model configs (coarse-to-fine)
- evaluate_segmentation() integrated into main benchmark pipeline

Gonna open the other PRs once we settle on the core implementation here.