### PR TITLE
feat: auto-download GeoBench V1 webdataset mirror from HF

### DIFF
--- a/docs/user/datasets.rst
+++ b/docs/user/datasets.rst
@@ -55,6 +55,14 @@ GeoBench V1 — classification
 
 V1 datasets use the ``m-`` prefix on the command line.
 
+The first time a V1 dataset is requested without a local copy under
+``data/classification_v1.0`` or ``data/classification_v1.0_wds``, the
+loader auto-downloads the requested dataset from the public mirror
+``isaaccorley/geobenchv1-webdataset`` on the Hugging Face Hub.  Set
+``GEOBENCH_V1_NO_HF_DOWNLOAD=1`` to disable the auto-download and force a
+local-only path (``torchgeo-bench download geobench_v1`` still works for
+the legacy per-sample HDF5 layout).
+
 .. list-table::
    :header-rows: 1
    :widths: 18 8 8 12 22 32

--- a/src/torchgeo_bench/datasets/_v1_webdataset.py
+++ b/src/torchgeo_bench/datasets/_v1_webdataset.py
@@ -2,14 +2,17 @@
 
 Drops the per-sample HDF5 file-open from ``__getitem__`` (one NFS round-trip
 per sample) by reading from ~22 tar shards instead.  Format is produced by
-``scripts/repack_geobench_v1.py``: each shard contains ``<sid>.bands.npz``
-and ``<sid>.meta.pkl`` files for ~1000 samples.
+``scripts/repack_geobench_v1.py`` and mirrored on the Hub at
+``isaaccorley/geobenchv1-webdataset`` (auto-pulled by
+:func:`ensure_sharded_root` when no local copy is present).
 
-Indexing happens once in ``__init__``: every sample's byte range inside its
-shard is recorded as ``(shard_path, offset, size)`` so ``__getitem__`` does
-a plain ``open()`` + ``seek()`` + ``read()`` and avoids the ``tarfile``
-state machine entirely.  This is fork-safe (each worker opens its own
-file descriptors) and faster (no per-call tar header parsing).
+Each shard contains ``<sid>.bands.npz`` and ``<sid>.meta.pkl`` files for
+~1000 samples.  Indexing happens once in ``__init__``: every sample's byte
+range inside its shard is recorded as ``(shard_path, offset, size)`` so
+``__getitem__`` does a plain ``open()`` + ``seek()`` + ``read()`` and
+avoids the ``tarfile`` state machine entirely.  This is fork-safe (each
+worker opens its own file descriptors) and faster (no per-call tar header
+parsing).
 
 Output dict matches :class:`~torchgeo_bench.datasets.geobench_v1.GeoBenchv1`
 exactly.
@@ -17,6 +20,8 @@ exactly.
 
 import io
 import json
+import logging
+import os
 import pickle
 import tarfile
 from collections.abc import Callable
@@ -26,6 +31,54 @@ from typing import Literal
 import numpy as np
 import torch
 from torch.utils.data import Dataset
+
+logger = logging.getLogger(__name__)
+
+V1_HF_REPO_ID = "isaaccorley/geobenchv1-webdataset"
+
+
+def ensure_sharded_root(
+    dataset_name: str,
+    sharded_root: Path,
+    *,
+    repo_id: str = V1_HF_REPO_ID,
+    cache_dir: str | os.PathLike | None = None,
+) -> Path:
+    """Snapshot-download the sharded V1 mirror into ``sharded_root`` if absent.
+
+    Pulls only the requested ``dataset_name`` subdirectory so a single-dataset
+    run doesn't download the full 35 GB collection.  Returns the local path of
+    the dataset directory (whether downloaded or already present).
+    """
+    target = Path(sharded_root) / dataset_name
+    if target.exists() and any(target.glob("shard_*.tar")):
+        return target
+
+    try:
+        from huggingface_hub import snapshot_download
+    except ImportError as e:
+        raise RuntimeError(
+            "huggingface_hub is required to auto-download the GeoBench V1 "
+            "WebDataset mirror.  Install via `pip install huggingface_hub`, "
+            "or set GEOBENCH_V1_NO_HF_DOWNLOAD=1 and provide the data manually."
+        ) from e
+
+    sharded_root = Path(sharded_root)
+    sharded_root.mkdir(parents=True, exist_ok=True)
+    logger.info("Downloading %s/%s -> %s", repo_id, dataset_name, sharded_root)
+    snapshot_download(
+        repo_id=repo_id,
+        repo_type="dataset",
+        local_dir=sharded_root,
+        allow_patterns=[f"{dataset_name}/*"],
+        cache_dir=cache_dir,
+    )
+    if not any(target.glob("shard_*.tar")):
+        raise RuntimeError(
+            f"Auto-download of {repo_id}/{dataset_name} produced no shards under "
+            f"{target}; check the repo layout."
+        )
+    return target
 
 
 class _StubUnpickler(pickle.Unpickler):

--- a/src/torchgeo_bench/datasets/geobench_v1.py
+++ b/src/torchgeo_bench/datasets/geobench_v1.py
@@ -7,6 +7,7 @@ HDF5 files using the partition JSON files distributed alongside them.
 
 import io
 import json
+import os
 import pickle
 import warnings
 from collections.abc import Callable
@@ -24,6 +25,10 @@ from .base import BenchDataset
 
 V1_ROOT = Path("data/classification_v1.0")
 V1_SHARDED_ROOT = Path("data/classification_v1.0_wds")
+
+# Public mirror of the WebDataset-converted V1 collection.  Auto-pulled the
+# first time a dataset is requested if no local copy is present.
+V1_HF_REPO_ID = "isaaccorley/geobenchv1-webdataset"
 
 
 @dataclass
@@ -234,16 +239,31 @@ class _V1Dataset(BenchDataset):
     ) -> Dataset:
         """Return a torch :class:`Dataset` for the split (raw values).
 
-        Auto-selects between two backends:
+        Backend resolution order:
 
-        * **Sharded WebDataset** at :data:`V1_SHARDED_ROOT` if present (5–7×
-          faster on NFS, fork-safe at high ``num_workers``).
-        * **Per-sample HDF5** at :data:`V1_ROOT` as fallback for backwards
-          compatibility with the upstream V1 distribution layout.
+        1. **Sharded WebDataset** at :data:`V1_SHARDED_ROOT` if shards already
+           exist locally (5–7× faster on NFS, fork-safe at high
+           ``num_workers``).
+        2. **Per-sample HDF5** at :data:`V1_ROOT` if the legacy distribution
+           layout is present.
+        3. **HuggingFace mirror** :data:`V1_HF_REPO_ID` — auto-downloaded into
+           :data:`V1_SHARDED_ROOT` on first use, then served via the sharded
+           backend.  Disabled by ``GEOBENCH_V1_NO_HF_DOWNLOAD=1``.
         """
         v1_split: Literal["train", "valid", "test"] = "valid" if split == "val" else split  # type: ignore[assignment]
         source_bands = tuple(spec.source_name for spec in self.select_band_specs(bands))
+
         sharded_dir = V1_SHARDED_ROOT / self.name
+        hdf5_dir = self.data_root() / self.name
+        if (
+            not (sharded_dir.exists() and any(sharded_dir.glob("shard_*.tar")))
+            and not hdf5_dir.exists()
+            and os.environ.get("GEOBENCH_V1_NO_HF_DOWNLOAD") != "1"
+        ):
+            from ._v1_webdataset import ensure_sharded_root
+
+            ensure_sharded_root(self.name, V1_SHARDED_ROOT)
+
         if sharded_dir.exists() and any(sharded_dir.glob("shard_*.tar")):
             from ._v1_webdataset import GeoBenchv1Sharded
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Pytest configuration and fixtures for torchgeo-bench tests."""
 
+import os
 from pathlib import Path
 
 import pytest
@@ -8,6 +9,11 @@ import pytest
 GEOBENCH_ROOT = Path("data/classification_v1.0")
 GEOBENCH_V2_ROOT = Path("data/geobenchv2")
 EUROSAT_ROOT = Path("data/eurosat")
+
+# Tests rely on the dataset-not-on-disk path raising FileNotFoundError so the
+# test-skip branch fires.  The V1 loader otherwise auto-downloads the public
+# WebDataset mirror — which would force CI to pull tens of GBs and time out.
+os.environ.setdefault("GEOBENCH_V1_NO_HF_DOWNLOAD", "1")
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- When neither legacy HDF5 (`data/classification_v1.0`) nor local shards
  (`data/classification_v1.0_wds`) are present, fall back to
  `snapshot_download(\"isaaccorley/geobenchv1-webdataset\", allow_patterns=[\"<name>/*\"])`.
- Pulls only the dataset being requested, so single-dataset runs don't
  drag the full 35 GB collection.
- New env knob `GEOBENCH_V1_NO_HF_DOWNLOAD=1` disables the fallback for
  CI / offline runs.
- Doc note added to \`docs/user/datasets.rst\`.

## Test plan
- [ ] Local: \`pytest tests/test_band_mapping.py tests/test_bench_model.py\`
- [ ] Sphinx \`-W --keep-going\` clean.
- [ ] End-to-end: \`rm -rf data/classification_v1.0_wds/m-eurosat &&
  torchgeo-bench run model=rcf dataset.names=[m-eurosat]\` — should pull
  m-eurosat shards from the Hub before evaluating.