### PR TITLE
fix: handle KuroSiwo resize and channel dry runs

### DIFF
--- a/src/torchgeo_bench/datasets/kuro_siwo.py
+++ b/src/torchgeo_bench/datasets/kuro_siwo.py
@@ -62,9 +62,10 @@ class KuroSiwo(_V2Dataset):
         canonicalize = self.canonicalize_sample
 
         def chained(sample: dict) -> dict:
+            sample = canonicalize(sample)
             if transform is not None:
                 sample = transform(sample)
-            return canonicalize(sample)
+            return sample
 
         return GeoBenchv2(
             root=self.data_root(),

--- a/src/torchgeo_bench/segmentation_probe.py
+++ b/src/torchgeo_bench/segmentation_probe.py
@@ -227,7 +227,8 @@ class SegmentationProbe(nn.Module):
 
     def _dry_run_channels(self) -> list[int]:
         device = self._backbone_device()
-        dummy = torch.randn(1, 3, 224, 224, device=device)
+        in_channels = int(getattr(self.backbone, "num_channels", 3))
+        dummy = torch.randn(1, in_channels, 224, 224, device=device)
         if not self.layer_names:
             self.layer_names = ["backbone_output"]
             self.hooks.append(self.backbone.register_forward_hook(self._hook_fn("backbone_output")))

--- a/tests/test_geobench_v2_datasets.py
+++ b/tests/test_geobench_v2_datasets.py
@@ -298,6 +298,20 @@ class TestKuroSiwoCanonicalization:
         assert torch.allclose(img[:2], torch.full_like(img[:2], 3.0))
         assert torch.allclose(img[2:], torch.full_like(img[2:], 99.0))
 
+    def test_resize_runs_after_canonicalization(self, mocked_kuro_siwo):
+        """Framework transforms must see the folded ``image`` key."""
+        del mocked_kuro_siwo
+        _, train_dl, _ = get_datasets(
+            dataset_name="kuro_siwo",
+            bands=("vv", "vh"),
+            image_size=32,
+            batch_size=2,
+            num_workers=0,
+        )
+        batch = next(iter(train_dl))
+        assert batch["image"].shape[-2:] == (32, 32)
+        assert batch["mask"].shape[-2:] == (32, 32)
+
 
 @pytest.mark.slow
 class TestKuroSiwoLive:

--- a/tests/test_segmentation.py
+++ b/tests/test_segmentation.py
@@ -57,6 +57,19 @@ class ViTBackbone(nn.Module):
         return x
 
 
+class TwoChannelBackbone(nn.Module):
+    """Backbone with a BenchModel-like num_channels attribute."""
+
+    num_channels = 2
+
+    def __init__(self):
+        super().__init__()
+        self.conv = nn.Conv2d(2, 8, kernel_size=3, padding=1)
+
+    def forward(self, x):
+        return self.conv(x).mean(dim=(-2, -1))
+
+
 @pytest.fixture
 def mock_backbone():
     return MockBackbone()
@@ -291,6 +304,15 @@ def test_probe_vit_token_features():
     # 'blocks' is an Identity that passes through (B, L, C); hook it directly
     probe = make_probe(backbone, ["blocks"], head_type="linear")
     images = torch.randn(2, 3, 64, 64)
+    logits = probe(images)
+    assert logits.shape == (2, NUM_CLASSES, 64, 64)
+
+
+def test_probe_dry_run_uses_backbone_num_channels():
+    """Dry-run channel inference supports non-RGB benchmark models."""
+    backbone = TwoChannelBackbone()
+    probe = make_probe(backbone, [], head_type="linear")
+    images = torch.randn(2, 2, 64, 64)
     logits = probe(images)
     assert logits.shape == (2, NUM_CLASSES, 64, 64)
 


### PR DESCRIPTION
## Summary
- canonicalize KuroSiwo samples before framework image/mask transforms run
- dry-run segmentation probes with the backbone's declared channel count
- add focused tests for KuroSiwo resize and 2-channel probe dry-runs

## Tests
- uv run pytest --no-cov tests/test_geobench_v2_datasets.py::TestKuroSiwoCanonicalization tests/test_segmentation.py::test_probe_dry_run_uses_backbone_num_channels -q