### PR TITLE
fix(experiments): port c_sweep + lbfgs_vs_adam to the bands BenchModel API

### DIFF
--- a/experiments/run_c_sweep_experiment.py
+++ b/experiments/run_c_sweep_experiment.py
@@ -22,7 +22,8 @@ from _runner import add_devices_argument, default_output
 from sklearn.metrics import accuracy_score
 from tqdm import tqdm
 
-from torchgeo_bench.datasets import get_datasets
+from torchgeo_bench.datasets import get_bench_dataset_class, get_datasets
+from torchgeo_bench.datasets.base import BandSpec
 from torchgeo_bench.linear import LogisticRegression
 from torchgeo_bench.utils import extract_features
 
@@ -78,7 +79,7 @@ MODEL_CONFIGS = {
 C_VALUES = np.sort(np.unique(np.append(np.logspace(-7, 2, 40), 1.0)))
 
 
-def instantiate_model(model_cfg: dict, num_channels: int) -> torch.nn.Module:
+def instantiate_model(model_cfg: dict, bands: list[BandSpec]) -> torch.nn.Module:
     """Instantiate a model from its ``MODEL_CONFIGS`` entry."""
     target = model_cfg["_target_"]
     module_name, class_name = target.rsplit(".", 1)
@@ -86,7 +87,7 @@ def instantiate_model(model_cfg: dict, num_channels: int) -> torch.nn.Module:
     cls = getattr(module, class_name)
 
     kwargs = {k: v for k, v in model_cfg.items() if k not in ("_target_", "name")}
-    kwargs["num_channels"] = num_channels
+    kwargs["bands"] = bands
     return cls(**kwargs)
 
 
@@ -143,6 +144,15 @@ def run_c_sweep(
 
 def run_dataset_sweep(dataset_name: str, device: torch.device, all_rows: list[dict]) -> list[dict]:
     """Run the C sweep for one dataset, appending rows in-place to ``all_rows``."""
+    bench_cls = get_bench_dataset_class(dataset_name)
+    if bench_cls.multilabel:
+        logger.warning(
+            "Skipping %s: this script is single-label only (uses accuracy_score + "
+            "single-label LogisticRegression).",
+            dataset_name,
+        )
+        return all_rows
+
     completed_models = {r["model"] for r in all_rows if r.get("dataset") == dataset_name}
     if completed_models:
         logger.info(
@@ -153,7 +163,7 @@ def run_dataset_sweep(dataset_name: str, device: torch.device, all_rows: list[di
         )
 
     logger.info("Loading %s dataset...", dataset_name)
-    train_dataset, train_loader, val_loader, test_loader = get_datasets(
+    _train_dataset, train_loader, val_loader, test_loader = get_datasets(
         dataset_name=dataset_name,
         partition_name="default",
         batch_size=64,
@@ -161,7 +171,7 @@ def run_dataset_sweep(dataset_name: str, device: torch.device, all_rows: list[di
         image_size=IMAGE_SIZE,
         interpolation="bilinear",
     )
-    num_channels = train_dataset[0]["image"].shape[0]
+    bands = bench_cls().select_band_specs(tuple(bench_cls.rgb_bands))
 
     for model_name, model_cfg in MODEL_CONFIGS.items():
         if model_name in completed_models:
@@ -170,7 +180,7 @@ def run_dataset_sweep(dataset_name: str, device: torch.device, all_rows: list[di
 
         logger.info("=== %s/%s ===", dataset_name, model_name)
         logger.info("  Loading model %s...", model_name)
-        model = instantiate_model(model_cfg, num_channels)
+        model = instantiate_model(model_cfg, bands)
         model.to(device).eval()
 
         logger.info("  Extracting features...")

--- a/experiments/run_effect_of_lbfgs_vs_adam.py
+++ b/experiments/run_effect_of_lbfgs_vs_adam.py
@@ -33,7 +33,7 @@ from _runner import add_devices_argument, default_output
 from sklearn.metrics import accuracy_score
 from tqdm import tqdm
 
-from torchgeo_bench.datasets import get_datasets
+from torchgeo_bench.datasets import get_bench_dataset_class, get_datasets
 from torchgeo_bench.linear import LogisticRegression
 from torchgeo_bench.utils import extract_features
 
@@ -74,7 +74,7 @@ MAX_ITER = 2000
 TOL = 1e-6
 
 
-def instantiate_model(model_cfg: dict, num_channels: int) -> torch.nn.Module:
+def instantiate_model(model_cfg: dict, bands: list) -> torch.nn.Module:
     """Instantiate a model from its ``MODEL_CONFIGS`` entry."""
     target = model_cfg["_target_"]
     module_name, class_name = target.rsplit(".", 1)
@@ -82,7 +82,7 @@ def instantiate_model(model_cfg: dict, num_channels: int) -> torch.nn.Module:
     cls = getattr(module, class_name)
 
     kwargs = {k: v for k, v in model_cfg.items() if k not in ("_target_", "name")}
-    kwargs["num_channels"] = num_channels
+    kwargs["bands"] = bands
     return cls(**kwargs)
 
 
@@ -146,6 +146,13 @@ def run_dataset(
         logger.info("Resume: %d existing rows for %s", len(completed), dataset_name)
 
     logger.info("Loading %s dataset...", dataset_name)
+    bench = get_bench_dataset_class(dataset_name)()
+    if bench.multilabel:
+        logger.info(
+            "=== %s === skipping (multi-label not supported by this comparison)", dataset_name
+        )
+        return all_rows
+    bands_list = bench.select_band_specs(tuple(bench.rgb_bands))
     train_dataset, train_loader, val_loader, test_loader = get_datasets(
         dataset_name=dataset_name,
         partition_name="default",
@@ -155,6 +162,9 @@ def run_dataset(
         interpolation="bilinear",
     )
     num_channels = train_dataset[0]["image"].shape[0]
+    assert len(bands_list) == num_channels, (
+        f"BandSpec count {len(bands_list)} != tensor channel count {num_channels} for {dataset_name}"
+    )
 
     for model_name, model_cfg in MODEL_CONFIGS.items():
         remaining = [
@@ -180,7 +190,7 @@ def run_dataset(
         )
 
         logger.info("  Loading model %s...", model_name)
-        model = instantiate_model(model_cfg, num_channels)
+        model = instantiate_model(model_cfg, bands_list)
         model.to(device).eval()
 
         logger.info("  Extracting features...")


### PR DESCRIPTION
## Symptom

Two of the in-process experiment scripts crashed at model instantiation:

\`\`\`
$ python experiments/run_c_sweep_experiment.py --devices 0
[INFO] === m-bigearthnet/resnet18 ===
[INFO]   Loading model resnet18...
TypeError: TimmPatchBenchModel.__init__() missing 1 required positional argument: 'bands'
\`\`\`

## Root cause

\`run_c_sweep_experiment.py\` and \`run_effect_of_lbfgs_vs_adam.py\` were written against the older \`BenchModel(num_channels: int)\` constructor. After the API was refactored to \`BenchModel(bands: list[BandSpec])\` (so each input channel carries its own mean/std for normalisation), both scripts kept passing \`num_channels=N\` into \`**_kwargs\` and \`super().__init__()\` was called with no \`bands\` arg.

The CLI (\`torchgeo-bench run\`) and the cls_token / main_experiments scripts go through \`main.py\` which already does the band resolution, so they were unaffected.

## Fix

Same shape in both scripts:

- Resolve the dataset's \`BandSpec\` list via the \`BenchDataset\` registry — \`get_bench_dataset_class(name)().select_band_specs(tuple(bench.rgb_bands))\` — and forward it through \`instantiate_model\` → \`super().__init__(bands=bands)\`.
- Skip multilabel datasets (today: just \`m-bigearthnet\`) up front with a logged warning. Both scripts use single-label \`LogisticRegression\` + \`accuracy_score\` and would crash again post-bands-fix on multilabel \`y\`.

The lbfgs_vs_adam edits were already in the working tree as an uncommitted local change matching this same fix; bundling them with the c_sweep fix since they're the same API drift in two siblings.

## Verification

Ran on GPU 0 (V100):

- m-bigearthnet → correctly skipped with \"single-label only\" warning.
- m-brick-kiln → 5/5 models, 41 C values each, 205 rows.
- m-eurosat → 5/5 models, 41 C values each, 205 rows.
- m-forestnet → 2/5 models complete when I stopped the long-running process; same loop as the prior datasets.

Best test accuracies (best-val C):

| dataset       | model                  | best C  | test acc |
|---------------|------------------------|---------|---------:|
| m-brick-kiln  | dinov3sat              | 2.42    |  0.973   |
| m-brick-kiln  | dinov3                 | 0.49    |  0.964   |
| m-brick-kiln  | resnet50               | 0.49    |  0.957   |
| m-brick-kiln  | convnext_large_dinov3  | 0.020   |  0.967   |
| m-brick-kiln  | resnet18               | 0.020   |  0.962   |
| m-eurosat     | dinov3                 | 0.49    |  0.962   |
| m-eurosat     | dinov3sat              | 7.02    |  0.958   |
| m-eurosat     | resnet50               | 34.6    |  0.944   |
| m-eurosat     | convnext_large_dinov3  | 0.058   |  0.935   |
| m-eurosat     | resnet18               | 4.12    |  0.925   |

\`ruff check\` + \`ruff format\` clean on \`experiments/\`.