### PR TITLE
fix(explorer): per-dataset auto-range + V1/V2 labels on leaderboard

### DIFF
--- a/docs/_static/results-explorer.html
+++ b/docs/_static/results-explorer.html
@@ -612,17 +612,34 @@ const PLOTLY_LAYOUT_BASE = {
 };
 const PLOTLY_CONFIG = { responsive: true, displaylogo: false, modeBarButtonsToRemove: ["lasso2d", "select2d"] };
 
+// V1 datasets are prefixed with "m-"; everything else under
+// torchgeo_bench.datasets is V2.  EuroSAT (the torchgeo wrapper) is its own
+// thing and gets a separate label.
+function _datasetLabel(ds) {
+  if (ds.startsWith("m-")) return `GeoBench V1 · ${ds}`;
+  if (ds === "eurosat") return `EuroSAT (torchgeo)`;
+  return `GeoBench V2 · ${ds}`;
+}
+
 function renderLeaderboard(data) {
   const method = document.getElementById("leaderboard-method").value;
   const topn = parseInt(document.getElementById("leaderboard-topn").value, 10);
   const datasets = uniqSorted(data.map(r => r.dataset));
+  const perDatasetRows = datasets
+    .map(ds => {
+      let rows = data.filter(r => r.dataset === ds && r.method === method);
+      rows.sort((a, b) => b.metric_value - a.metric_value);
+      if (topn > 0) rows = rows.slice(0, topn);
+      return { ds, rows };
+    })
+    .filter(d => d.rows.length);
+
   const traces = [];
-  datasets.forEach((ds, i) => {
-    let rows = data.filter(r => r.dataset === ds && r.method === method);
-    rows.sort((a, b) => b.metric_value - a.metric_value);
-    if (topn > 0) rows = rows.slice(0, topn);
-    rows.reverse();
-    if (!rows.length) return;
+  const ranges = [];
+  perDatasetRows.forEach(({ ds, rows: sortedDesc }, i) => {
+    // Plotly's horizontal bars place `y[0]` at the bottom; reverse the sorted
+    // list so the highest-scoring entry sits at the top of the subplot.
+    const rows = sortedDesc.slice().reverse();
     const labels = rows.map(r => `${r.name} · ${r.normalization}`);
     const vals = rows.map(r => r.metric_value);
     const lo = rows.map(r => r.metric_value - r.ci_lower);
@@ -633,28 +650,41 @@ function renderLeaderboard(data) {
       error_x: { type: "data", array: hi, arrayminus: lo, color: "#66605c", thickness: 1, width: 4 },
       marker: { color: PALETTE[i % PALETTE.length], line: { color: "#262a33", width: 0.5 } },
       name: ds, xaxis: `x${i+1}`, yaxis: `y${i+1}`,
-      hovertemplate: "%{y}<br>accuracy=%{x:.4f}<extra>"+ds+"</extra>",
+      hovertemplate: "%{y}<br>value=%{x:.4f}<extra>"+ds+"</extra>",
     });
+    // Auto-range per subplot: when scores are saturated near 1.0 a fixed
+    // [0, 1] axis collapses all the differences visually.  Centre on the
+    // observed range with a 5pp margin (and a floor at 0.05 so very low
+    // values still get a visible bar).
+    const minV = Math.min(...vals, ...rows.map(r => r.ci_lower));
+    const maxV = Math.max(...vals, ...rows.map(r => r.ci_upper));
+    const span = Math.max(maxV - minV, 0.05);
+    const pad = span * 0.1;
+    const xLo = Math.max(0, minV - pad - 0.02);
+    const xHi = Math.min(1.02, maxV + pad + 0.02);
+    ranges.push([xLo, xHi]);
   });
-  const cols = Math.min(datasets.length, 2);
-  const rows = Math.ceil(datasets.length / cols);
-  // Drop the base `xaxis`/`yaxis` from the spread so they don't alias `xaxis1`
-  // / `yaxis1` (Plotly treats `xaxisN` and `xaxis` as the same axis when N=1,
-  // and the unstyled base would otherwise win for the first subplot).
+
+  const cols = Math.min(perDatasetRows.length, 2);
+  const rows = Math.ceil(perDatasetRows.length / cols);
   const { xaxis: _bx, yaxis: _by, ...layoutBase } = PLOTLY_LAYOUT_BASE;
   const layout = {
     ...layoutBase,
     height: rows * 380 + 80,
     showlegend: false,
     grid: { rows, columns: cols, pattern: "independent" },
-    annotations: datasets.map((ds, i) => ({
-      text: `<b>${ds}</b>`, showarrow: false, x: 0, y: 1.0,
+    annotations: perDatasetRows.map(({ ds }, i) => ({
+      text: `<b>${_datasetLabel(ds)}</b>`, showarrow: false, x: 0, y: 1.0,
       xref: `x${i+1} domain`, yref: `y${i+1} domain`, yanchor: "bottom", xanchor: "left",
       font: { color: "#262a33", size: 13, family: "Inter, sans-serif" },
     })),
   };
-  for (let i = 1; i <= datasets.length; i++) {
-    layout[`xaxis${i}`] = { ...PLOTLY_LAYOUT_BASE.xaxis, title: { text: "accuracy", font: { size: 11 } }, range: [0, 1.02] };
+  for (let i = 1; i <= perDatasetRows.length; i++) {
+    layout[`xaxis${i}`] = {
+      ...PLOTLY_LAYOUT_BASE.xaxis,
+      title: { text: "score", font: { size: 11 } },
+      range: ranges[i - 1],
+    };
     layout[`yaxis${i}`] = { ...PLOTLY_LAYOUT_BASE.yaxis, automargin: true, tickfont: { size: 10 } };
   }
   Plotly.react("chart-leaderboard", traces, layout, PLOTLY_CONFIG);

--- a/docs/user/datasets.rst
+++ b/docs/user/datasets.rst
@@ -133,9 +133,23 @@ required for the sweep.
 
 .. note::
 
-   ``m-forestnet`` and ``forestnet`` are *different* datasets.  V1 uses
-   Landsat with 6 bands; V2 uses Sentinel-2 with the same number of
-   bands but a different sensor and split.
+   V1 and V2 share several CLI names but the underlying data are
+   *different* datasets — different sensors, splits, label spaces, or
+   normalisation conventions:
+
+   * ``m-bigearthnet`` (V1) — original BigEarthNet, 43-class
+     **multilabel** scene tags, S2 top-of-atmosphere DN.
+     ``benv2`` (V2) — BigEarthNet v2.0 with 19-class multilabel and
+     stacked S1 + S2.
+   * ``m-so2sat`` (V1) — 18-band stack including LCZ context.
+     ``so2sat`` (V2) — 10 S2 + 2 S1 bands stored at reflectance scale.
+   * ``m-forestnet`` (V1) — Landsat-8 6-band uint8.
+     ``forestnet`` (V2) — Sentinel-2 6-band uint8 with a different split
+     than V1 despite the same channel count.
+
+   The leaderboard prefixes panel titles with ``GeoBench V1`` /
+   ``GeoBench V2`` so V1 and V2 results are never compared on the same
+   axis.
 
 GeoBench V2 — segmentation
 --------------------------


### PR DESCRIPTION
## Summary
Two issues you flagged on Figure 1 (per-dataset leaderboard):

1. **Bars looked unsorted on saturated datasets.** The x-axis was hardcoded \`[0, 1.02]\`, so for datasets like m-brick-kiln where the top-10 linear-probe scores all sit in 0.95-0.97, every bar rendered at indistinguishable lengths even though the underlying sort was correct. Switched to per-subplot auto-range with a small margin so the score deltas are visible. Floor at 0 and a 5pp minimum span keep low-score datasets readable too.
2. **m-forestnet (V1, Landsat) and forestnet (V2, Sentinel-2) shared the same look at first glance.** Prefixed each subplot title with \`GeoBench V1 ·\` / \`GeoBench V2 ·\` (and \`EuroSAT (torchgeo)\` for the standalone wrapper) so reviewers can tell them apart at a glance.

The sort itself was already correct (\`b.metric_value - a.metric_value\` desc, then reverse for Plotly's bottom-up bar ordering); only the visualization was misleading.

## Test plan
- [ ] Open the rebuilt page in a browser, pick the 2026-05-09 snapshot, confirm:
  - m-brick-kiln linear top-10 panel now shows distinct bar lengths.
  - Title bar for forestnet reads \`GeoBench V2 · forestnet\` and m-forestnet reads \`GeoBench V1 · m-forestnet\`.
- [ ] Sphinx \`-W --keep-going\` clean.