### PR TITLE
feat: optional intrinsic-dimension metrics via torchid

### DIFF
--- a/docs/plans/torchid-intrinsic-dim.md
+++ b/docs/plans/torchid-intrinsic-dim.md
@@ -1,0 +1,139 @@
+# Plan: Intrinsic Dimension (ID) metrics via `torchid`
+
+Branch: `feat/torchid-intrinsic-dim`
+
+## Goal
+
+During embedding-based evaluation (KNN, linear probe), optionally compute
+intrinsic dimension (ID) metrics on the extracted train/val/test features so we
+can correlate ID across pretrained models × datasets with downstream
+performance (accuracy / micro-mAP). Hypothesis: higher ID ⇒ better downstream.
+
+## Dependency
+
+- pkg: `torchid` (https://github.com/isaaccorley/torchid)
+- install: `pip install torchid`
+- API: sklearn-style `Estimator().fit(X).dimension_` (global) and
+  `.dimension_pw_` (pointwise). GPU-accelerated, batched, `scikit-dimension`
+  parity.
+- Estimators:
+  - global: `lPCA`, `TwoNN`, `MLE`, `CorrInt`, `MiND_ML`, `KNN`, `DANCo`,
+    `FisherS`
+  - local: `MOM`, `MADA`, `TLE`, `ESS`
+
+## Integration points
+
+Embeddings already live as `(x_train, y_train)`, `(x_val, ...)`, `(x_test, ...)`
+in `src/torchgeo_bench/main.py:559-561` (classification path only — segmentation
+has no global feature matrix and is **out of scope** for v1).
+
+Touched files:
+- `pyproject.toml` — add `torchid>=…` (pin after install + health check).
+- `src/torchgeo_bench/conf/config.yaml` — new `eval.intrinsic_dim` block.
+- `src/torchgeo_bench/intrinsic_dim.py` — new thin wrapper module.
+- `src/torchgeo_bench/main.py` — call wrapper after `embed_split`, emit rows.
+- `tests/test_intrinsic_dim.py` — unit tests on synthetic manifolds.
+
+## Config (Hydra)
+
+```yaml
+eval:
+  intrinsic_dim:
+    enabled: false                  # off by default (extra compute)
+    estimators: [TwoNN, MLE, lPCA]  # subset of torchid global estimators
+    splits: [train]                 # which splits to compute on (train|val|test|all)
+    max_samples: 10000              # subsample per split for speed; null = all
+    device: ${device}               # reuse top-level device
+    seed: ${seed}
+```
+
+Defaults aim cheap: 3 fast global estimators on train only, ≤10k pts.
+
+## Wrapper module sketch
+
+`src/torchgeo_bench/intrinsic_dim.py`:
+
+- `ESTIMATORS: dict[str, type]` lazy import map → torchid classes.
+- `compute_id(X, estimators, device, max_samples, seed) -> dict[str, float]`
+  - subsample with seeded RNG if `len(X) > max_samples`
+  - move to device tensor (float32)
+  - for each name: `est = ESTIMATORS[name]().fit(X); out[name] = float(est.dimension_)`
+  - on per-estimator failure: log warning, record `nan` (do not abort run).
+- Return `{est_name: dim_value}`.
+
+Keep wrapper <100 LOC. No pointwise / local estimators in v1 — scalar-per-split
+keeps the schema flat.
+
+## Result schema
+
+Two options — pick A:
+
+**A. New rows** (recommended; minimal schema churn):
+- One row per (dataset, model, split, estimator) with
+  `method = "intrinsic_dim"`, `metric_name = f"id_{estimator}_{split}"`,
+  `metric_value = dim`, CI = 0, feature_dim populated, `best_c = None`.
+- Pros: works with existing `EvaluationResult` + CSV append.
+- Cons: many rows; downstream join needed for ID-vs-accuracy plots.
+
+**B. Sidecar columns on existing knn5/linear rows.**
+- Cons: changes `EvaluationResult` dataclass + breaks resume keys / older CSVs.
+
+Going with **A**. Add `split` to `common_meta` only when emitting ID rows
+(reuse a separate row-emit helper to avoid touching the dataclass — store
+split inside `name` suffix or extend dataclass with optional `split: str | None
+= None`). Decide during impl; lean toward adding `split` field defaulting None.
+
+## Main loop change (sketch)
+
+After line 562 (`feature_dim = x_train.shape[1]`):
+
+```python
+if cfg.eval.intrinsic_dim.enabled:
+    from torchgeo_bench.intrinsic_dim import compute_id_for_splits
+    id_rows = compute_id_for_splits(
+        splits={"train": x_train, "val": x_val, "test": x_test},
+        cfg=cfg.eval.intrinsic_dim,
+        common_meta=common_meta,
+        feature_dim=feature_dim,
+        n_train=len(x_train), n_val=len(x_val), n_test=len(x_test),
+    )
+    all_rows.extend(id_rows)
+```
+
+ID computation is independent of knn/linear — runs once per (dataset, model)
+even if both are skipped via resume? → only run when at least one of knn/linear
+runs OR add separate `id_key` resume tracking. Simpler: gate ID on
+`not (skip_knn and skip_linear)` for v1.
+
+## Tests
+
+`tests/test_intrinsic_dim.py`:
+- Synthetic Swiss roll (true ID=2 in 3D) → `TwoNN`/`MLE` ≈ 2 ± 0.5.
+- Uniform cube (true ID=d) → `lPCA` ≈ d.
+- Subsampling determinism w/ fixed seed.
+- Estimator failure path → nan + logged warning, run continues.
+
+## Open questions
+
+1. **Normalization before ID?** torchid expects raw float features; current
+   embeddings are not L2-normalized. KNN uses L2 distance on raw, so match
+   that — pass raw. Note this in module docstring.
+2. **Pointwise/local estimators** (MADA, TLE) for per-class ID would be
+   interesting (does ID per class predict per-class accuracy?). Defer to v2.
+3. **Segmentation features.** Could compute ID on patch-token embeddings from
+   the segmentation probe — separate follow-up; skip in v1.
+4. **CUDA OOM** for large N×D. Cap via `max_samples`; document.
+
+## Rollout
+
+1. Add dep, wrapper, config, tests. Commit: `feat: add torchid intrinsic
+   dimension metrics`.
+2. Run on a small dataset/model pair, eyeball numbers vs. paper expectations.
+3. Open PR. After merge, schedule a sweep across all (model, dataset) and
+   produce a notebook plotting ID vs downstream accuracy.
+
+## Non-goals (v1)
+
+- Local/pointwise ID columns.
+- ID for segmentation backbones.
+- ID-aware model selection / training-loop integration.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dependencies = [
 ]
 optional-dependencies.all = [
   "torchgeo-bench[dev]",
+  "torchgeo-bench[id]",
   "torchgeo-bench[sam3]",
   "torchgeo-bench[viz]",
 ]
@@ -61,6 +62,9 @@ optional-dependencies.dev = [
   "pytest>=7.3",
   "pytest-cov>=4.1",
   "ruff>=0.0.270",
+]
+optional-dependencies.id = [
+  "torchid>=0.3; python_version>='3.13'",
 ]
 optional-dependencies.olmoearth = [
   "olmoearth-pretrain-minimal>=0.0.2",

--- a/src/torchgeo_bench/conf/config.yaml
+++ b/src/torchgeo_bench/conf/config.yaml
@@ -28,6 +28,16 @@ eval:
   merge_val: true          # merge train+val for final logistic training
   skip_linear: false       # if true, skip LogisticRegression evaluation
 
+  # Optional intrinsic dimension (ID) metrics on extracted embeddings.
+  # Computed alongside KNN/linear probing when enabled. Adds rows with
+  # method="intrinsic_dim" and metric_name="id_<estimator>_<split>".
+  intrinsic_dim:
+    enabled: false
+    estimators: [TwoNN, MLE, lPCA]   # subset of torchid global estimators
+    splits: [train]                  # any of: train, val, test
+    max_samples: 10000               # null disables subsampling
+    device: null                     # null = auto (cuda if available, else cpu)
+
   segmentation:
     head_type: "fpn"
     layers: []

--- a/src/torchgeo_bench/intrinsic_dim.py
+++ b/src/torchgeo_bench/intrinsic_dim.py
@@ -1,0 +1,111 @@
+"""Intrinsic dimension (ID) estimation over feature embeddings.
+
+Thin wrapper around ``torchid`` (https://github.com/isaaccorley/torchid).
+Provides a single entry point to compute one or more global ID estimates on a
+feature matrix and return scalar values per estimator.
+
+ID is computed on raw embeddings (no L2-normalization) to match the distance
+geometry used by KNN/linear probes elsewhere in this package.
+"""
+
+import logging
+from typing import Any
+
+import numpy as np
+import torch
+
+logger = logging.getLogger(__name__)
+
+SUPPORTED_ESTIMATORS: tuple[str, ...] = (
+    "lPCA",
+    "TwoNN",
+    "MLE",
+    "CorrInt",
+    "MiND_ML",
+    "KNN",
+    "DANCo",
+    "FisherS",
+)
+
+
+def _load_estimator(name: str) -> type:
+    """Lazy-import a torchid global estimator class by name."""
+    try:
+        from torchid import estimators as _est
+    except ImportError as e:
+        raise ImportError(
+            "torchid is required for intrinsic-dimension metrics. "
+            "Install with `pip install 'torchgeo-bench[id]'` "
+            "(requires Python >=3.13)."
+        ) from e
+    if not hasattr(_est, name):
+        raise ValueError(
+            f"Unknown torchid estimator '{name}'. Supported: {', '.join(SUPPORTED_ESTIMATORS)}."
+        )
+    return getattr(_est, name)
+
+
+def _resolve_device(device: str | torch.device | None) -> torch.device:
+    """Resolve the requested device, falling back to CPU when CUDA unavailable."""
+    if device is None:
+        dev = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    else:
+        dev = torch.device(device)
+    if dev.type == "cuda" and not torch.cuda.is_available():
+        logger.warning("CUDA requested for intrinsic-dim but unavailable; using CPU.")
+        dev = torch.device("cpu")
+    return dev
+
+
+def _subsample(X: np.ndarray, max_samples: int | None, seed: int) -> np.ndarray:
+    """Deterministically subsample rows of X if it exceeds max_samples."""
+    if max_samples is None or X.shape[0] <= max_samples:
+        return X
+    rng = np.random.default_rng(seed)
+    idx = rng.choice(X.shape[0], size=max_samples, replace=False)
+    return X[idx]
+
+
+def compute_intrinsic_dim(
+    X: np.ndarray,
+    estimators: list[str],
+    device: str | torch.device | None = None,
+    max_samples: int | None = 10_000,
+    seed: int = 0,
+) -> dict[str, float]:
+    """Compute intrinsic dimension of X for each requested estimator.
+
+    Args:
+        X: Feature matrix of shape ``(n_samples, n_features)``.
+        estimators: Names of torchid global estimators (see
+            ``SUPPORTED_ESTIMATORS``).
+        device: ``"cuda"``, ``"cpu"``, a ``torch.device``, or ``None`` to
+            auto-select (CUDA when available, otherwise CPU).
+        max_samples: Cap row count via random subsampling for speed/memory.
+            ``None`` disables subsampling.
+        seed: RNG seed for subsampling determinism.
+
+    Returns:
+        Mapping ``{estimator_name: dimension}``. Failed estimators yield
+        ``float('nan')`` and a logged warning rather than aborting the run.
+    """
+    if X.ndim != 2:
+        raise ValueError(f"X must be 2D, got shape {X.shape}")
+    if not estimators:
+        return {}
+
+    dev = _resolve_device(device)
+    Xs = _subsample(X, max_samples, seed)
+    X_tensor = torch.from_numpy(np.ascontiguousarray(Xs)).to(dev, dtype=torch.float32)
+
+    out: dict[str, float] = {}
+    for name in estimators:
+        try:
+            cls = _load_estimator(name)
+            est: Any = cls().fit(X_tensor)
+            value = float(est.dimension_)
+        except Exception as e:  # noqa: BLE001 — log and continue per-estimator
+            logger.warning(f"[intrinsic-dim] {name} failed on X{tuple(X_tensor.shape)}: {e}")
+            value = float("nan")
+        out[name] = value
+    return out

--- a/src/torchgeo_bench/main.py
+++ b/src/torchgeo_bench/main.py
@@ -23,6 +23,7 @@ from torchgeo_bench.datasets import (
     get_datasets,
     list_datasets,
 )
+from torchgeo_bench.intrinsic_dim import compute_intrinsic_dim
 from torchgeo_bench.knn import KNNClassifier
 from torchgeo_bench.linear import LogisticRegression
 from torchgeo_bench.models.interface import BenchModel
@@ -410,6 +411,62 @@ def _build_seg_probe_and_solver(
     return probe, solver
 
 
+def evaluate_intrinsic_dim(
+    splits: dict[str, np.ndarray],
+    estimators: Sequence[str],
+    selected_splits: Sequence[str],
+    device: str | None,
+    max_samples: int | None,
+    seed: int,
+    common_meta: dict,
+    feature_dim: int,
+    n_counts: dict[str, int],
+    verbose: bool = False,
+) -> list[dict]:
+    """Compute intrinsic-dimension metrics over selected splits and return CSV rows.
+
+    Each (split, estimator) yields one row with ``method="intrinsic_dim"`` and
+    ``metric_name=f"id_{estimator}_{split}"``.
+    """
+    rows: list[dict] = []
+    for split_name in selected_splits:
+        if split_name not in splits:
+            logger.warning(f"[intrinsic-dim] unknown split '{split_name}', skipping")
+            continue
+        X = splits[split_name]
+        if verbose:
+            logger.info(
+                f"[intrinsic-dim] split={split_name} X{X.shape} "
+                f"estimators={list(estimators)} device={device}"
+            )
+        dims = compute_intrinsic_dim(
+            X,
+            estimators=list(estimators),
+            device=device,
+            max_samples=max_samples,
+            seed=seed,
+        )
+        for est_name, dim in dims.items():
+            rows.append(
+                EvaluationResult(
+                    **common_meta,
+                    method="intrinsic_dim",
+                    metric_name=f"id_{est_name}_{split_name}",
+                    metric_value=float(dim),
+                    ci_lower=0.0,
+                    ci_upper=0.0,
+                    feature_dim=feature_dim,
+                    best_c=None,
+                    best_lr=None,
+                    best_batch_size=None,
+                    n_train=n_counts.get("train", 0),
+                    n_val=n_counts.get("val", 0),
+                    n_test=n_counts.get("test", 0),
+                ).to_row()
+            )
+    return rows
+
+
 def evaluate_segmentation(
     model: torch.nn.Module,
     train_loader: DataLoader,
@@ -628,6 +685,7 @@ def main(cfg: DictConfig) -> None:
 
         seg_method = f"seg-{eval_cfg_merged.segmentation.head_type}"
         seg_key = (ds_name, seg_method, cfg.model._target_, cfg.model.name, *config_tuple)
+        id_key = (ds_name, "intrinsic_dim", cfg.model._target_, cfg.model.name, *config_tuple)
 
         try:
             result = get_datasets(
@@ -786,8 +844,11 @@ def main(cfg: DictConfig) -> None:
             skip_linear = (cfg.resume and linear_key in completed_runs) or getattr(
                 cfg.eval, "skip_linear", False
             )
+            id_cfg = getattr(cfg.eval, "intrinsic_dim", None)
+            id_enabled = bool(id_cfg and id_cfg.get("enabled", False))
+            skip_id = (not id_enabled) or (cfg.resume and id_key in completed_runs)
 
-            if skip_knn and skip_linear:
+            if skip_knn and skip_linear and skip_id:
                 continue
 
             x_train, y_train = embed_split(model, train_loader, device, verbose=cfg.verbose)
@@ -855,6 +916,25 @@ def main(cfg: DictConfig) -> None:
                         n_test=len(x_test),
                     ).to_row()
                 )
+
+            if not skip_id:
+                id_rows = evaluate_intrinsic_dim(
+                    splits={"train": x_train, "val": x_val, "test": x_test},
+                    estimators=list(id_cfg.estimators),
+                    selected_splits=list(id_cfg.splits),
+                    device=id_cfg.get("device", None) or cfg.device,
+                    max_samples=id_cfg.get("max_samples", None),
+                    seed=cfg.seed,
+                    common_meta=common_meta,
+                    feature_dim=feature_dim,
+                    n_counts={
+                        "train": len(x_train),
+                        "val": len(x_val),
+                        "test": len(x_test),
+                    },
+                    verbose=cfg.verbose,
+                )
+                all_rows.extend(id_rows)
 
         append_rows_atomic(output_path, all_rows)
         all_rows.clear()

--- a/tests/test_intrinsic_dim.py
+++ b/tests/test_intrinsic_dim.py
@@ -1,0 +1,225 @@
+"""Tests for intrinsic-dimension wrapper around torchid."""
+
+import logging
+from importlib.util import find_spec
+from unittest import mock
+
+import numpy as np
+import pytest
+import torch
+
+from torchgeo_bench.intrinsic_dim import (
+    SUPPORTED_ESTIMATORS,
+    _resolve_device,
+    _subsample,
+    compute_intrinsic_dim,
+)
+
+torchid_available = find_spec("torchid") is not None
+requires_torchid = pytest.mark.skipif(
+    not torchid_available, reason="torchid not installed (requires Python >=3.13)"
+)
+
+
+# ---- pure-python helpers (no torchid required) ---------------------------
+
+
+class TestResolveDevice:
+    def test_none_uses_cuda_when_available(self) -> None:
+        with mock.patch.object(torch.cuda, "is_available", return_value=True):
+            assert _resolve_device(None).type == "cuda"
+
+    def test_none_falls_back_to_cpu(self) -> None:
+        with mock.patch.object(torch.cuda, "is_available", return_value=False):
+            assert _resolve_device(None).type == "cpu"
+
+    def test_explicit_cpu(self) -> None:
+        assert _resolve_device("cpu").type == "cpu"
+
+    def test_cuda_unavailable_falls_back_to_cpu(self, caplog: pytest.LogCaptureFixture) -> None:
+        with (
+            mock.patch.object(torch.cuda, "is_available", return_value=False),
+            caplog.at_level(logging.WARNING),
+        ):
+            dev = _resolve_device("cuda")
+        assert dev.type == "cpu"
+        assert any("CUDA requested" in r.message for r in caplog.records)
+
+    def test_torch_device_passthrough(self) -> None:
+        d = torch.device("cpu")
+        assert _resolve_device(d) == d
+
+
+class TestSubsample:
+    def test_no_subsample_when_under_cap(self) -> None:
+        X = np.arange(20).reshape(10, 2)
+        out = _subsample(X, max_samples=100, seed=0)
+        assert out is X  # unchanged ref
+
+    def test_no_subsample_when_max_is_none(self) -> None:
+        X = np.arange(20).reshape(10, 2)
+        out = _subsample(X, max_samples=None, seed=0)
+        assert out is X
+
+    def test_subsamples_to_exact_size(self) -> None:
+        X = np.arange(200).reshape(100, 2)
+        out = _subsample(X, max_samples=10, seed=0)
+        assert out.shape == (10, 2)
+
+    def test_seed_determinism(self) -> None:
+        X = np.arange(200).reshape(100, 2)
+        a = _subsample(X, max_samples=10, seed=42)
+        b = _subsample(X, max_samples=10, seed=42)
+        np.testing.assert_array_equal(a, b)
+
+    def test_different_seeds_differ(self) -> None:
+        X = np.arange(2000).reshape(1000, 2)
+        a = _subsample(X, max_samples=10, seed=1)
+        b = _subsample(X, max_samples=10, seed=2)
+        assert not np.array_equal(a, b)
+
+
+# ---- compute_intrinsic_dim: argument validation (no torchid needed) ------
+
+
+class TestComputeBasic:
+    def test_rejects_non_2d(self) -> None:
+        with pytest.raises(ValueError, match="2D"):
+            compute_intrinsic_dim(np.zeros((10,)), estimators=["TwoNN"])
+
+    def test_empty_estimator_list_returns_empty(self) -> None:
+        out = compute_intrinsic_dim(np.zeros((10, 3)), estimators=[])
+        assert out == {}
+
+    def test_supported_estimators_constant(self) -> None:
+        for name in ("TwoNN", "MLE", "lPCA"):
+            assert name in SUPPORTED_ESTIMATORS
+
+
+# ---- error paths (mocked torchid) ----------------------------------------
+
+
+class TestErrorHandling:
+    def test_unknown_estimator_returns_nan(self, caplog: pytest.LogCaptureFixture) -> None:
+        X = np.random.RandomState(0).randn(100, 5).astype(np.float32)
+        with caplog.at_level(logging.WARNING):
+            out = compute_intrinsic_dim(
+                X, estimators=["NotARealEstimator"], device="cpu", max_samples=None
+            )
+        assert "NotARealEstimator" in out
+        assert np.isnan(out["NotARealEstimator"])
+        assert any("NotARealEstimator" in r.message for r in caplog.records)
+
+    def test_failing_estimator_continues_others(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A failing estimator should log+nan, not abort the loop."""
+
+        class _Boom:
+            def fit(self, X: torch.Tensor) -> "_Boom":  # noqa: ARG002
+                raise RuntimeError("boom")
+
+        class _Good:
+            def fit(self, X: torch.Tensor) -> "_Good":  # noqa: ARG002
+                self.dimension_ = 3.5
+                return self
+
+        fake_module = mock.MagicMock()
+        fake_module.Boom = _Boom
+        fake_module.Good = _Good
+        fake_pkg = mock.MagicMock()
+        fake_pkg.estimators = fake_module
+
+        X = np.random.RandomState(0).randn(50, 4).astype(np.float32)
+        with (
+            mock.patch.dict(
+                "sys.modules", {"torchid": fake_pkg, "torchid.estimators": fake_module}
+            ),
+            caplog.at_level(logging.WARNING),
+        ):
+            out = compute_intrinsic_dim(
+                X, estimators=["Boom", "Good"], device="cpu", max_samples=None
+            )
+        assert np.isnan(out["Boom"])
+        assert out["Good"] == pytest.approx(3.5)
+        assert any("Boom" in r.message for r in caplog.records)
+
+    def test_missing_torchid_raises_importerror(self) -> None:
+        from torchgeo_bench import intrinsic_dim as mod
+
+        X = np.random.RandomState(0).randn(50, 4).astype(np.float32)
+        # Force ImportError inside _load_estimator regardless of install state.
+        with mock.patch.object(mod, "_load_estimator", side_effect=ImportError("no torchid")):
+            out = compute_intrinsic_dim(X, estimators=["TwoNN"], device="cpu", max_samples=None)
+        # ImportError is caught per-estimator → nan, not raised.
+        assert np.isnan(out["TwoNN"])
+
+
+# ---- real torchid integration (requires py>=3.13) ------------------------
+
+
+@requires_torchid
+class TestRealTorchid:
+    @pytest.fixture(autouse=True)
+    def _seed(self) -> None:
+        torch.manual_seed(0)
+        np.random.seed(0)
+
+    @staticmethod
+    def _swiss_roll(n: int) -> np.ndarray:
+        """2D manifold embedded in 3D — true intrinsic dim = 2."""
+        rng = np.random.default_rng(0)
+        t = rng.uniform(1.5, 4.5, size=n) * np.pi
+        h = rng.uniform(0, 5, size=n)
+        X = np.stack([t * np.cos(t), h, t * np.sin(t)], axis=1)
+        return X.astype(np.float32)
+
+    @staticmethod
+    def _uniform_cube(n: int, d: int) -> np.ndarray:
+        rng = np.random.default_rng(0)
+        return rng.uniform(0, 1, size=(n, d)).astype(np.float32)
+
+    def test_swiss_roll_two_nn_close_to_2(self) -> None:
+        X = self._swiss_roll(2000)
+        out = compute_intrinsic_dim(X, estimators=["TwoNN"], device="cpu", max_samples=None)
+        assert abs(out["TwoNN"] - 2.0) < 0.5
+
+    def test_swiss_roll_mle_close_to_2(self) -> None:
+        X = self._swiss_roll(2000)
+        out = compute_intrinsic_dim(X, estimators=["MLE"], device="cpu", max_samples=None)
+        assert abs(out["MLE"] - 2.0) < 0.5
+
+    def test_uniform_cube_lpca_matches_ambient(self) -> None:
+        X = self._uniform_cube(1000, d=5)
+        out = compute_intrinsic_dim(X, estimators=["lPCA"], device="cpu", max_samples=None)
+        # lPCA on full-rank cube yields ambient dim
+        assert out["lPCA"] == pytest.approx(5.0, abs=0.1)
+
+    def test_multiple_estimators_returned(self) -> None:
+        X = self._uniform_cube(800, d=4)
+        out = compute_intrinsic_dim(
+            X, estimators=["TwoNN", "MLE", "lPCA"], device="cpu", max_samples=None
+        )
+        assert set(out) == {"TwoNN", "MLE", "lPCA"}
+        for v in out.values():
+            assert np.isfinite(v)
+
+    def test_subsampling_determinism(self) -> None:
+        X = self._uniform_cube(5000, d=3)
+        a = compute_intrinsic_dim(X, estimators=["TwoNN"], device="cpu", max_samples=500, seed=7)
+        b = compute_intrinsic_dim(X, estimators=["TwoNN"], device="cpu", max_samples=500, seed=7)
+        assert a == b
+
+    def test_cpu_explicit(self) -> None:
+        X = self._uniform_cube(500, d=3)
+        out = compute_intrinsic_dim(X, estimators=["TwoNN"], device="cpu", max_samples=None)
+        assert np.isfinite(out["TwoNN"])
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_cuda_path(self) -> None:
+        X = self._uniform_cube(500, d=3)
+        out = compute_intrinsic_dim(X, estimators=["TwoNN"], device="cuda", max_samples=None)
+        assert np.isfinite(out["TwoNN"])
+
+    def test_auto_device_runs(self) -> None:
+        X = self._uniform_cube(500, d=3)
+        out = compute_intrinsic_dim(X, estimators=["TwoNN"], device=None, max_samples=None)
+        assert np.isfinite(out["TwoNN"])


### PR DESCRIPTION
## Summary

Optionally compute intrinsic dimension (ID) on extracted feature embeddings during KNN / linear probing, gated by `eval.intrinsic_dim.enabled`. Goal: correlate ID across pretrained encoders × benchmark datasets vs. downstream performance.

Wraps [torchid](https://github.com/isaaccorley/torchid) global estimators (`lPCA`, `TwoNN`, `MLE`, `CorrInt`, `MiND_ML`, `KNN`, `DANCo`, `FisherS`). Added as optional extra `[id]` (`torchid>=0.3`, py>=3.13); no new required deps.

## Behavior

- Auto device (cuda if available, else cpu); explicit `cuda` falls back to cpu with a warning.
- Per-estimator failures → `nan` + logged warning, sweep continues.
- `max_samples` cap with seeded subsampling (`null` uses full split).
- Emits CSV rows with `method="intrinsic_dim"`, `metric_name="id_<estimator>_<split>"`. Resume-aware. Runs orthogonally to KNN/linear. Segmentation untouched.

```yaml
eval:
  intrinsic_dim:
    enabled: false
    estimators: [TwoNN, MLE, lPCA]
    splits: [train]                  # train | val | test
    max_samples: 10000               # null = full split
    device: null                     # null = auto
```

## Demo run — A100, full test-set ID (job 81194, 4m27s)

| dataset   | model                  | embed_dim | n_test | linear_acc | knn_acc | TwoNN | MLE | lPCA | CorrInt | FisherS |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| m-eurosat | RCF (random)           | 512 | 1000 | 0.763 | 0.611 | nan  | 2.8  | 3.0  | 2.7  | 1.7 |
| m-eurosat | resnet18 (IN1k)        | 512 | 1000 | 0.935 | 0.859 | 20.7 | 12.2 | 17.0 | 5.4  | 5.4 |
| m-eurosat | vit_small_patch16_224  | 384 | 1000 | 0.943 | 0.856 | 19.6 | 13.3 | 12.0 | 9.4  | 4.2 |
| m-pv4ger  | RCF (random)           | 512 | 999  | 0.912 | 0.902 | 3.7  | 3.3  | 2.0  | 2.8  | 1.8 |
| m-pv4ger  | resnet18 (IN1k)        | 512 | 999  | 0.965 | 0.947 | 15.4 | 12.3 | 13.0 | 6.9  | 4.6 |
| m-pv4ger  | vit_small_patch16_224  | 384 | 999  | 0.967 | 0.953 | 16.5 | 14.3 | 26.0 | 10.4 | 6.7 |

Pretrained encoders → much higher ID and better downstream accuracy than RCF. On m-pv4ger ViT-S has clearly higher ID than ResNet-18 at near-identical accuracy — suggestive that ID carries info accuracy alone doesn't.

## Test plan

- [x] `pytest tests/test_intrinsic_dim.py` — 23 passed, 1 CUDA-skipped.
- [x] `ruff check` / `ruff format --check` clean.
- [x] End-to-end SLURM run on A100 (results above).