### PR TITLE
fix: require segmentation feature layers

### DIFF
--- a/src/torchgeo_bench/conf/config.yaml
+++ b/src/torchgeo_bench/conf/config.yaml
@@ -42,7 +42,7 @@ eval:
 
   segmentation:
     head_type: "fpn"
-    layers: []
+    layers: []                 # must be overridden per model for segmentation datasets
     lr: 1e-3
     epochs: 10
     criterion:

--- a/src/torchgeo_bench/main.py
+++ b/src/torchgeo_bench/main.py
@@ -392,9 +392,15 @@ def _build_seg_probe_and_solver(
     Returns:
         Tuple of (probe, solver).
     """
+    layer_names = list(eval_cfg.segmentation.layers)
+    if not layer_names:
+        raise ValueError(
+            "Segmentation evaluation requires eval.segmentation.layers to name "
+            "spatial backbone layers. Refusing to probe the global backbone output."
+        )
     probe = SegmentationProbe(
         backbone=model,
-        layer_names=eval_cfg.segmentation.layers,
+        layer_names=layer_names,
         num_classes=num_classes,
         head_type=eval_cfg.segmentation.head_type,
         freeze_backbone=True,

--- a/tests/test_segmentation.py
+++ b/tests/test_segmentation.py
@@ -1,8 +1,10 @@
 import pytest
 import torch
 import torch.nn as nn
+from omegaconf import OmegaConf
 from torch.utils.data import DataLoader, TensorDataset
 
+from torchgeo_bench.main import _build_seg_probe_and_solver
 from torchgeo_bench.segmentation_probe import (
     CachedFeaturesDataset,
     GPUTensorCache,
@@ -103,6 +105,28 @@ def test_probe_unknown_head_type(mock_backbone):
     with pytest.raises(ValueError, match="Unknown head_type"):
         SegmentationProbe(
             backbone=mock_backbone, layer_names=["layer1"], num_classes=2, head_type="invalid_type"
+        )
+
+
+def test_build_seg_probe_requires_spatial_layers(mock_backbone):
+    """Segmentation evaluation refuses the global-output fallback."""
+    eval_cfg = OmegaConf.create(
+        {
+            "segmentation": {
+                "layers": [],
+                "head_type": "fpn",
+                "criterion": {"_target_": "torch.nn.CrossEntropyLoss", "ignore_index": 255},
+                "lr_scheduler": "none",
+            }
+        }
+    )
+    with pytest.raises(ValueError, match="requires eval.segmentation.layers"):
+        _build_seg_probe_and_solver(
+            mock_backbone,
+            num_classes=NUM_CLASSES,
+            eval_cfg=eval_cfg,
+            device=torch.device("cpu"),
+            lr=1e-3,
         )
 
 


### PR DESCRIPTION
## Summary
- reject segmentation runs without configured spatial feature layers
- note in the default config that segmentation layers must be model-specific
- add coverage for the guard

## Tests
- uv run pytest --no-cov tests/test_segmentation.py -q