### PR TITLE
fix: detect torchgeo input unit mismatches

### DIFF
--- a/src/torchgeo_bench/models/torchgeo_models.py
+++ b/src/torchgeo_bench/models/torchgeo_models.py
@@ -32,7 +32,7 @@ from torchvision.transforms.v2 import Normalize as NormalizeV2
 
 from torchgeo_bench.datasets.base import BandSpec
 
-from ._input_units import InputUnit
+from ._input_units import InputUnit, detect_input_unit
 from .interface import BenchModel
 
 logger = logging.getLogger(__name__)
@@ -144,6 +144,12 @@ _UNIT_EXPECTED_MEAN: dict[str, tuple[float, float]] = {
     "s2_dn_div10000": (0.0, 10000.0),
 }
 
+_UNIT_EXPECTED_SOURCE: dict[str, InputUnit] = {
+    "uint8_div255": InputUnit.UINT8,
+    "reflectance_0_1": InputUnit.REFLECTANCE_0_1,
+    "s2_dn_div10000": InputUnit.S2_DN,
+}
+
 
 def _warn_unit_mismatch(
     cls_name: str,
@@ -162,6 +168,19 @@ def _warn_unit_mismatch(
             ``"ignore"`` is silent.
     """
     if check == "ignore" or weights_input_unit is None:
+        return
+    expected_unit = _UNIT_EXPECTED_SOURCE.get(weights_input_unit)
+    detected_unit = detect_input_unit(bands)
+    if expected_unit is not None and detected_unit != expected_unit:
+        msg = (
+            f"{cls_name}: pretrained weights expect {weights_input_unit!r} inputs "
+            f"({expected_unit.value}), but selected bands look like {detected_unit.value}: "
+            f"{[(b.name, b.mean, b.max) for b in bands[:5]]}"
+            f"{'...' if len(bands) > 5 else ''}. Embeddings may be poorly scaled."
+        )
+        if check == "error":
+            raise RuntimeError(msg)
+        warnings.warn(msg, UserWarning, stacklevel=3)
         return
     expected = _UNIT_EXPECTED_MEAN.get(weights_input_unit)
     if expected is None:

--- a/tests/test_torchgeo_unit_check.py
+++ b/tests/test_torchgeo_unit_check.py
@@ -1,0 +1,37 @@
+"""Tests for torchgeo pretrained input-unit plausibility checks."""
+
+import warnings
+
+import pytest
+
+from torchgeo_bench.datasets.m_eurosat import MEurosat
+from torchgeo_bench.datasets.m_so2sat import MSo2Sat
+from torchgeo_bench.models.torchgeo_models import _warn_unit_mismatch
+
+
+def _bands(cls, names: tuple[str, ...]):
+    by_name = {b.name: b for b in cls.bands}
+    return [by_name[name] for name in names]
+
+
+def test_s2_dn_weights_warn_on_reflectance_dataset() -> None:
+    """Reflectance-scale So2Sat must not pass as raw Sentinel-2 DN."""
+    bands = _bands(MSo2Sat, ("red", "green", "blue"))
+    with pytest.warns(UserWarning, match="look like reflectance_0_1"):
+        _warn_unit_mismatch("Demo", "s2_dn_div10000", bands, "warn")
+
+
+def test_s2_dn_weights_accept_raw_s2_dataset() -> None:
+    """Raw Sentinel-2 DN datasets remain accepted for /10000 torchgeo weights."""
+    bands = _bands(MEurosat, ("red", "green", "blue"))
+    with warnings.catch_warnings(record=True) as records:
+        warnings.simplefilter("always")
+        _warn_unit_mismatch("Demo", "s2_dn_div10000", bands, "warn")
+    assert records == []
+
+
+def test_unit_mismatch_error_mode_raises() -> None:
+    """input_unit_check=error turns the plausibility warning into a hard failure."""
+    bands = _bands(MSo2Sat, ("red", "green", "blue"))
+    with pytest.raises(RuntimeError, match="look like reflectance_0_1"):
+        _warn_unit_mismatch("Demo", "s2_dn_div10000", bands, "error")


### PR DESCRIPTION
## Summary
- compare detected dataset input units against torchgeo weights expectations
- warn or error when reflectance inputs are paired with raw-DN pretrained transforms
- add focused coverage for So2Sat reflectance and EuroSAT raw DN cases

## Tests
- uv run pytest --no-cov tests/test_torchgeo_unit_check.py -q