### PR TITLE
ci: deploy Sphinx docs to GitHub Pages

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,54 @@
+name: Deploy docs to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+# Only one concurrent deployment.  Cancel in-progress runs that the new push supersedes,
+# but let any actively-deploying job finish so the live site is never half-updated.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build Sphinx site
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: astral-sh/setup-uv@v8.0.0
+        with:
+          enable-cache: true
+
+      - name: Install docs dependencies
+        run: uv sync --extra docs
+
+      - name: Build HTML (warnings as errors)
+        run: uv run --extra docs sphinx-build -W --keep-going -b html docs docs/_build/html
+
+      - name: Upload Pages artifact
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: docs/_build/html
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Companion to #17 (the docs site itself). Adds a GitHub Actions workflow
that builds the Sphinx docs and deploys them to GitHub Pages.

## What it does

- **`.github/workflows/docs.yaml`**:
  - **Triggers**: push to `main`, pull requests targeting `main`, and
    manual `workflow_dispatch`.
  - **`build` job**: `astral-sh/setup-uv` → `uv sync --extra docs` →
    `sphinx-build -W --keep-going -b html docs docs/_build/html`.
    Uploads the built site as a Pages artifact (skipped on PRs).
  - **`deploy` job** (push-to-main and `workflow_dispatch` only):
    `actions/deploy-pages@v4` publishes the artifact to the
    `github-pages` environment.
  - **PRs**: build only — they verify the docs still compile cleanly
    without publishing anything.
  - **Concurrency**: `group: pages`, `cancel-in-progress: false` so an
    actively-deploying run finishes before a newer one starts (live
    site is never half-updated).

## Style notes

- Matches the existing `ci.yaml` / `release.yml` workflows: `uv` via
  `astral-sh/setup-uv@v8.0.0`, `actions/checkout@v6`.
- Uses the same `-W --keep-going` flags that `docs/Makefile` and
  `.readthedocs.yaml` use locally / on RTD, so a regression is caught
  identically in all three places.

## Manual setup needed (one-time)

After this PR lands, enable Pages from the repo settings:

> **Settings → Pages → Source: `GitHub Actions`**

The first deploy after that will publish to
**https://torchgeo.github.io/torchgeo-bench/**.

## Coexistence with Read the Docs

The `.readthedocs.yaml` introduced in #17 is left in place — RTD and
Pages can both serve the docs in parallel. If we'd rather pick one,
that's a follow-up.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>