### PR TITLE
Add experiments/ directory with shared GPU-queue runner

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,6 +69,7 @@ nitpick_ignore = [
     ("py:class", "RCF"),
     ("py:class", "EvaluationResult"),
     ("py:class", "BandSpec"),
+    ("py:class", "GeoBenchv2"),
     ("py:class", "Single-label"),
     ("py:class", "auto_resize /"),
     ("py:class", "FeatureFusionBlock"),

--- a/experiments/_runner.py
+++ b/experiments/_runner.py
@@ -67,11 +67,16 @@ def add_devices_argument(parser: argparse.ArgumentParser) -> None:
         "jobs are dispatched via a queue with one worker per device. "
         "Default: 0.",
     )
-    parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Print the job list without executing anything.",
-    )
+
+
+def default_output(script_file: str | Path) -> str:
+    """Derive the standard ``results/<basename>.csv`` path from a script's ``__file__``.
+
+    Drops the ``run_`` prefix and ``.py`` suffix. For example,
+    ``run_cls_token_experiment.py`` becomes ``results/cls_token_experiment.csv``.
+    """
+    stem = Path(script_file).stem.removeprefix("run_")
+    return f"results/{stem}.csv"
 
 
 def _run_one(job: Job, gpu: int, idx: int, total: int, output: str) -> _JobResult:
@@ -231,33 +236,12 @@ def run_jobs(
     return 0 if failed == 0 else 1
 
 
-def main_with_runner(
-    parser: argparse.ArgumentParser,
-    build_jobs,  # callable[[argparse.Namespace], tuple[list[Job], str]]
-) -> int:
-    """Convenience wrapper used by the non-custom scripts.
-
-    Args:
-        parser: Argparse parser with all script-specific args already added
-            (including the standard ``--devices`` / ``--dry-run`` registered
-            via :func:`add_devices_argument`).
-        build_jobs: Callable taking the parsed args and returning
-            ``(jobs, output_path)``.
-
-    Returns:
-        Process exit code (forward to ``sys.exit``).
-    """
-    args = parser.parse_args()
-    jobs, output = build_jobs(args)
-    return run_jobs(jobs, args.devices, output=output, dry_run=args.dry_run)
-
-
 __all__ = [
+    "REPO_ROOT",
     "Job",
     "add_devices_argument",
-    "main_with_runner",
+    "default_output",
     "run_jobs",
-    "REPO_ROOT",
 ]
 
 

--- a/experiments/_runner.py
+++ b/experiments/_runner.py
@@ -1,0 +1,266 @@
+"""Shared GPU queue dispatcher for non-custom experiment runners.
+
+Each non-custom experiment script builds a list of :class:`Job` instances
+(one per ``torchgeo-bench run …`` invocation it wants to make) and calls
+:func:`run_jobs` to execute them. With a single device the jobs run
+sequentially; with multiple devices they fan out across one worker thread
+per device, each pulling jobs from a shared queue.
+
+This module is invoked as a sibling import from scripts in the same
+directory (``from _runner import …``) — Python prepends the script's
+directory to ``sys.path`` so no path setup is required.
+"""
+
+import argparse
+import logging
+import subprocess
+import sys
+import threading
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from queue import Empty, Queue
+
+logger = logging.getLogger(__name__)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+@dataclass
+class Job:
+    """One ``torchgeo-bench run`` invocation.
+
+    Attributes:
+        label: Short human-readable identifier for log lines.
+        overrides: Hydra-style overrides forwarded to ``torchgeo-bench run``
+            (e.g. ``["model=timm/resnet18", "dataset.names=[m-eurosat]"]``).
+            ``device`` and ``output`` are appended automatically by the
+            runner — do not include them here.
+    """
+
+    label: str
+    overrides: list[str] = field(default_factory=list)
+
+
+@dataclass
+class _JobResult:
+    label: str
+    gpu: int
+    elapsed: float
+    returncode: int
+    stderr_tail: str = ""
+
+
+def add_devices_argument(parser: argparse.ArgumentParser) -> None:
+    """Register a ``--devices`` flag that takes one or more GPU indices.
+
+    Defaults to ``[0]`` (single GPU, sequential execution).
+    """
+    parser.add_argument(
+        "--devices",
+        nargs="+",
+        type=int,
+        default=[0],
+        metavar="GPU",
+        help="One or more CUDA device indices (e.g. --devices 0 1 2). "
+        "With a single device jobs run sequentially; with multiple devices "
+        "jobs are dispatched via a queue with one worker per device. "
+        "Default: 0.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the job list without executing anything.",
+    )
+
+
+def _run_one(job: Job, gpu: int, idx: int, total: int, output: str) -> _JobResult:
+    """Shell out to ``torchgeo-bench run …`` for a single job."""
+    cmd = [
+        "torchgeo-bench",
+        "run",
+        *job.overrides,
+        f"device=cuda:{gpu}",
+        f"output={output}",
+        "resume=true",
+    ]
+
+    print(f"[{idx}/{total}] START  {job.label} on cuda:{gpu}", flush=True)
+    start = time.time()
+    proc = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT),
+    )
+    elapsed = time.time() - start
+
+    if proc.returncode == 0:
+        print(
+            f"[{idx}/{total}] DONE   {job.label} ({elapsed:.0f}s) on cuda:{gpu}",
+            flush=True,
+        )
+        return _JobResult(job.label, gpu, elapsed, 0)
+
+    stderr_tail = "\n".join(proc.stderr.strip().splitlines()[-5:])
+    print(
+        f"[{idx}/{total}] FAILED {job.label} ({elapsed:.0f}s) on cuda:{gpu}\n  {stderr_tail}",
+        flush=True,
+    )
+    return _JobResult(job.label, gpu, elapsed, proc.returncode, stderr_tail)
+
+
+def _worker(
+    gpu: int,
+    job_queue: "Queue[tuple[int, Job]]",
+    total: int,
+    output: str,
+    results: list[_JobResult],
+    lock: threading.Lock,
+) -> None:
+    """Pull jobs off the queue and run them on the assigned GPU until empty."""
+    while True:
+        try:
+            idx, job = job_queue.get_nowait()
+        except Empty:
+            return
+        try:
+            result = _run_one(job, gpu, idx, total, output)
+            with lock:
+                results.append(result)
+        finally:
+            job_queue.task_done()
+
+
+def run_jobs(
+    jobs: list[Job],
+    devices: list[int],
+    *,
+    output: str,
+    dry_run: bool = False,
+) -> int:
+    """Dispatch ``jobs`` across ``devices`` and return a process exit code.
+
+    Args:
+        jobs: List of :class:`Job` instances to execute.
+        devices: GPU indices to dispatch across. With one device jobs run
+            sequentially; with multiple devices each device gets a worker
+            thread that pulls from a shared queue.
+        output: CSV path passed as ``output=<path>`` to every invocation.
+        dry_run: If ``True``, print the planned jobs and return 0 without
+            running anything.
+
+    Returns:
+        ``0`` if every job succeeded, ``1`` otherwise (or if ``jobs`` is
+        empty, ``0`` with a warning log).
+    """
+    total = len(jobs)
+    print("=" * 60)
+    print(f"Jobs:    {total}")
+    print(f"Devices: {devices} ({len(devices)} worker{'s' if len(devices) != 1 else ''})")
+    print(f"Output:  {output}")
+    print("Resume:  true")
+    print("=" * 60)
+
+    if total == 0:
+        logger.warning("No jobs to run.")
+        return 0
+
+    if dry_run:
+        for i, job in enumerate(jobs, start=1):
+            gpu = devices[(i - 1) % len(devices)]
+            print(f"  [{i}/{total}] {job.label} -> cuda:{gpu}")
+            print(
+                f"      torchgeo-bench run {' '.join(job.overrides)} "
+                f"device=cuda:{gpu} output={output} resume=true"
+            )
+        print(f"\n[DRY RUN] {total} job(s) across {len(devices)} device(s)")
+        return 0
+
+    job_queue: Queue[tuple[int, Job]] = Queue()
+    for i, job in enumerate(jobs, start=1):
+        job_queue.put((i, job))
+
+    results: list[_JobResult] = []
+    lock = threading.Lock()
+
+    start_time = time.time()
+    threads: list[threading.Thread] = []
+    for gpu in devices:
+        t = threading.Thread(
+            target=_worker,
+            args=(gpu, job_queue, total, output, results, lock),
+            daemon=True,
+        )
+        t.start()
+        threads.append(t)
+
+    for t in threads:
+        t.join()
+
+    elapsed = time.time() - start_time
+    passed = sum(1 for r in results if r.returncode == 0)
+    failed = total - passed
+
+    print()
+    print("=" * 60)
+    print("Run Complete")
+    print("=" * 60)
+    print(f"Total:    {total}")
+    print(f"Passed:   {passed}")
+    print(f"Failed:   {failed}")
+    print(f"Time:     {elapsed:.0f}s ({elapsed / 60:.1f}m)")
+    print(f"Output:   {output}")
+
+    if failed:
+        print("\nFailed jobs:")
+        for r in results:
+            if r.returncode != 0:
+                print(f"  {r.label} ({r.elapsed:.0f}s, cuda:{r.gpu})")
+
+    if passed:
+        times = sorted(
+            [(r.label, r.elapsed) for r in results if r.returncode == 0],
+            key=lambda x: x[1],
+        )
+        avg = sum(t for _, t in times) / len(times)
+        print(f"\nAvg time per job: {avg:.0f}s ({avg / 60:.1f}m)")
+        print(f"Fastest: {times[0][0]} ({times[0][1]:.0f}s)")
+        print(f"Slowest: {times[-1][0]} ({times[-1][1]:.0f}s)")
+
+    return 0 if failed == 0 else 1
+
+
+def main_with_runner(
+    parser: argparse.ArgumentParser,
+    build_jobs,  # callable[[argparse.Namespace], tuple[list[Job], str]]
+) -> int:
+    """Convenience wrapper used by the non-custom scripts.
+
+    Args:
+        parser: Argparse parser with all script-specific args already added
+            (including the standard ``--devices`` / ``--dry-run`` registered
+            via :func:`add_devices_argument`).
+        build_jobs: Callable taking the parsed args and returning
+            ``(jobs, output_path)``.
+
+    Returns:
+        Process exit code (forward to ``sys.exit``).
+    """
+    args = parser.parse_args()
+    jobs, output = build_jobs(args)
+    return run_jobs(jobs, args.devices, output=output, dry_run=args.dry_run)
+
+
+__all__ = [
+    "Job",
+    "add_devices_argument",
+    "main_with_runner",
+    "run_jobs",
+    "REPO_ROOT",
+]
+
+
+if __name__ == "__main__":  # pragma: no cover
+    print("This module is a helper; import from a script in experiments/.", file=sys.stderr)
+    sys.exit(2)

--- a/experiments/run_c_sweep_experiment.py
+++ b/experiments/run_c_sweep_experiment.py
@@ -6,9 +6,8 @@ regularization strength ``C`` of :class:`torchgeo_bench.linear.LogisticRegressio
 and records train/val/test accuracy for each ``C`` value.
 
 Usage:
-    python experiments/run_c_sweep_experiment.py --dataset m-eurosat
-    python experiments/run_c_sweep_experiment.py --dataset m-so2sat --device cuda:3
-    python experiments/run_c_sweep_experiment.py --dataset m-eurosat,m-forestnet
+    python experiments/run_c_sweep_experiment.py
+    python experiments/run_c_sweep_experiment.py --device cuda:3
 """
 
 import argparse
@@ -27,6 +26,9 @@ from torchgeo_bench.utils import extract_features
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
+
+DATASETS = ["m-bigearthnet", "m-brick-kiln", "m-eurosat", "m-forestnet", "m-pv4ger", "m-so2sat"]
+IMAGE_SIZE = 224
 
 MODEL_CONFIGS = {
     "resnet18": {
@@ -81,17 +83,6 @@ def instantiate_model(model_cfg: dict, num_channels: int) -> torch.nn.Module:
     kwargs = {k: v for k, v in model_cfg.items() if k not in ("_target_", "name")}
     kwargs["num_channels"] = num_channels
     return cls(**kwargs)
-
-
-def parse_dataset_names(raw_names: list[str]) -> list[str]:
-    """Parse comma- and space-separated dataset name lists."""
-    out: list[str] = []
-    for raw in raw_names:
-        for name in raw.split(","):
-            clean = name.strip()
-            if clean and clean not in out:
-                out.append(clean)
-    return out
 
 
 def run_c_sweep(
@@ -171,7 +162,7 @@ def run_dataset_sweep(dataset_name: str, args: argparse.Namespace) -> str:
         partition_name="default",
         batch_size=64,
         return_val=True,
-        image_size=args.image_size,
+        image_size=IMAGE_SIZE,
         interpolation="bilinear",
     )
     num_channels = train_dataset[0]["image"].shape[0]
@@ -226,14 +217,6 @@ def run_dataset_sweep(dataset_name: str, args: argparse.Namespace) -> str:
 def main() -> None:
     """Entry point."""
     parser = argparse.ArgumentParser(description="C-sweep for linear probing")
-    parser.add_argument(
-        "--dataset",
-        "--datasets",
-        dest="datasets",
-        nargs="+",
-        default=["m-eurosat"],
-        help="Dataset name(s), space- or comma-separated (default: m-eurosat).",
-    )
     parser.add_argument("--device", default="cuda:0", help="PyTorch device.")
     parser.add_argument(
         "--output-dir",
@@ -241,19 +224,15 @@ def main() -> None:
         help="Output directory.",
     )
     parser.add_argument("--seed", type=int, default=0)
-    parser.add_argument("--image-size", type=int, default=224)
     args = parser.parse_args()
 
     os.makedirs(args.output_dir, exist_ok=True)
-    dataset_names = parse_dataset_names(args.datasets)
-    if not dataset_names:
-        raise ValueError("Provide at least one dataset name via --dataset.")
 
     torch.manual_seed(args.seed)
     np.random.seed(args.seed)
-    logger.info("Running C sweep for datasets: %s", ", ".join(dataset_names))
+    logger.info("Running C sweep for datasets: %s", ", ".join(DATASETS))
 
-    output_paths = [run_dataset_sweep(name, args) for name in dataset_names]
+    output_paths = [run_dataset_sweep(name, args) for name in DATASETS]
     logger.info("Finished C sweeps: %s", ", ".join(output_paths))
 
 

--- a/experiments/run_c_sweep_experiment.py
+++ b/experiments/run_c_sweep_experiment.py
@@ -7,16 +7,18 @@ and records train/val/test accuracy for each ``C`` value.
 
 Usage:
     python experiments/run_c_sweep_experiment.py
-    python experiments/run_c_sweep_experiment.py --device cuda:3
+    python experiments/run_c_sweep_experiment.py --devices 3
 """
 
 import argparse
 import logging
 import os
+import sys
 
 import numpy as np
 import pandas as pd
 import torch
+from _runner import add_devices_argument, default_output
 from sklearn.metrics import accuracy_score
 from tqdm import tqdm
 
@@ -27,8 +29,11 @@ from torchgeo_bench.utils import extract_features
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
 
-DATASETS = ["m-bigearthnet", "m-brick-kiln", "m-eurosat", "m-forestnet", "m-pv4ger", "m-so2sat"]
+OUTPUT = default_output(__file__)
+SEED = 0
 IMAGE_SIZE = 224
+
+DATASETS = ["m-bigearthnet", "m-brick-kiln", "m-eurosat", "m-forestnet", "m-pv4ger", "m-so2sat"]
 
 MODEL_CONFIGS = {
     "resnet18": {
@@ -94,9 +99,7 @@ def run_c_sweep(
     y_val: np.ndarray,
     x_test: np.ndarray,
     y_test: np.ndarray,
-    c_values: np.ndarray,
-    device: str,
-    seed: int = 0,
+    device: torch.device,
 ) -> list[dict]:
     """Train ``LogisticRegression`` for each ``C`` and return per-C metrics."""
     rows = []
@@ -105,12 +108,12 @@ def run_c_sweep(
     x_val_t = torch.from_numpy(x_val)
     x_test_t = torch.from_numpy(x_test)
 
-    for c in tqdm(c_values, desc=f"  C-sweep ({model_name})", leave=False):
+    for c in tqdm(C_VALUES, desc=f"  C-sweep ({model_name})", leave=False):
         clf = LogisticRegression(
             C=float(c),
             max_iter=2000,
             tol=1e-6,
-            random_state=seed,
+            random_state=SEED,
             device=device,
         )
         clf.fit(x_train_t, y_train_t)
@@ -138,22 +141,15 @@ def run_c_sweep(
     return rows
 
 
-def run_dataset_sweep(dataset_name: str, args: argparse.Namespace) -> str:
-    """Run the C sweep for one dataset and write its CSV."""
-    output_path = os.path.join(args.output_dir, f"c_sweep_{dataset_name}.csv")
-    device = torch.device(args.device)
-
-    completed_models: set[str] = set()
-    all_rows: list[dict] = []
-    if os.path.exists(output_path):
-        existing_df = pd.read_csv(output_path)
-        all_rows = existing_df.to_dict("records")
-        completed_models = set(existing_df["model"].unique())
+def run_dataset_sweep(dataset_name: str, device: torch.device, all_rows: list[dict]) -> list[dict]:
+    """Run the C sweep for one dataset, appending rows in-place to ``all_rows``."""
+    completed_models = {r["model"] for r in all_rows if r.get("dataset") == dataset_name}
+    if completed_models:
         logger.info(
-            "Resume: found %d completed models in %s: %s",
+            "Resume: %d models already computed for %s: %s",
             len(completed_models),
-            output_path,
-            completed_models,
+            dataset_name,
+            sorted(completed_models),
         )
 
     logger.info("Loading %s dataset...", dataset_name)
@@ -200,41 +196,45 @@ def run_dataset_sweep(dataset_name: str, args: argparse.Namespace) -> str:
             y_val,
             x_test,
             y_test,
-            C_VALUES,
-            args.device,
-            args.seed,
+            device,
         )
         all_rows.extend(rows)
+        pd.DataFrame(all_rows).to_csv(OUTPUT, index=False)
+        logger.info("  Saved %d rows to %s", len(all_rows), OUTPUT)
 
-        df = pd.DataFrame(all_rows)
-        df.to_csv(output_path, index=False)
-        logger.info("  Saved %d rows to %s", len(all_rows), output_path)
-
-    logger.info("Done. Final results for %s: %s", dataset_name, output_path)
-    return output_path
+    return all_rows
 
 
-def main() -> None:
+def main() -> int:
     """Entry point."""
     parser = argparse.ArgumentParser(description="C-sweep for linear probing")
-    parser.add_argument("--device", default="cuda:0", help="PyTorch device.")
-    parser.add_argument(
-        "--output-dir",
-        default="results/c_sweep_results",
-        help="Output directory.",
-    )
-    parser.add_argument("--seed", type=int, default=0)
+    add_devices_argument(parser)
     args = parser.parse_args()
 
-    os.makedirs(args.output_dir, exist_ok=True)
+    if len(args.devices) > 1:
+        logger.warning(
+            "This script runs in-process; using only the first of --devices=%s.",
+            args.devices,
+        )
+    device = torch.device(f"cuda:{args.devices[0]}")
 
-    torch.manual_seed(args.seed)
-    np.random.seed(args.seed)
-    logger.info("Running C sweep for datasets: %s", ", ".join(DATASETS))
+    os.makedirs(os.path.dirname(OUTPUT) or ".", exist_ok=True)
 
-    output_paths = [run_dataset_sweep(name, args) for name in DATASETS]
-    logger.info("Finished C sweeps: %s", ", ".join(output_paths))
+    all_rows: list[dict] = []
+    if os.path.exists(OUTPUT):
+        all_rows = pd.read_csv(OUTPUT).to_dict("records")
+        logger.info("Resume: loaded %d existing rows from %s", len(all_rows), OUTPUT)
+
+    torch.manual_seed(SEED)
+    np.random.seed(SEED)
+    logger.info("Running C sweep on %d datasets -> %s", len(DATASETS), OUTPUT)
+
+    for dataset_name in DATASETS:
+        all_rows = run_dataset_sweep(dataset_name, device, all_rows)
+
+    logger.info("Done. Final results: %s", OUTPUT)
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/experiments/run_c_sweep_experiment.py
+++ b/experiments/run_c_sweep_experiment.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python
+"""C-sweep analysis for linear probing.
+
+Extracts features once per (model, dataset), then sweeps the L2
+regularization strength ``C`` of :class:`torchgeo_bench.linear.LogisticRegression`
+and records train/val/test accuracy for each ``C`` value.
+
+Usage:
+    python experiments/run_c_sweep_experiment.py --dataset m-eurosat
+    python experiments/run_c_sweep_experiment.py --dataset m-so2sat --device cuda:3
+    python experiments/run_c_sweep_experiment.py --dataset m-eurosat,m-forestnet
+"""
+
+import argparse
+import logging
+import os
+
+import numpy as np
+import pandas as pd
+import torch
+from sklearn.metrics import accuracy_score
+from tqdm import tqdm
+
+from torchgeo_bench.datasets import get_datasets
+from torchgeo_bench.linear import LogisticRegression
+from torchgeo_bench.utils import extract_features
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+MODEL_CONFIGS = {
+    "resnet18": {
+        "_target_": "torchgeo_bench.models.timm.TimmPatchBenchModel",
+        "model_name": "resnet18",
+        "pretrained": True,
+        "global_pool": "avg",
+        "name": "resnet18",
+    },
+    "resnet50": {
+        "_target_": "torchgeo_bench.models.timm.TimmPatchBenchModel",
+        "model_name": "resnet50",
+        "pretrained": True,
+        "global_pool": "avg",
+        "name": "resnet50",
+    },
+    "convnext_large_dinov3": {
+        "_target_": "torchgeo_bench.models.timm.TimmPatchBenchModel",
+        "model_name": "convnext_large.dinov3_lvd1689m",
+        "pretrained": True,
+        "global_pool": "avg",
+        "name": "convnext_large_dinov3",
+    },
+    "dinov3": {
+        "_target_": "torchgeo_bench.models.timm.TimmPatchBenchModel",
+        "model_name": "vit_large_patch16_dinov3.lvd1689m",
+        "pretrained": True,
+        "global_pool": "avg",
+        "use_cls_token": False,
+        "name": "vit_large_patch16_dinov3",
+    },
+    "dinov3sat": {
+        "_target_": "torchgeo_bench.models.timm.TimmPatchBenchModel",
+        "model_name": "vit_large_patch16_dinov3.sat493m",
+        "pretrained": True,
+        "global_pool": "avg",
+        "use_cls_token": False,
+        "name": "vit_large_patch16_dinov3sat",
+    },
+}
+
+C_VALUES = np.sort(np.unique(np.append(np.logspace(-7, 2, 40), 1.0)))
+
+
+def instantiate_model(model_cfg: dict, num_channels: int) -> torch.nn.Module:
+    """Instantiate a model from its ``MODEL_CONFIGS`` entry."""
+    target = model_cfg["_target_"]
+    module_name, class_name = target.rsplit(".", 1)
+    module = __import__(module_name, fromlist=[class_name])
+    cls = getattr(module, class_name)
+
+    kwargs = {k: v for k, v in model_cfg.items() if k not in ("_target_", "name")}
+    kwargs["num_channels"] = num_channels
+    return cls(**kwargs)
+
+
+def parse_dataset_names(raw_names: list[str]) -> list[str]:
+    """Parse comma- and space-separated dataset name lists."""
+    out: list[str] = []
+    for raw in raw_names:
+        for name in raw.split(","):
+            clean = name.strip()
+            if clean and clean not in out:
+                out.append(clean)
+    return out
+
+
+def run_c_sweep(
+    model_name: str,
+    dataset_name: str,
+    x_train: np.ndarray,
+    y_train: np.ndarray,
+    x_val: np.ndarray,
+    y_val: np.ndarray,
+    x_test: np.ndarray,
+    y_test: np.ndarray,
+    c_values: np.ndarray,
+    device: str,
+    seed: int = 0,
+) -> list[dict]:
+    """Train ``LogisticRegression`` for each ``C`` and return per-C metrics."""
+    rows = []
+    x_train_t = torch.from_numpy(x_train)
+    y_train_t = torch.from_numpy(y_train).long()
+    x_val_t = torch.from_numpy(x_val)
+    x_test_t = torch.from_numpy(x_test)
+
+    for c in tqdm(c_values, desc=f"  C-sweep ({model_name})", leave=False):
+        clf = LogisticRegression(
+            C=float(c),
+            max_iter=2000,
+            tol=1e-6,
+            random_state=seed,
+            device=device,
+        )
+        clf.fit(x_train_t, y_train_t)
+
+        train_preds = clf.predict(x_train_t)
+        val_preds = clf.predict(x_val_t)
+        test_preds = clf.predict(x_test_t)
+
+        rows.append(
+            {
+                "dataset": dataset_name,
+                "model": model_name,
+                "C": float(c),
+                "log10_C": float(np.log10(c)),
+                "train_acc": float(accuracy_score(y_train, train_preds)),
+                "val_acc": float(accuracy_score(y_val, val_preds)),
+                "test_acc": float(accuracy_score(y_test, test_preds)),
+                "feature_dim": int(x_train.shape[1]),
+                "n_train": int(len(x_train)),
+                "n_val": int(len(x_val)),
+                "n_test": int(len(x_test)),
+            }
+        )
+
+    return rows
+
+
+def run_dataset_sweep(dataset_name: str, args: argparse.Namespace) -> str:
+    """Run the C sweep for one dataset and write its CSV."""
+    output_path = os.path.join(args.output_dir, f"c_sweep_{dataset_name}.csv")
+    device = torch.device(args.device)
+
+    completed_models: set[str] = set()
+    all_rows: list[dict] = []
+    if os.path.exists(output_path):
+        existing_df = pd.read_csv(output_path)
+        all_rows = existing_df.to_dict("records")
+        completed_models = set(existing_df["model"].unique())
+        logger.info(
+            "Resume: found %d completed models in %s: %s",
+            len(completed_models),
+            output_path,
+            completed_models,
+        )
+
+    logger.info("Loading %s dataset...", dataset_name)
+    train_dataset, train_loader, val_loader, test_loader = get_datasets(
+        dataset_name=dataset_name,
+        partition_name="default",
+        batch_size=64,
+        return_val=True,
+        image_size=args.image_size,
+        interpolation="bilinear",
+    )
+    num_channels = train_dataset[0]["image"].shape[0]
+
+    for model_name, model_cfg in MODEL_CONFIGS.items():
+        if model_name in completed_models:
+            logger.info("=== %s/%s === skipping, already computed", dataset_name, model_name)
+            continue
+
+        logger.info("=== %s/%s ===", dataset_name, model_name)
+        logger.info("  Loading model %s...", model_name)
+        model = instantiate_model(model_cfg, num_channels)
+        model.to(device).eval()
+
+        logger.info("  Extracting features...")
+        x_train, y_train = extract_features(model, train_loader, device, verbose=False)
+        x_val, y_val = extract_features(model, val_loader, device, verbose=False)
+        x_test, y_test = extract_features(model, test_loader, device, verbose=False)
+        logger.info(
+            "  Features: train=%s, val=%s, test=%s",
+            x_train.shape,
+            x_val.shape,
+            x_test.shape,
+        )
+
+        del model
+        torch.cuda.empty_cache()
+
+        rows = run_c_sweep(
+            model_name,
+            dataset_name,
+            x_train,
+            y_train,
+            x_val,
+            y_val,
+            x_test,
+            y_test,
+            C_VALUES,
+            args.device,
+            args.seed,
+        )
+        all_rows.extend(rows)
+
+        df = pd.DataFrame(all_rows)
+        df.to_csv(output_path, index=False)
+        logger.info("  Saved %d rows to %s", len(all_rows), output_path)
+
+    logger.info("Done. Final results for %s: %s", dataset_name, output_path)
+    return output_path
+
+
+def main() -> None:
+    """Entry point."""
+    parser = argparse.ArgumentParser(description="C-sweep for linear probing")
+    parser.add_argument(
+        "--dataset",
+        "--datasets",
+        dest="datasets",
+        nargs="+",
+        default=["m-eurosat"],
+        help="Dataset name(s), space- or comma-separated (default: m-eurosat).",
+    )
+    parser.add_argument("--device", default="cuda:0", help="PyTorch device.")
+    parser.add_argument(
+        "--output-dir",
+        default="results/c_sweep_results",
+        help="Output directory.",
+    )
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--image-size", type=int, default=224)
+    args = parser.parse_args()
+
+    os.makedirs(args.output_dir, exist_ok=True)
+    dataset_names = parse_dataset_names(args.datasets)
+    if not dataset_names:
+        raise ValueError("Provide at least one dataset name via --dataset.")
+
+    torch.manual_seed(args.seed)
+    np.random.seed(args.seed)
+    logger.info("Running C sweep for datasets: %s", ", ".join(dataset_names))
+
+    output_paths = [run_dataset_sweep(name, args) for name in dataset_names]
+    logger.info("Finished C sweeps: %s", ", ".join(output_paths))
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/run_cls_token_experiment.py
+++ b/experiments/run_cls_token_experiment.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
 """CLS-token vs spatial-average sweep for ViT/DeiT models.
 
-Ported from ``scripts/run_cls_token_experiment.sh``. Each ViT/DeiT model is
-evaluated twice per dataset — once with ``model.use_cls_token=false``
-(spatial average) and once with ``model.use_cls_token=true`` (CLS token).
-Swin models are excluded (no CLS token). Results land in
-``results/cls_token_experiment.csv``.
+Each ViT/DeiT model is evaluated twice per dataset — once with
+``model.use_cls_token=false`` (spatial average) and once with
+``model.use_cls_token=true`` (CLS token). Swin models are excluded (no CLS
+token). Results land in ``results/cls_token_experiment.csv``.
 
 Usage:
     python experiments/run_cls_token_experiment.py

--- a/experiments/run_cls_token_experiment.py
+++ b/experiments/run_cls_token_experiment.py
@@ -4,20 +4,19 @@
 Each ViT/DeiT model is evaluated twice per dataset — once with
 ``model.use_cls_token=false`` (spatial average) and once with
 ``model.use_cls_token=true`` (CLS token). Swin models are excluded (no CLS
-token). Results land in ``results/cls_token_experiment.csv``.
+token).
 
 Usage:
     python experiments/run_cls_token_experiment.py
     python experiments/run_cls_token_experiment.py --devices 0 1 2
-    python experiments/run_cls_token_experiment.py --dry-run
 """
 
 import argparse
 import sys
 
-from _runner import Job, add_devices_argument, run_jobs
+from _runner import Job, add_devices_argument, default_output, run_jobs
 
-OUTPUT = "results/cls_token_experiment.csv"
+OUTPUT = default_output(__file__)
 
 DATASETS = ["m-bigearthnet", "m-brick-kiln", "m-eurosat", "m-forestnet", "m-pv4ger", "m-so2sat"]
 
@@ -58,9 +57,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     add_devices_argument(parser)
     args = parser.parse_args()
-
-    jobs = build_jobs()
-    return run_jobs(jobs, args.devices, output=OUTPUT, dry_run=args.dry_run)
+    return run_jobs(build_jobs(), args.devices, output=OUTPUT)
 
 
 if __name__ == "__main__":

--- a/experiments/run_cls_token_experiment.py
+++ b/experiments/run_cls_token_experiment.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+"""CLS-token vs spatial-average sweep for ViT/DeiT models.
+
+Ported from ``scripts/run_cls_token_experiment.sh``. Each ViT/DeiT model is
+evaluated twice per dataset — once with ``model.use_cls_token=false``
+(spatial average) and once with ``model.use_cls_token=true`` (CLS token).
+Swin models are excluded (no CLS token). Results land in
+``results/cls_token_experiment.csv``.
+
+Usage:
+    python experiments/run_cls_token_experiment.py
+    python experiments/run_cls_token_experiment.py --devices 0 1 2
+    python experiments/run_cls_token_experiment.py --dry-run
+"""
+
+import argparse
+import sys
+
+from _runner import Job, add_devices_argument, run_jobs
+
+OUTPUT = "results/cls_token_experiment.csv"
+
+DATASETS = ["m-eurosat", "m-so2sat"]
+
+MODELS = [
+    "timm/vit/vit_tiny_patch16_224",
+    "timm/vit/vit_small_patch16_224",
+    "timm/vit/vit_base_patch16_224",
+    "timm/vit/vit_large_patch16_224",
+    "timm/vit/vit_large_patch16_dinov3",
+    "timm/vit/vit_large_patch16_dinov3sat",
+    "timm/vit/deit_tiny_patch16_224",
+    "timm/vit/deit_small_patch16_224",
+    "timm/vit/deit_base_patch16_224",
+]
+
+
+def build_jobs() -> list[Job]:
+    """Build dataset × model × use_cls_token jobs."""
+    jobs: list[Job] = []
+    for dataset in DATASETS:
+        for model in MODELS:
+            short = model.removeprefix("timm/vit/")
+            for use_cls in (False, True):
+                tag = "cls" if use_cls else "avg"
+                overrides = [
+                    f"model={model}",
+                    f"model.use_cls_token={'true' if use_cls else 'false'}",
+                    f"model.name={short}_{tag}",
+                    f"dataset.names=[{dataset}]",
+                    "dataset.partition=default",
+                ]
+                jobs.append(Job(label=f"{dataset} {short} {tag}", overrides=overrides))
+    return jobs
+
+
+def main() -> int:
+    """Entry point."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    add_devices_argument(parser)
+    args = parser.parse_args()
+
+    jobs = build_jobs()
+    return run_jobs(jobs, args.devices, output=OUTPUT, dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/experiments/run_cls_token_experiment.py
+++ b/experiments/run_cls_token_experiment.py
@@ -19,7 +19,7 @@ from _runner import Job, add_devices_argument, run_jobs
 
 OUTPUT = "results/cls_token_experiment.csv"
 
-DATASETS = ["m-eurosat", "m-so2sat"]
+DATASETS = ["m-bigearthnet", "m-brick-kiln", "m-eurosat", "m-forestnet", "m-pv4ger", "m-so2sat"]
 
 MODELS = [
     "timm/vit/vit_tiny_patch16_224",

--- a/experiments/run_effect_of_lbfgs_vs_adam.py
+++ b/experiments/run_effect_of_lbfgs_vs_adam.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python
+"""Compare LBFGS vs Adam for linear probing — speed and final accuracy.
+
+Both branches use :class:`torchgeo_bench.linear.LogisticRegression` (the
+same class the main pipeline uses for its linear probe), so the comparison
+is apples-to-apples on regularization and the training objective::
+
+    loss = (1/n) * CrossEntropy + (1/n) * 0.5/C * ||W||^2
+
+For each (model, dataset, fit_config) we record wall-clock fit time,
+number of optimizer iterations, and train/val/test accuracy. With these
+columns you can plot e.g. accuracy-vs-time Pareto curves to see which
+solver hits a target accuracy fastest.
+
+Configs swept (per (model, dataset)):
+    - LBFGS: one fit per ``C``, ``lr=1.0`` (LBFGS uses strong-Wolfe line
+      search, so ``lr`` is mostly a starting step; we keep the default).
+    - Adam:  one fit per (``C``, ``lr``) on a small LR grid.
+
+Usage:
+    python experiments/run_effect_of_lbfgs_vs_adam.py
+    python experiments/run_effect_of_lbfgs_vs_adam.py --dataset m-eurosat m-forestnet
+    python experiments/run_effect_of_lbfgs_vs_adam.py --device cuda:3
+"""
+
+import argparse
+import logging
+import os
+import time
+
+import numpy as np
+import pandas as pd
+import torch
+from sklearn.metrics import accuracy_score
+from tqdm import tqdm
+
+from torchgeo_bench.datasets import get_datasets
+from torchgeo_bench.linear import LogisticRegression
+from torchgeo_bench.utils import extract_features
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+MODEL_CONFIGS = {
+    "resnet18": {
+        "_target_": "torchgeo_bench.models.timm.TimmPatchBenchModel",
+        "model_name": "resnet18",
+        "pretrained": True,
+        "global_pool": "avg",
+        "name": "resnet18",
+    },
+    "dinov3sat": {
+        "_target_": "torchgeo_bench.models.timm.TimmPatchBenchModel",
+        "model_name": "vit_large_patch16_dinov3.sat493m",
+        "pretrained": True,
+        "global_pool": "avg",
+        "use_cls_token": False,
+        "auto_resize": True,
+        "name": "vit_large_patch16_dinov3sat",
+    },
+}
+
+# Mirrors the main pipeline's c_range default (small, focused grid). Adjust
+# via --c-values if you want a wider sweep.
+DEFAULT_C_VALUES = [1e-3, 1e-2, 1e-1, 1.0, 10.0, 100.0]
+DEFAULT_ADAM_LRS = [1e-3, 1e-2, 1e-1, 1.0]
+DEFAULT_DATASETS = ["m-eurosat", "m-forestnet"]
+
+# Match main.py's linear-probe call (LogisticRegression(C=c, max_iter=2000, tol=1e-6)).
+MAX_ITER = 2000
+TOL = 1e-6
+
+
+def instantiate_model(model_cfg: dict, num_channels: int) -> torch.nn.Module:
+    """Instantiate a model from its ``MODEL_CONFIGS`` entry."""
+    target = model_cfg["_target_"]
+    module_name, class_name = target.rsplit(".", 1)
+    module = __import__(module_name, fromlist=[class_name])
+    cls = getattr(module, class_name)
+
+    kwargs = {k: v for k, v in model_cfg.items() if k not in ("_target_", "name")}
+    kwargs["num_channels"] = num_channels
+    return cls(**kwargs)
+
+
+def parse_dataset_names(raw_names: list[str]) -> list[str]:
+    """Parse comma- and space-separated dataset name lists."""
+    out: list[str] = []
+    for raw in raw_names:
+        for name in raw.split(","):
+            clean = name.strip()
+            if clean and clean not in out:
+                out.append(clean)
+    return out
+
+
+def parse_float_list(raw: str | None, default: list[float]) -> list[float]:
+    """Parse a comma-separated float list (e.g. ``"1e-3,1e-2,1"``)."""
+    if raw is None:
+        return list(default)
+    values = [float(x) for x in raw.split(",") if x.strip()]
+    if not values:
+        raise ValueError(f"Empty float list: {raw!r}")
+    return values
+
+
+def build_configs(c_values: list[float], adam_lrs: list[float]) -> list[dict]:
+    """Build a flat list of ``(solver, C, lr)`` fit configurations."""
+    configs: list[dict] = []
+    for c in c_values:
+        configs.append({"solver": "lbfgs", "C": float(c), "lr": 1.0})
+    for c in c_values:
+        for lr in adam_lrs:
+            configs.append({"solver": "adam", "C": float(c), "lr": float(lr)})
+    return configs
+
+
+def fit_one(
+    cfg: dict,
+    x_train: torch.Tensor,
+    y_train: torch.Tensor,
+    x_val: torch.Tensor,
+    x_test: torch.Tensor,
+    device: torch.device,
+    seed: int,
+) -> tuple[LogisticRegression, float, np.ndarray, np.ndarray, np.ndarray]:
+    """Fit one config and return ``(clf, fit_seconds, train_pred, val_pred, test_pred)``."""
+    clf = LogisticRegression(
+        C=cfg["C"],
+        lr=cfg["lr"],
+        solver=cfg["solver"],
+        max_iter=MAX_ITER,
+        tol=TOL,
+        random_state=seed,
+        device=device,
+    )
+
+    if device.type == "cuda":
+        torch.cuda.synchronize()
+    start = time.perf_counter()
+    clf.fit(x_train, y_train)
+    if device.type == "cuda":
+        torch.cuda.synchronize()
+    fit_seconds = time.perf_counter() - start
+
+    train_pred = clf.predict(x_train)
+    val_pred = clf.predict(x_val)
+    test_pred = clf.predict(x_test)
+    return clf, fit_seconds, train_pred, val_pred, test_pred
+
+
+def run_dataset(dataset_name: str, configs: list[dict], args: argparse.Namespace) -> str:
+    """Run all (model, config) fits for one dataset and write its CSV."""
+    output_path = os.path.join(args.output_dir, f"effect_of_lbfgs_vs_adam_{dataset_name}.csv")
+    device = torch.device(args.device)
+
+    completed: set[tuple] = set()
+    all_rows: list[dict] = []
+    if os.path.exists(output_path):
+        existing = pd.read_csv(output_path)
+        all_rows = existing.to_dict("records")
+        completed = {(r["model"], r["solver"], float(r["C"]), float(r["lr"])) for r in all_rows}
+        logger.info("Resume: found %d existing rows in %s", len(existing), output_path)
+
+    logger.info("Loading %s dataset...", dataset_name)
+    train_dataset, train_loader, val_loader, test_loader = get_datasets(
+        dataset_name=dataset_name,
+        partition_name="default",
+        batch_size=64,
+        return_val=True,
+        image_size=args.image_size,
+        interpolation="bilinear",
+    )
+    num_channels = train_dataset[0]["image"].shape[0]
+
+    for model_name, model_cfg in MODEL_CONFIGS.items():
+        remaining = [
+            c
+            for c in configs
+            if (model_name, c["solver"], float(c["C"]), float(c["lr"])) not in completed
+        ]
+        if not remaining:
+            logger.info(
+                "=== %s/%s === all %d configs already computed, skipping",
+                dataset_name,
+                model_name,
+                len(configs),
+            )
+            continue
+
+        logger.info(
+            "=== %s/%s === %d/%d configs remaining",
+            dataset_name,
+            model_name,
+            len(remaining),
+            len(configs),
+        )
+
+        logger.info("  Loading model %s...", model_name)
+        model = instantiate_model(model_cfg, num_channels)
+        model.to(device).eval()
+
+        logger.info("  Extracting features...")
+        x_train, y_train = extract_features(model, train_loader, device, verbose=False)
+        x_val, y_val = extract_features(model, val_loader, device, verbose=False)
+        x_test, y_test = extract_features(model, test_loader, device, verbose=False)
+        logger.info(
+            "  Features: train=%s, val=%s, test=%s",
+            x_train.shape,
+            x_val.shape,
+            x_test.shape,
+        )
+
+        del model
+        if device.type == "cuda":
+            torch.cuda.empty_cache()
+
+        x_train_t = torch.from_numpy(x_train)
+        y_train_t = torch.from_numpy(y_train).long()
+        x_val_t = torch.from_numpy(x_val)
+        x_test_t = torch.from_numpy(x_test)
+
+        for cfg in tqdm(remaining, desc=f"  fits ({model_name})", leave=False):
+            clf, fit_seconds, train_pred, val_pred, test_pred = fit_one(
+                cfg,
+                x_train_t,
+                y_train_t,
+                x_val_t,
+                x_test_t,
+                device,
+                args.seed,
+            )
+            all_rows.append(
+                {
+                    "dataset": dataset_name,
+                    "model": model_name,
+                    "solver": cfg["solver"],
+                    "C": float(cfg["C"]),
+                    "log10_C": float(np.log10(cfg["C"])),
+                    "lr": float(cfg["lr"]),
+                    "fit_seconds": float(fit_seconds),
+                    "n_iter": int(clf.n_iter_),
+                    "train_acc": float(accuracy_score(y_train, train_pred)),
+                    "val_acc": float(accuracy_score(y_val, val_pred)),
+                    "test_acc": float(accuracy_score(y_test, test_pred)),
+                    "feature_dim": int(x_train.shape[1]),
+                    "n_train": int(len(x_train)),
+                    "n_val": int(len(x_val)),
+                    "n_test": int(len(x_test)),
+                    "max_iter": MAX_ITER,
+                    "tol": TOL,
+                    "device": str(device),
+                }
+            )
+
+        df = pd.DataFrame(all_rows)
+        df.to_csv(output_path, index=False)
+        logger.info("  Saved %d rows to %s", len(all_rows), output_path)
+
+    logger.info("Done. Final results for %s: %s", dataset_name, output_path)
+    return output_path
+
+
+def main() -> None:
+    """Entry point."""
+    parser = argparse.ArgumentParser(description="LBFGS vs Adam linear-probing speed test")
+    parser.add_argument(
+        "--dataset",
+        "--datasets",
+        dest="datasets",
+        nargs="+",
+        default=DEFAULT_DATASETS,
+        help=(
+            f"Dataset name(s), space- or comma-separated (default: {', '.join(DEFAULT_DATASETS)})."
+        ),
+    )
+    parser.add_argument("--device", default="cuda:0", help="PyTorch device.")
+    parser.add_argument(
+        "--output-dir",
+        default="results/effect_of_lbfgs_vs_adam",
+        help="Output directory (one CSV per dataset).",
+    )
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--image-size", type=int, default=224)
+    parser.add_argument(
+        "--c-values",
+        default=None,
+        help=(
+            "Comma-separated C values for both solvers "
+            f"(default: {','.join(repr(c) for c in DEFAULT_C_VALUES)})."
+        ),
+    )
+    parser.add_argument(
+        "--adam-lrs",
+        default=None,
+        help=(
+            "Comma-separated learning rates for the Adam branch "
+            f"(default: {','.join(repr(lr) for lr in DEFAULT_ADAM_LRS)})."
+        ),
+    )
+    args = parser.parse_args()
+
+    os.makedirs(args.output_dir, exist_ok=True)
+    dataset_names = parse_dataset_names(args.datasets)
+    if not dataset_names:
+        raise ValueError("Provide at least one dataset name via --dataset.")
+
+    c_values = parse_float_list(args.c_values, DEFAULT_C_VALUES)
+    adam_lrs = parse_float_list(args.adam_lrs, DEFAULT_ADAM_LRS)
+    configs = build_configs(c_values, adam_lrs)
+    logger.info(
+        "Configs per (model, dataset): %d LBFGS + %d Adam = %d total",
+        len(c_values),
+        len(c_values) * len(adam_lrs),
+        len(configs),
+    )
+
+    torch.manual_seed(args.seed)
+    np.random.seed(args.seed)
+    logger.info("Running LBFGS-vs-Adam sweep on datasets: %s", ", ".join(dataset_names))
+
+    output_paths = [run_dataset(name, configs, args) for name in dataset_names]
+    logger.info("Finished sweeps: %s", ", ".join(output_paths))
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/run_effect_of_lbfgs_vs_adam.py
+++ b/experiments/run_effect_of_lbfgs_vs_adam.py
@@ -19,7 +19,6 @@ Configs swept (per (model, dataset)):
 
 Usage:
     python experiments/run_effect_of_lbfgs_vs_adam.py
-    python experiments/run_effect_of_lbfgs_vs_adam.py --dataset m-eurosat m-forestnet
     python experiments/run_effect_of_lbfgs_vs_adam.py --device cuda:3
 """
 
@@ -41,6 +40,9 @@ from torchgeo_bench.utils import extract_features
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
 
+DATASETS = ["m-bigearthnet", "m-brick-kiln", "m-eurosat", "m-forestnet", "m-pv4ger", "m-so2sat"]
+IMAGE_SIZE = 224
+
 MODEL_CONFIGS = {
     "resnet18": {
         "_target_": "torchgeo_bench.models.timm.TimmPatchBenchModel",
@@ -60,11 +62,9 @@ MODEL_CONFIGS = {
     },
 }
 
-# Mirrors the main pipeline's c_range default (small, focused grid). Adjust
-# via --c-values if you want a wider sweep.
-DEFAULT_C_VALUES = [1e-3, 1e-2, 1e-1, 1.0, 10.0, 100.0]
-DEFAULT_ADAM_LRS = [1e-3, 1e-2, 1e-1, 1.0]
-DEFAULT_DATASETS = ["m-eurosat", "m-forestnet"]
+# Mirrors the main pipeline's c_range default (small, focused grid).
+C_VALUES = [1e-3, 1e-2, 1e-1, 1.0, 10.0, 100.0]
+ADAM_LRS = [1e-3, 1e-2, 1e-1, 1.0]
 
 # Match main.py's linear-probe call (LogisticRegression(C=c, max_iter=2000, tol=1e-6)).
 MAX_ITER = 2000
@@ -83,34 +83,13 @@ def instantiate_model(model_cfg: dict, num_channels: int) -> torch.nn.Module:
     return cls(**kwargs)
 
 
-def parse_dataset_names(raw_names: list[str]) -> list[str]:
-    """Parse comma- and space-separated dataset name lists."""
-    out: list[str] = []
-    for raw in raw_names:
-        for name in raw.split(","):
-            clean = name.strip()
-            if clean and clean not in out:
-                out.append(clean)
-    return out
-
-
-def parse_float_list(raw: str | None, default: list[float]) -> list[float]:
-    """Parse a comma-separated float list (e.g. ``"1e-3,1e-2,1"``)."""
-    if raw is None:
-        return list(default)
-    values = [float(x) for x in raw.split(",") if x.strip()]
-    if not values:
-        raise ValueError(f"Empty float list: {raw!r}")
-    return values
-
-
-def build_configs(c_values: list[float], adam_lrs: list[float]) -> list[dict]:
+def build_configs() -> list[dict]:
     """Build a flat list of ``(solver, C, lr)`` fit configurations."""
     configs: list[dict] = []
-    for c in c_values:
+    for c in C_VALUES:
         configs.append({"solver": "lbfgs", "C": float(c), "lr": 1.0})
-    for c in c_values:
-        for lr in adam_lrs:
+    for c in C_VALUES:
+        for lr in ADAM_LRS:
             configs.append({"solver": "adam", "C": float(c), "lr": float(lr)})
     return configs
 
@@ -168,7 +147,7 @@ def run_dataset(dataset_name: str, configs: list[dict], args: argparse.Namespace
         partition_name="default",
         batch_size=64,
         return_val=True,
-        image_size=args.image_size,
+        image_size=IMAGE_SIZE,
         interpolation="bilinear",
     )
     num_channels = train_dataset[0]["image"].shape[0]
@@ -264,16 +243,6 @@ def run_dataset(dataset_name: str, configs: list[dict], args: argparse.Namespace
 def main() -> None:
     """Entry point."""
     parser = argparse.ArgumentParser(description="LBFGS vs Adam linear-probing speed test")
-    parser.add_argument(
-        "--dataset",
-        "--datasets",
-        dest="datasets",
-        nargs="+",
-        default=DEFAULT_DATASETS,
-        help=(
-            f"Dataset name(s), space- or comma-separated (default: {', '.join(DEFAULT_DATASETS)})."
-        ),
-    )
     parser.add_argument("--device", default="cuda:0", help="PyTorch device.")
     parser.add_argument(
         "--output-dir",
@@ -281,45 +250,23 @@ def main() -> None:
         help="Output directory (one CSV per dataset).",
     )
     parser.add_argument("--seed", type=int, default=0)
-    parser.add_argument("--image-size", type=int, default=224)
-    parser.add_argument(
-        "--c-values",
-        default=None,
-        help=(
-            "Comma-separated C values for both solvers "
-            f"(default: {','.join(repr(c) for c in DEFAULT_C_VALUES)})."
-        ),
-    )
-    parser.add_argument(
-        "--adam-lrs",
-        default=None,
-        help=(
-            "Comma-separated learning rates for the Adam branch "
-            f"(default: {','.join(repr(lr) for lr in DEFAULT_ADAM_LRS)})."
-        ),
-    )
     args = parser.parse_args()
 
     os.makedirs(args.output_dir, exist_ok=True)
-    dataset_names = parse_dataset_names(args.datasets)
-    if not dataset_names:
-        raise ValueError("Provide at least one dataset name via --dataset.")
 
-    c_values = parse_float_list(args.c_values, DEFAULT_C_VALUES)
-    adam_lrs = parse_float_list(args.adam_lrs, DEFAULT_ADAM_LRS)
-    configs = build_configs(c_values, adam_lrs)
+    configs = build_configs()
     logger.info(
         "Configs per (model, dataset): %d LBFGS + %d Adam = %d total",
-        len(c_values),
-        len(c_values) * len(adam_lrs),
+        len(C_VALUES),
+        len(C_VALUES) * len(ADAM_LRS),
         len(configs),
     )
 
     torch.manual_seed(args.seed)
     np.random.seed(args.seed)
-    logger.info("Running LBFGS-vs-Adam sweep on datasets: %s", ", ".join(dataset_names))
+    logger.info("Running LBFGS-vs-Adam sweep on datasets: %s", ", ".join(DATASETS))
 
-    output_paths = [run_dataset(name, configs, args) for name in dataset_names]
+    output_paths = [run_dataset(name, configs, args) for name in DATASETS]
     logger.info("Finished sweeps: %s", ", ".join(output_paths))
 
 

--- a/experiments/run_effect_of_lbfgs_vs_adam.py
+++ b/experiments/run_effect_of_lbfgs_vs_adam.py
@@ -8,9 +8,7 @@ is apples-to-apples on regularization and the training objective::
     loss = (1/n) * CrossEntropy + (1/n) * 0.5/C * ||W||^2
 
 For each (model, dataset, fit_config) we record wall-clock fit time,
-number of optimizer iterations, and train/val/test accuracy. With these
-columns you can plot e.g. accuracy-vs-time Pareto curves to see which
-solver hits a target accuracy fastest.
+number of optimizer iterations, and train/val/test accuracy.
 
 Configs swept (per (model, dataset)):
     - LBFGS: one fit per ``C``, ``lr=1.0`` (LBFGS uses strong-Wolfe line
@@ -19,17 +17,19 @@ Configs swept (per (model, dataset)):
 
 Usage:
     python experiments/run_effect_of_lbfgs_vs_adam.py
-    python experiments/run_effect_of_lbfgs_vs_adam.py --device cuda:3
+    python experiments/run_effect_of_lbfgs_vs_adam.py --devices 3
 """
 
 import argparse
 import logging
 import os
+import sys
 import time
 
 import numpy as np
 import pandas as pd
 import torch
+from _runner import add_devices_argument, default_output
 from sklearn.metrics import accuracy_score
 from tqdm import tqdm
 
@@ -40,8 +40,11 @@ from torchgeo_bench.utils import extract_features
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
 
-DATASETS = ["m-bigearthnet", "m-brick-kiln", "m-eurosat", "m-forestnet", "m-pv4ger", "m-so2sat"]
+OUTPUT = default_output(__file__)
+SEED = 0
 IMAGE_SIZE = 224
+
+DATASETS = ["m-bigearthnet", "m-brick-kiln", "m-eurosat", "m-forestnet", "m-pv4ger", "m-so2sat"]
 
 MODEL_CONFIGS = {
     "resnet18": {
@@ -101,7 +104,6 @@ def fit_one(
     x_val: torch.Tensor,
     x_test: torch.Tensor,
     device: torch.device,
-    seed: int,
 ) -> tuple[LogisticRegression, float, np.ndarray, np.ndarray, np.ndarray]:
     """Fit one config and return ``(clf, fit_seconds, train_pred, val_pred, test_pred)``."""
     clf = LogisticRegression(
@@ -110,7 +112,7 @@ def fit_one(
         solver=cfg["solver"],
         max_iter=MAX_ITER,
         tol=TOL,
-        random_state=seed,
+        random_state=SEED,
         device=device,
     )
 
@@ -128,18 +130,20 @@ def fit_one(
     return clf, fit_seconds, train_pred, val_pred, test_pred
 
 
-def run_dataset(dataset_name: str, configs: list[dict], args: argparse.Namespace) -> str:
-    """Run all (model, config) fits for one dataset and write its CSV."""
-    output_path = os.path.join(args.output_dir, f"effect_of_lbfgs_vs_adam_{dataset_name}.csv")
-    device = torch.device(args.device)
-
-    completed: set[tuple] = set()
-    all_rows: list[dict] = []
-    if os.path.exists(output_path):
-        existing = pd.read_csv(output_path)
-        all_rows = existing.to_dict("records")
-        completed = {(r["model"], r["solver"], float(r["C"]), float(r["lr"])) for r in all_rows}
-        logger.info("Resume: found %d existing rows in %s", len(existing), output_path)
+def run_dataset(
+    dataset_name: str,
+    configs: list[dict],
+    device: torch.device,
+    all_rows: list[dict],
+) -> list[dict]:
+    """Run all (model, config) fits for one dataset, appending rows to ``all_rows``."""
+    completed = {
+        (r["model"], r["solver"], float(r["C"]), float(r["lr"]))
+        for r in all_rows
+        if r.get("dataset") == dataset_name
+    }
+    if completed:
+        logger.info("Resume: %d existing rows for %s", len(completed), dataset_name)
 
     logger.info("Loading %s dataset...", dataset_name)
     train_dataset, train_loader, val_loader, test_loader = get_datasets(
@@ -207,7 +211,6 @@ def run_dataset(dataset_name: str, configs: list[dict], args: argparse.Namespace
                 x_val_t,
                 x_test_t,
                 device,
-                args.seed,
             )
             all_rows.append(
                 {
@@ -232,27 +235,31 @@ def run_dataset(dataset_name: str, configs: list[dict], args: argparse.Namespace
                 }
             )
 
-        df = pd.DataFrame(all_rows)
-        df.to_csv(output_path, index=False)
-        logger.info("  Saved %d rows to %s", len(all_rows), output_path)
+        pd.DataFrame(all_rows).to_csv(OUTPUT, index=False)
+        logger.info("  Saved %d rows to %s", len(all_rows), OUTPUT)
 
-    logger.info("Done. Final results for %s: %s", dataset_name, output_path)
-    return output_path
+    return all_rows
 
 
-def main() -> None:
+def main() -> int:
     """Entry point."""
     parser = argparse.ArgumentParser(description="LBFGS vs Adam linear-probing speed test")
-    parser.add_argument("--device", default="cuda:0", help="PyTorch device.")
-    parser.add_argument(
-        "--output-dir",
-        default="results/effect_of_lbfgs_vs_adam",
-        help="Output directory (one CSV per dataset).",
-    )
-    parser.add_argument("--seed", type=int, default=0)
+    add_devices_argument(parser)
     args = parser.parse_args()
 
-    os.makedirs(args.output_dir, exist_ok=True)
+    if len(args.devices) > 1:
+        logger.warning(
+            "This script runs in-process; using only the first of --devices=%s.",
+            args.devices,
+        )
+    device = torch.device(f"cuda:{args.devices[0]}")
+
+    os.makedirs(os.path.dirname(OUTPUT) or ".", exist_ok=True)
+
+    all_rows: list[dict] = []
+    if os.path.exists(OUTPUT):
+        all_rows = pd.read_csv(OUTPUT).to_dict("records")
+        logger.info("Resume: loaded %d existing rows from %s", len(all_rows), OUTPUT)
 
     configs = build_configs()
     logger.info(
@@ -262,13 +269,16 @@ def main() -> None:
         len(configs),
     )
 
-    torch.manual_seed(args.seed)
-    np.random.seed(args.seed)
-    logger.info("Running LBFGS-vs-Adam sweep on datasets: %s", ", ".join(DATASETS))
+    torch.manual_seed(SEED)
+    np.random.seed(SEED)
+    logger.info("Running LBFGS-vs-Adam sweep on %d datasets -> %s", len(DATASETS), OUTPUT)
 
-    output_paths = [run_dataset(name, configs, args) for name in DATASETS]
-    logger.info("Finished sweeps: %s", ", ".join(output_paths))
+    for dataset_name in DATASETS:
+        all_rows = run_dataset(dataset_name, configs, device, all_rows)
+
+    logger.info("Done. Final results: %s", OUTPUT)
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/experiments/run_main_experiments.py
+++ b/experiments/run_main_experiments.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python
+"""Run every benchmark model across every dataset (or chosen subsets).
+
+Ported from ``scripts/run_full_benchmark.py``. Each model is one job; the
+job evaluates that model across all datasets specified by ``--datasets``
+(default ``all``). Results land in ``results/all_results.csv``.
+
+Usage:
+    python experiments/run_main_experiments.py
+    python experiments/run_main_experiments.py --devices 0 1 2 3
+    python experiments/run_main_experiments.py --models timm/resnet18 timm/resnet50
+    python experiments/run_main_experiments.py --datasets [m-eurosat,m-forestnet]
+    python experiments/run_main_experiments.py --dry-run
+"""
+
+import argparse
+import sys
+
+from _runner import Job, add_devices_argument, run_jobs
+
+OUTPUT = "results/all_results.csv"
+
+MODELS = [
+    "timm/convnext_base",
+    "timm/convnext_large",
+    "timm/convnext_large_dinov3",
+    "timm/convnext_small",
+    "timm/convnext_tiny",
+    "timm/convnextv2_base",
+    "timm/convnextv2_tiny",
+    "timm/densenet121",
+    "timm/densenet161",
+    "timm/densenet169",
+    "timm/densenet201",
+    "timm/efficientnet_b0",
+    "timm/efficientnet_b1",
+    "timm/efficientnet_b2",
+    "timm/efficientnet_b3",
+    "timm/efficientnet_b4",
+    "timm/efficientnetv2_l",
+    "timm/efficientnetv2_m",
+    "timm/efficientnetv2_s",
+    "imagestats",
+    "timm/maxvit_tiny_tf_224",
+    "timm/mobilenetv3_large_100",
+    "timm/mobilenetv3_small_100",
+    "rcf",
+    "timm/regnetx_002",
+    "timm/regnetx_008",
+    "timm/regnety_002",
+    "timm/regnety_008",
+    "timm/resnet101",
+    "timm/resnet152",
+    "timm/resnet18",
+    "timm/resnet34",
+    "timm/resnet50",
+    "timm/vgg16",
+    "timm/vgg19",
+    "timm/wide_resnet50_2",
+    "timm/vit/deit_base_patch16_224",
+    "timm/vit/deit_small_patch16_224",
+    "timm/vit/deit_tiny_patch16_224",
+    "timm/vit/swin_base_patch4_window7_224",
+    "timm/vit/swin_large_patch4_window7_224",
+    "timm/vit/swin_small_patch4_window7_224",
+    "timm/vit/swin_tiny_patch4_window7_224",
+    "timm/vit/swinv2_base_window8_256",
+    "timm/vit/swinv2_small_window8_256",
+    "timm/vit/swinv2_tiny_window8_256",
+    "timm/vit/vit_base_patch16_224",
+    "timm/vit/vit_large_patch16_224",
+    "timm/vit/vit_large_patch16_dinov3",
+    "timm/vit/vit_large_patch16_dinov3sat",
+    "timm/vit/vit_small_patch16_224",
+    "timm/vit/vit_tiny_patch16_224",
+    "torchgeo/resnet18_s2rgb_moco",
+    "torchgeo/resnet18_s2rgb_seco",
+    "torchgeo/resnet50_s2rgb_moco",
+    "torchgeo/resnet50_s2rgb_seco",
+    "torchgeo/resnet50_fmow_gassl",
+    "torchgeo/resnet50_s2rgb_satlas_mi",
+    "torchgeo/resnet50_s2rgb_satlas_si",
+    "torchgeo/resnet152_s2rgb_satlas_mi",
+    "torchgeo/resnet152_s2rgb_satlas_si",
+    "torchgeo/swinv2b_naip_satlas_mi",
+    "torchgeo/swinv2b_naip_satlas_si",
+    "torchgeo/swinv2b_s2rgb_satlas_mi",
+    "torchgeo/swinv2b_s2rgb_satlas_si",
+    "torchgeo/swinv2t_s2rgb_satlas_mi",
+    "torchgeo/swinv2t_s2rgb_satlas_si",
+    "torchgeo/scalemae_large_fmow",
+    "torchgeo/dofa_base",
+    "torchgeo/dofa_large",
+    "torchgeo/earthloc_s2_resnet50",
+]
+
+
+def build_jobs(models: list[str], datasets: str) -> list[Job]:
+    """Build one job per model.
+
+    Args:
+        models: Model identifiers (Hydra ``model=`` overrides) to evaluate.
+        datasets: Hydra value forwarded as ``dataset.names=<datasets>``
+            (e.g. ``"all"`` or ``"[m-eurosat,m-forestnet]"``).
+    """
+    jobs: list[Job] = []
+    for model in models:
+        short = model.split("/")[-1]
+        overrides = [f"model={model}", f"dataset.names={datasets}"]
+        jobs.append(Job(label=short, overrides=overrides))
+    return jobs
+
+
+def main() -> int:
+    """Entry point."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--models",
+        nargs="+",
+        default=None,
+        help=f"Subset of models to run (default: all {len(MODELS)}).",
+    )
+    parser.add_argument(
+        "--datasets",
+        default="all",
+        help="Hydra value for dataset.names — 'all' or a bracketed list "
+        "such as '[m-eurosat,m-forestnet]'. Default: all.",
+    )
+    parser.add_argument(
+        "--output",
+        default=OUTPUT,
+        help=f"Output CSV path (default: {OUTPUT}).",
+    )
+    add_devices_argument(parser)
+    args = parser.parse_args()
+
+    models = args.models if args.models is not None else MODELS
+    jobs = build_jobs(models, args.datasets)
+    return run_jobs(jobs, args.devices, output=args.output, dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/experiments/run_main_experiments.py
+++ b/experiments/run_main_experiments.py
@@ -1,24 +1,20 @@
 #!/usr/bin/env python
-"""Run every benchmark model across every dataset (or chosen subsets).
+"""Run every benchmark model across every dataset.
 
-Each model is one job; the job evaluates that model across all datasets
-specified by ``--datasets`` (default ``all``). Results land in
-``results/all_results.csv``.
+Each model is one job that evaluates that model across all datasets
+(``dataset.names=all``).
 
 Usage:
     python experiments/run_main_experiments.py
     python experiments/run_main_experiments.py --devices 0 1 2 3
-    python experiments/run_main_experiments.py --models timm/resnet18 timm/resnet50
-    python experiments/run_main_experiments.py --datasets [m-eurosat,m-forestnet]
-    python experiments/run_main_experiments.py --dry-run
 """
 
 import argparse
 import sys
 
-from _runner import Job, add_devices_argument, run_jobs
+from _runner import Job, add_devices_argument, default_output, run_jobs
 
-OUTPUT = "results/all_results.csv"
+OUTPUT = default_output(__file__)
 
 MODELS = [
     "timm/convnext_base",
@@ -95,48 +91,20 @@ MODELS = [
 ]
 
 
-def build_jobs(models: list[str], datasets: str) -> list[Job]:
-    """Build one job per model.
-
-    Args:
-        models: Model identifiers (Hydra ``model=`` overrides) to evaluate.
-        datasets: Hydra value forwarded as ``dataset.names=<datasets>``
-            (e.g. ``"all"`` or ``"[m-eurosat,m-forestnet]"``).
-    """
-    jobs: list[Job] = []
-    for model in models:
-        short = model.split("/")[-1]
-        overrides = [f"model={model}", f"dataset.names={datasets}"]
-        jobs.append(Job(label=short, overrides=overrides))
-    return jobs
+def build_jobs() -> list[Job]:
+    """Build one job per model (each runs over all datasets)."""
+    return [
+        Job(label=model.split("/")[-1], overrides=[f"model={model}", "dataset.names=all"])
+        for model in MODELS
+    ]
 
 
 def main() -> int:
     """Entry point."""
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        "--models",
-        nargs="+",
-        default=None,
-        help=f"Subset of models to run (default: all {len(MODELS)}).",
-    )
-    parser.add_argument(
-        "--datasets",
-        default="all",
-        help="Hydra value for dataset.names — 'all' or a bracketed list "
-        "such as '[m-eurosat,m-forestnet]'. Default: all.",
-    )
-    parser.add_argument(
-        "--output",
-        default=OUTPUT,
-        help=f"Output CSV path (default: {OUTPUT}).",
-    )
     add_devices_argument(parser)
     args = parser.parse_args()
-
-    models = args.models if args.models is not None else MODELS
-    jobs = build_jobs(models, args.datasets)
-    return run_jobs(jobs, args.devices, output=args.output, dry_run=args.dry_run)
+    return run_jobs(build_jobs(), args.devices, output=OUTPUT)
 
 
 if __name__ == "__main__":

--- a/experiments/run_main_experiments.py
+++ b/experiments/run_main_experiments.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 """Run every benchmark model across every dataset (or chosen subsets).
 
-Ported from ``scripts/run_full_benchmark.py``. Each model is one job; the
-job evaluates that model across all datasets specified by ``--datasets``
-(default ``all``). Results land in ``results/all_results.csv``.
+Each model is one job; the job evaluates that model across all datasets
+specified by ``--datasets`` (default ``all``). Results land in
+``results/all_results.csv``.
 
 Usage:
     python experiments/run_main_experiments.py

--- a/experiments/run_resize_and_normalization_experiment.py
+++ b/experiments/run_resize_and_normalization_experiment.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python
 """Sweep resnet18 on m-eurosat varying normalization, image size, and interpolation.
 
-Ported from ``scripts/run_eurosat_effect_of_input_choices.sh``. Results land in
-``results/eurosat_effect_of_experimental_setting.csv``.
+Results land in ``results/eurosat_effect_of_experimental_setting.csv``.
 
 Usage:
     python experiments/run_resize_and_normalization_experiment.py

--- a/experiments/run_resize_and_normalization_experiment.py
+++ b/experiments/run_resize_and_normalization_experiment.py
@@ -3,21 +3,19 @@
 
 Sweeps the model-side ``input_normalization`` knob (``bands_zscore``,
 ``none``, ``imagenet``, ``timm_default``) — the dataset always emits raw
-values, so normalization is configured on the model. Results land in
-``results/eurosat_effect_of_experimental_setting.csv``.
+values, so normalization is configured on the model.
 
 Usage:
     python experiments/run_resize_and_normalization_experiment.py
     python experiments/run_resize_and_normalization_experiment.py --devices 0 1 2
-    python experiments/run_resize_and_normalization_experiment.py --dry-run
 """
 
 import argparse
 import sys
 
-from _runner import Job, add_devices_argument, run_jobs
+from _runner import Job, add_devices_argument, default_output, run_jobs
 
-OUTPUT = "results/eurosat_effect_of_experimental_setting.csv"
+OUTPUT = default_output(__file__)
 
 NORMALIZATIONS = ["bands_zscore", "none", "imagenet", "timm_default"]
 IMAGE_SIZES: list[str] = ["null", "224", "256", "448", "512"]
@@ -54,9 +52,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     add_devices_argument(parser)
     args = parser.parse_args()
-
-    jobs = build_jobs()
-    return run_jobs(jobs, args.devices, output=OUTPUT, dry_run=args.dry_run)
+    return run_jobs(build_jobs(), args.devices, output=OUTPUT)
 
 
 if __name__ == "__main__":

--- a/experiments/run_resize_and_normalization_experiment.py
+++ b/experiments/run_resize_and_normalization_experiment.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python
-"""Sweep resnet18 on m-eurosat varying normalization, image size, and interpolation.
+"""Sweep resnet18 on m-eurosat varying image size, interpolation, and the model's input normalization mode.
 
-Results land in ``results/eurosat_effect_of_experimental_setting.csv``.
+Sweeps the model-side ``input_normalization`` knob (``bands_zscore``,
+``none``, ``imagenet``, ``timm_default``) — the dataset always emits raw
+values, so normalization is configured on the model. Results land in
+``results/eurosat_effect_of_experimental_setting.csv``.
 
 Usage:
     python experiments/run_resize_and_normalization_experiment.py
@@ -16,7 +19,7 @@ from _runner import Job, add_devices_argument, run_jobs
 
 OUTPUT = "results/eurosat_effect_of_experimental_setting.csv"
 
-NORMALIZATIONS = ["mean_stdev", "min_max", "percentile_2_98", "none"]
+NORMALIZATIONS = ["bands_zscore", "none", "imagenet", "timm_default"]
 IMAGE_SIZES: list[str] = ["null", "224", "256", "448", "512"]
 INTERPOLATIONS = ["bilinear", "bicubic", "nearest"]
 
@@ -32,8 +35,8 @@ def build_jobs() -> list[Job]:
 
                 overrides = [
                     "model=timm/resnet18",
+                    f"model.input_normalization={norm}",
                     "dataset.names=[m-eurosat]",
-                    f"dataset.normalization={norm}",
                     f"dataset.image_size={size}",
                     "eval.merge_val=false",
                     "verbose=false",

--- a/experiments/run_resize_and_normalization_experiment.py
+++ b/experiments/run_resize_and_normalization_experiment.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+"""Sweep resnet18 on m-eurosat varying normalization, image size, and interpolation.
+
+Ported from ``scripts/run_eurosat_effect_of_input_choices.sh``. Results land in
+``results/eurosat_effect_of_experimental_setting.csv``.
+
+Usage:
+    python experiments/run_resize_and_normalization_experiment.py
+    python experiments/run_resize_and_normalization_experiment.py --devices 0 1 2
+    python experiments/run_resize_and_normalization_experiment.py --dry-run
+"""
+
+import argparse
+import sys
+
+from _runner import Job, add_devices_argument, run_jobs
+
+OUTPUT = "results/eurosat_effect_of_experimental_setting.csv"
+
+NORMALIZATIONS = ["mean_stdev", "min_max", "percentile_2_98", "none"]
+IMAGE_SIZES: list[str] = ["null", "224", "256", "448", "512"]
+INTERPOLATIONS = ["bilinear", "bicubic", "nearest"]
+
+
+def build_jobs() -> list[Job]:
+    """Build the full norm × size × interpolation grid (skipping non-bilinear@null)."""
+    jobs: list[Job] = []
+    for norm in NORMALIZATIONS:
+        for size in IMAGE_SIZES:
+            for interp in INTERPOLATIONS:
+                if size == "null" and interp != "bilinear":
+                    continue
+
+                overrides = [
+                    "model=timm/resnet18",
+                    "dataset.names=[m-eurosat]",
+                    f"dataset.normalization={norm}",
+                    f"dataset.image_size={size}",
+                    "eval.merge_val=false",
+                    "verbose=false",
+                ]
+                if size != "null":
+                    overrides.append(f"dataset.interpolation={interp}")
+
+                label = f"norm={norm} size={size} interp={interp}"
+                jobs.append(Job(label=label, overrides=overrides))
+    return jobs
+
+
+def main() -> int:
+    """Entry point."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    add_devices_argument(parser)
+    args = parser.parse_args()
+
+    jobs = build_jobs()
+    return run_jobs(jobs, args.devices, output=OUTPUT, dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Moves five experiment runners out of the gitignored `scripts/` directory
into a tracked `experiments/` package and gives the non-custom ones a
uniform CLI for single- or multi-GPU dispatch.

## What's new

`experiments/_runner.py` — shared GPU queue dispatcher used by the
non-custom runners. Public surface:

- `Job` dataclass — one `torchgeo-bench run` invocation
- `add_devices_argument(parser)` — registers `--devices N [N …]`
  (default `[0]`) and `--dry-run`
- `run_jobs(jobs, devices, *, output, dry_run=False)` — single device
  runs jobs sequentially; multiple devices fan out via `queue.Queue`
  with one worker thread per GPU. Each worker shells out to
  `torchgeo-bench run <overrides> device=cuda:G output=<path>
  resume=true` and prints `[i/N] START / DONE / FAILED` log lines plus
  a final summary (passed / failed / wall time / fastest / slowest).

### Runner scripts

| New (experiments/) | Replaces (scripts/) | Notes |
|---|---|---|
| `run_resize_and_normalization_experiment.py` | `run_eurosat_effect_of_input_choices.sh` | 52 jobs: m-eurosat × resnet18 × normalization × image_size × interpolation. Skips non-`bilinear` when `image_size=null`. Output `results/eurosat_effect_of_experimental_setting.csv`. |
| `run_cls_token_experiment.py` | `run_cls_token_experiment.sh` | 36 jobs: 2 datasets × 9 ViT/DeiT models × `use_cls_token`. Output `results/cls_token_experiment.csv`. |
| `run_main_experiments.py` | `run_full_benchmark.py` | 71 jobs (one per model); `--models` / `--datasets` / `--output` flags. Output `results/all_results.csv`. |
| `run_c_sweep_experiment.py` | `run_c_sweep.py` | Verbatim port; stale `from src.*` imports replaced with `from torchgeo_bench.*`. |
| `run_effect_of_lbfgs_vs_adam.py` | `run_optimizer_sweep.py` | Rewritten to compare Adam vs LBFGS *speed* using the same `LogisticRegression` class the main pipeline uses (`max_iter=2000, tol=1e-6`). Sweeps `C` for both solvers + a per-LR grid for Adam. Records `fit_seconds`, `n_iter`, train/val/test acc per fit. |

The old `scripts/*` files were already gitignored — this PR is purely
additive from git's point of view.

## CLI examples

```bash
# Sequential on GPU 0 (default)
python experiments/run_main_experiments.py --models timm/resnet18

# Fan out across 4 GPUs
python experiments/run_main_experiments.py --devices 0 1 2 3

# Inspect the planned jobs without running anything
python experiments/run_resize_and_normalization_experiment.py --dry-run
```

## Verification

- `ruff check experiments/` — clean
- `ruff format experiments/` — clean
- `--dry-run` exercised on all 3 non-custom runners (52, 36, 71 jobs);
  multi-device dispatch verified with `--devices 0 1`
- `--help` exercised on both custom runners; imports resolve via the
  editable install
