### PR TITLE
Fix V2 DataLoading

### DIFF
--- a/src/torchgeo_bench/datasets/geobench_v2.py
+++ b/src/torchgeo_bench/datasets/geobench_v2.py
@@ -169,9 +169,9 @@ class _V2Dataset(BenchDataset):
         canonicalize = self.canonicalize_sample
 
         def chained(sample: dict) -> dict:
-            sample = canonicalize(sample)    # rename image_b → "image" first
+            sample = canonicalize(sample)  # rename image_b → "image" first
             if transform is not None:
-                sample = transform(sample)   # _resize now finds "image" safely
+                sample = transform(sample)  # _resize now finds "image" safely
             return sample
 
         kwargs: dict[str, object] = {"data_normalizer": nn.Identity}

--- a/src/torchgeo_bench/datasets/geobench_v2.py
+++ b/src/torchgeo_bench/datasets/geobench_v2.py
@@ -6,6 +6,7 @@ the matching ``geobench_v2.datasets.GeoBench<X>`` upstream class.
 """
 
 import logging
+import os
 from collections.abc import Callable
 from pathlib import Path
 from typing import Literal
@@ -18,7 +19,7 @@ from .base import BenchDataset
 
 logger = logging.getLogger(__name__)
 
-V2_ROOT = Path("data/geobenchv2")
+V2_ROOT = Path(os.environ.get("GEOBENCH_V2_ROOT", "data/geobenchv2"))
 
 
 # Map dataset name → upstream class name on ``geobench_v2.datasets``.
@@ -168,9 +169,10 @@ class _V2Dataset(BenchDataset):
         canonicalize = self.canonicalize_sample
 
         def chained(sample: dict) -> dict:
+            sample = canonicalize(sample)    # rename image_b → "image" first
             if transform is not None:
-                sample = transform(sample)
-            return canonicalize(sample)
+                sample = transform(sample)   # _resize now finds "image" safely
+            return sample
 
         kwargs: dict[str, object] = {"data_normalizer": nn.Identity}
         if self.band_order_strategy == "by_sensor":


### PR DESCRIPTION
I think the order has to be switched around, because the transforms are already expecting our canonical naming scheme, for example `fotw` dataset. Also add ENV variable for V2 datasets.