### PR TITLE
fix: derive DOFA wavelengths from bands

### DIFF
--- a/src/torchgeo_bench/conf/model/torchgeo/dofa_base.yaml
+++ b/src/torchgeo_bench/conf/model/torchgeo/dofa_base.yaml
@@ -5,7 +5,6 @@ _target_: torchgeo_bench.models.TorchGeoDOFABench
 factory: dofa_base_patch16_224
 weights_class: DOFABase16_Weights
 weights_member: DOFA_MAE
-wavelengths: [0.665, 0.56, 0.49]
 auto_resize: true
 target_size: 224
 name: tgeo_dofa_base

--- a/src/torchgeo_bench/conf/model/torchgeo/dofa_large.yaml
+++ b/src/torchgeo_bench/conf/model/torchgeo/dofa_large.yaml
@@ -5,7 +5,6 @@ _target_: torchgeo_bench.models.TorchGeoDOFABench
 factory: dofa_large_patch16_224
 weights_class: DOFALarge16_Weights
 weights_member: DOFA_MAE
-wavelengths: [0.665, 0.56, 0.49]
 auto_resize: true
 target_size: 224
 name: tgeo_dofa_large

--- a/src/torchgeo_bench/models/torchgeo_models.py
+++ b/src/torchgeo_bench/models/torchgeo_models.py
@@ -379,25 +379,34 @@ class TorchGeoScaleMAEBench(_TorchGeoBackboneBench):
 # ---------------------------------------------------------------------------
 
 
+def _resolve_dofa_wavelengths(
+    bands: list[BandSpec],
+    wavelengths: list[float] | None,
+) -> list[float]:
+    """Return one DOFA wavelength per selected input channel."""
+    if wavelengths is not None:
+        if len(wavelengths) != len(bands):
+            raise ValueError(
+                f"DOFA wavelengths length {len(wavelengths)} must match "
+                f"selected channel count {len(bands)}."
+            )
+        return [float(w) for w in wavelengths]
+
+    from ._band_mapping import wavelengths_um
+
+    return wavelengths_um(bands, default_um=0.6)
+
+
 class TorchGeoDOFABench(_TorchGeoBackboneBench):
     """Wrapper for torchgeo DOFA models (dofa_base / dofa_large).
 
     DOFA requires a list of wavelengths (one per input channel in µm).
     ``forward_features(x, wavelengths)`` returns ``(B, D)``.
-
-    .. note::
-
-       The wavelength list is currently hard-coded to Sentinel-2 RGB
-       (``[0.665, 0.56, 0.49]``).  Plumbing per-band wavelengths from
-       :attr:`BenchModel.bands` is tracked in
-       `#15 <https://github.com/torchgeo/torchgeo-bench/issues/15>`_.
     """
 
     # No magnitude check — DOFA's pretrained transform is empty in current
     # torchgeo releases, and dataset units vary widely.
     weights_input_unit = None
-
-    S2_RGB_WAVELENGTHS: list[float] = [0.665, 0.56, 0.49]
 
     def __init__(
         self,
@@ -421,7 +430,7 @@ class TorchGeoDOFABench(_TorchGeoBackboneBench):
             target_size=target_size,
             input_unit_check=input_unit_check,
         )
-        self.wavelengths = wavelengths or self.S2_RGB_WAVELENGTHS
+        self.wavelengths = _resolve_dofa_wavelengths(bands, wavelengths)
 
     @torch.no_grad()
     def _forward_patch_features(

--- a/tests/test_band_mapping.py
+++ b/tests/test_band_mapping.py
@@ -8,6 +8,7 @@ from torchgeo_bench.models._band_mapping import (
     map_to_model_bands,
     wavelengths_um,
 )
+from torchgeo_bench.models.torchgeo_models import _resolve_dofa_wavelengths
 
 
 def _band(name: str, wl: float | None = None) -> BandSpec:
@@ -92,3 +93,17 @@ class TestWavelengthsUm:
         bands = [_band("red", 0.665), _band("vv", None)]
         wls = wavelengths_um(bands, default_um=1.5)
         assert wls == [0.665, 1.5]
+
+
+class TestDofaWavelengths:
+    def test_derived_from_selected_bands(self) -> None:
+        bands = [_band("red", 0.665), _band("green", 0.56), _band("nir", 0.842)]
+        assert _resolve_dofa_wavelengths(bands, None) == [0.665, 0.56, 0.842]
+
+    def test_manual_override_length_must_match_channels(self) -> None:
+        bands = [_band("red", 0.665), _band("green", 0.56)]
+        try:
+            _resolve_dofa_wavelengths(bands, [0.665, 0.56, 0.49])
+        except ValueError:
+            return
+        raise AssertionError("expected ValueError for DOFA wavelength/channel mismatch")


### PR DESCRIPTION
## Summary
- derive DOFA wavelengths from the selected BandSpec list by default
- remove RGB-only wavelength overrides from DOFA configs
- reject manual wavelength overrides whose length does not match the input channels

## Tests
- uv run pytest --no-cov tests/test_band_mapping.py -q