### PR TITLE
fix(datasets): kuro_siwo bands=rgb/all returns 3-D image

### DIFF
--- a/src/torchgeo_bench/datasets/kuro_siwo.py
+++ b/src/torchgeo_bench/datasets/kuro_siwo.py
@@ -1,15 +1,28 @@
 """Kuro Siwo (GeoBench V2) benchmark dataset."""
 
+from collections.abc import Callable
+
+import torch
+import torch.nn as nn
+from torch.utils.data import Dataset
+
 from .base import BandSpec
-from .geobench_v2 import _V2Dataset
+from .geobench_v2 import GeoBenchv2, _V2Dataset
 
 
 class KuroSiwo(_V2Dataset):
     """SAR flood mapping segmentation (4 classes).
 
-    Upstream returns multi-temporal SAR (pre / pre / post) plus a static
-    DEM, so :meth:`canonicalize_sample` collapses the time axis by keeping
-    the post-flood acquisition.
+    Upstream emits multi-temporal SAR (``image_pre_1`` / ``image_pre_2`` /
+    ``image_post``) plus a static DEM (``image_dem``).  Its built-in
+    ``return_stacked_image=True`` path stacks per-timestep tensors along a
+    new temporal axis, which (a) leaves the result 4-D ``(C, T, H, W)`` and
+    (b) hits an assertion when SAR and DEM channel counts differ.
+
+    To produce a clean 3-D ``(C, H, W)`` image we bypass that path
+    altogether: we ask upstream for the post-event SAR only
+    (``time_step=["post"]``), then concatenate optional DEM along the
+    channel dimension ourselves in :meth:`canonicalize_sample`.
     """
 
     band_order_strategy = "by_sensor"
@@ -29,9 +42,55 @@ class KuroSiwo(_V2Dataset):
     ]
     # fmt: on
 
+    def get_dataset(
+        self,
+        split: str,
+        *,
+        partition: str = "default",
+        bands: tuple[str, ...] | None = None,
+        transform: Callable | None = None,
+    ) -> Dataset:
+        """Return a :class:`GeoBenchv2` configured for single-timestep SAR + DEM.
+
+        Forces ``return_stacked_image=False`` (so the upstream emits per-modality
+        keys we can stack ourselves) and ``time_step=["post"]`` (so only the
+        post-event SAR acquisition is loaded). :meth:`canonicalize_sample`
+        then folds the per-modality tensors into a single 3-D ``image`` key.
+        """
+        del partition
+        band_order = self.build_band_order(bands)
+        canonicalize = self.canonicalize_sample
+
+        def chained(sample: dict) -> dict:
+            if transform is not None:
+                sample = transform(sample)
+            return canonicalize(sample)
+
+        return GeoBenchv2(
+            root=self.data_root(),
+            dataset_name=self.name,
+            split=split,
+            band_order=band_order,
+            transforms=chained,
+            data_normalizer=nn.Identity,
+            time_step=["post"],
+        )
+
     def canonicalize_sample(self, sample: dict) -> dict:
-        """Squeeze the (C, T, H, W) tensor to (C, H, W) by keeping post-flood."""
-        img = sample.get("image")
-        if img is not None and img.dim() == 4:
-            sample["image"] = img[:, -1, ...]
+        """Fold per-modality keys into a single 3-D ``(C, H, W)`` image tensor.
+
+        Upstream emits ``image_post`` for SAR (we only request the post-event
+        timestep) and/or ``image_dem`` depending on the requested band order.
+        Both are 3-D ``(C, H, W)`` so we can simply concatenate them along
+        the channel dimension. Per-modality keys are removed from the sample
+        once merged.
+        """
+        modalities: list[torch.Tensor] = []
+        for key in ("image_post", "image_dem"):
+            if key in sample:
+                modalities.append(sample.pop(key))
+        if modalities:
+            sample["image"] = (
+                modalities[0] if len(modalities) == 1 else torch.cat(modalities, dim=0)
+            )
         return sample

--- a/tests/test_geobench_v2_datasets.py
+++ b/tests/test_geobench_v2_datasets.py
@@ -177,3 +177,148 @@ class TestV2Loading:
                 bo = call.kwargs["band_order"]
                 assert isinstance(bo, list), bo
                 assert bo == ["B04", "B03", "B02"], bo
+
+
+class MockKuroSiwo:
+    """Stand-in for ``geobench_v2.datasets.GeoBenchKuroSiwo``.
+
+    Mirrors the real upstream loader's *unstacked* output shape: a per-modality
+    dict containing ``image_pre_1`` / ``image_pre_2`` / ``image_post`` for SAR
+    (gated by ``time_step``) and ``image_dem`` for DEM, plus ``mask`` and
+    ``invalid_data``. Each tensor is 3-D ``(C, H, W)``.
+
+    Channel counts come from ``band_order`` (a ``dict[modality, list[str]]``),
+    which is what the wrapper's ``band_order_strategy = "by_sensor"`` produces.
+    """
+
+    def __init__(
+        self,
+        root,
+        split,
+        *,
+        band_order=None,
+        time_step=("pre_1", "pre_2", "post"),
+        transforms=None,
+        return_stacked_image=False,
+        **kwargs,
+    ):
+        del kwargs
+        self.root = root
+        self.split = split
+        self.band_order = band_order or {}
+        self.time_step = list(time_step)
+        self.transforms = transforms
+        self.return_stacked_image = return_stacked_image
+        self.h, self.w = 16, 16
+
+    def __len__(self):
+        return 4
+
+    def __getitem__(self, idx):
+        del idx
+        sample: dict[str, torch.Tensor] = {
+            "invalid_data": torch.ones(1, self.h, self.w, dtype=torch.long),
+            "mask": torch.zeros(self.h, self.w, dtype=torch.long),
+        }
+        if "sar" in self.band_order:
+            sar_c = len(self.band_order["sar"])
+            for ts in self.time_step:
+                sample[f"image_{ts}"] = torch.ones(sar_c, self.h, self.w) * float(
+                    {"pre_1": 1.0, "pre_2": 2.0, "post": 3.0}[ts]
+                )
+        if "dem" in self.band_order:
+            sample["image_dem"] = torch.full((len(self.band_order["dem"]), self.h, self.w), 99.0)
+        if self.transforms is not None:
+            sample = self.transforms(sample)
+        return sample
+
+
+class TestKuroSiwoCanonicalization:
+    """Verify the kuro_siwo wrapper folds per-modality keys into a 3-D image."""
+
+    @pytest.fixture
+    def mocked_kuro_siwo(self):
+        with patch(
+            "geobench_v2.datasets.GeoBenchKuroSiwo",
+            MagicMock(side_effect=MockKuroSiwo),
+        ) as mocked:
+            yield mocked
+
+    @pytest.mark.parametrize(
+        "bands,expected_channels",
+        [
+            (("vv", "vh"), 2),
+            (("vv",), 1),
+            (("dem",), 1),
+            (("vv", "dem"), 2),
+            (("vv", "vh", "dem"), 3),
+            (None, 3),  # all bands
+        ],
+    )
+    def test_image_is_3d_with_correct_channel_count(
+        self, mocked_kuro_siwo, bands, expected_channels
+    ):
+        """For every band selection the canonical image must be ``(C, H, W)``."""
+        bench = get_bench_dataset_class("kuro_siwo")()
+        ds = bench.get_dataset("train", bands=bands)
+        sample = ds[0]
+        assert "image" in sample
+        img = sample["image"]
+        assert img.dim() == 3, f"expected 3-D image, got shape {tuple(img.shape)} for bands={bands}"
+        assert img.shape[0] == expected_channels, (
+            f"expected {expected_channels} channels, got {img.shape[0]} for bands={bands}"
+        )
+
+        for stale in ("image_pre_1", "image_pre_2", "image_post", "image_dem"):
+            assert stale not in sample, f"per-modality key {stale!r} should be folded into 'image'"
+
+        assert mocked_kuro_siwo.called
+
+    def test_uses_post_event_sar_only(self, mocked_kuro_siwo):
+        """The wrapper must request ``time_step=['post']`` from upstream."""
+        bench = get_bench_dataset_class("kuro_siwo")()
+        bench.get_dataset("train", bands=("vv", "vh"))
+        for call in mocked_kuro_siwo.call_args_list:
+            assert call.kwargs["time_step"] == ["post"], call.kwargs
+
+    def test_does_not_request_stacked_image(self, mocked_kuro_siwo):
+        """The wrapper must NOT request upstream's broken stacking path."""
+        bench = get_bench_dataset_class("kuro_siwo")()
+        bench.get_dataset("train", bands=None)
+        for call in mocked_kuro_siwo.call_args_list:
+            assert call.kwargs.get("return_stacked_image", False) is False, call.kwargs
+
+    def test_dem_concatenated_after_sar(self, mocked_kuro_siwo):
+        """When both SAR and DEM are requested, DEM lives in the trailing channels."""
+        del mocked_kuro_siwo  # only used to install the mock
+        bench = get_bench_dataset_class("kuro_siwo")()
+        ds = bench.get_dataset("train", bands=("vv", "vh", "dem"))
+        img = ds[0]["image"]
+        # MockKuroSiwo paints SAR-post with 3.0 and DEM with 99.0
+        assert torch.allclose(img[:2], torch.full_like(img[:2], 3.0))
+        assert torch.allclose(img[2:], torch.full_like(img[2:], 99.0))
+
+
+@pytest.mark.slow
+class TestKuroSiwoLive:
+    """Smoke tests against real Kuro Siwo data (skipped if the dataset is missing)."""
+
+    @pytest.mark.parametrize(
+        "bands,expected_channels",
+        [
+            (("vv", "vh"), 2),
+            (None, 3),  # all bands: vv, vh, dem
+            (("vv", "dem"), 2),
+        ],
+    )
+    def test_real_sample_is_3d(self, geobench_v2_root, bands, expected_channels):
+        """Loading real kuro_siwo data must yield a 3-D image with the expected channels."""
+        del geobench_v2_root
+        bench = get_bench_dataset_class("kuro_siwo")()
+        ds = bench.get_dataset("train", bands=bands)
+        sample = ds[0]
+        img = sample["image"]
+        assert img.dim() == 3, f"expected 3-D, got shape {tuple(img.shape)}"
+        assert img.shape[0] == expected_channels, (
+            f"expected {expected_channels} channels, got {img.shape[0]}"
+        )


### PR DESCRIPTION
## Problem

The `kuro_siwo` V2 wrapper produces broken outputs:

- **`bands=rgb`** (or any SAR-only subset) returns 4-D `(C, T=3, H, W)` —
  the temporal axis is never collapsed.
- **`bands=all`** (sar + dem) crashes inside upstream's stacking block
  with `AssertionError: images_sizes ... currently only supports stacking
  of images/modalities with the same number of bands` (SAR has 2 channels
  but DEM has 1).

This is what's left of the ROADMAP item _"Fix V2 dataset `band_order`
bug"_. The original symptom (`benv2 KeyError: 's2'`) was already fixed by
the `band_order_strategy = "by_sensor"` mechanism — `kuro_siwo` is the
only V2 dataset still affected. A live smoke test across every other V2
dataset confirmed they all handle `bands=rgb`, `bands=all`, and explicit
subsets correctly.

## Root cause

The wrapper inherited the base `_V2Dataset.get_dataset` flow, which sets
`return_stacked_image=True`. Upstream then:

1. Stacks per-timestep SAR tensors along a new temporal dim (4-D output).
2. Asserts that all stacked modalities have the same shape — fails for
   sar (2 ch) + dem (1 ch).

The wrapper's `canonicalize_sample` was meant to collapse the temporal
axis, but it ran on the *unstacked* sample (upstream calls `transforms`
before `return_stacked_image=True` does its work), so the 4-D image it
expected to see never existed.

## Fix

In `src/torchgeo_bench/datasets/kuro_siwo.py`:

- Override `get_dataset` to **not** pass `return_stacked_image=True`
  upstream, and pass `time_step=["post"]` so only the post-event SAR
  acquisition is loaded (skipping unused tensors entirely).
- Replace `canonicalize_sample` to operate on the per-modality keys
  upstream actually emits (`image_post`, `image_dem`): use the post-event
  SAR, concatenate DEM along the channel axis when present, set the
  resulting 3-D `(C, H, W)` tensor as the canonical `image` key, and drop
  the per-modality keys.

## Verification

Verified live against real kuro_siwo data:

| `bands`                    | Result shape    |
|----------------------------|-----------------|
| `rgb` → `("vv","vh")`      | `(2, 224, 224)` |
| `("vv",)`                  | `(1, 224, 224)` |
| `("dem",)`                 | `(1, 224, 224)` |
| `("vv","dem")`             | `(2, 224, 224)` |
| `all` (None)               | `(3, 224, 224)` |
| `("vv","vh","dem")`        | `(3, 224, 224)` |

## Tests

In `tests/test_geobench_v2_datasets.py`:

- New `MockKuroSiwo` that mirrors upstream's *unstacked* output shape
  (`image_pre_1` / `image_pre_2` / `image_post` / `image_dem` keys), gated
  on `time_step` and `band_order`.
- 6 parametrised assertions that the wrapper canonicalises to 3-D
  `(C, H, W)` for every band selection (rgb, single-modality subsets,
  cross-modality, all-bands).
- Assertions that upstream is called with `time_step=["post"]` and not
  `return_stacked_image=True`.
- Channel-order assertion: SAR-post in the leading channels, DEM in the
  trailing channels.
- 3 slow integration assertions against real `kuro_siwo` data
  (skipped when the dataset is missing).

Full suite: **113 passed, 77 skipped, 0 failures.** Lint + format clean.

## ROADMAP

The V2 `band_order` bug item in `ROADMAP.md` (untracked in this repo)
should be removed once this lands. I've already removed it from my local
copy.

## Out of scope

- No changes to other V2 datasets (all working today).
- No upstream `geobench_v2` patches.
- No changes to V1 datasets, models, or evaluation logic.