### PR TITLE
docs: hide README's 'Learn more' section on the docs landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ torchgeo-bench run model=timm/resnet50 dataset.names=[m-eurosat]
 Results are appended to `results/all_results.csv`. Re-run with `resume=true`
 to skip already-completed rows.
 
+<!-- skip-on-docs-landing-start -->
 ## Learn more
 
 - **[Documentation](https://torchgeo.org/torchgeo-bench/)** — full
@@ -72,6 +73,7 @@ to skip already-completed rows.
   workflow, and troubleshooting.
 - **[AGENTS.md](https://github.com/torchgeo/torchgeo-bench/blob/main/AGENTS.md)**
   — contributor guide and house style.
+<!-- skip-on-docs-landing-end -->
 
 ## Citation
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,17 @@
 .. module:: torchgeo_bench
 
+.. The README is included in two parts so the docs-landing page can skip
+   the redundant "Learn more" section (its primary "Documentation" link
+   would just self-redirect here).  The HTML-comment markers in
+   README.md are invisible on GitHub.
+
 .. include:: ../README.md
    :parser: myst_parser.sphinx_
+   :end-before: <!-- skip-on-docs-landing-start -->
+
+.. include:: ../README.md
+   :parser: myst_parser.sphinx_
+   :start-after: <!-- skip-on-docs-landing-end -->
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
The README's *Learn more* bullet list links to the docs site itself
(self-redirect when viewed from the docs landing) and AGENTS.md.
Useful on github.com, redundant inside the rendered docs.

This PR wraps that section in HTML-comment markers (invisible on
GitHub) and splits the docs include into two ranges so the
docs-landing page skips just the *Learn more* section while still
rendering the README intro / install / download / run blocks above
**and** the Citation / License blocks below.

```rst
.. include:: ../README.md
   :parser: myst_parser.sphinx_
   :end-before: <!-- skip-on-docs-landing-start -->

.. include:: ../README.md
   :parser: myst_parser.sphinx_
   :start-after: <!-- skip-on-docs-landing-end -->
```

## Verified

- Local `make html` clean (zero real warnings).
- Rendered `index.html` no longer has a *Learn more* heading; *Citation* and *License* are still present.
- `README.md` viewed on github.com still shows the *Learn more* section as before (HTML comments render as nothing).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>