### PR TITLE
fix: align segmentation ignore index

### DIFF
--- a/src/torchgeo_bench/main.py
+++ b/src/torchgeo_bench/main.py
@@ -406,6 +406,7 @@ def _build_seg_probe_and_solver(
         freeze_backbone=True,
     )
     criterion = instantiate(eval_cfg.segmentation.criterion)
+    ignore_index = _resolve_segmentation_ignore_index(eval_cfg.segmentation, criterion)
     solver = SegmentationSolver(
         model=probe,
         num_classes=num_classes,
@@ -413,9 +414,24 @@ def _build_seg_probe_and_solver(
         device=str(device),
         criterion=criterion,
         lr_scheduler=eval_cfg.segmentation.get("lr_scheduler", "cosine"),
-        ignore_index=eval_cfg.segmentation.get("ignore_index", 255),
+        ignore_index=ignore_index,
     )
     return probe, solver
+
+
+def _resolve_segmentation_ignore_index(seg_cfg: DictConfig, criterion: torch.nn.Module) -> int:
+    """Resolve the ignore index shared by segmentation loss and metrics."""
+    explicit = seg_cfg.get("ignore_index", None)
+    criterion_value = getattr(criterion, "ignore_index", None)
+    if explicit is None:
+        return int(criterion_value) if criterion_value is not None else 255
+    if criterion_value is not None and int(criterion_value) != int(explicit):
+        raise ValueError(
+            "Segmentation ignore_index mismatch: "
+            f"eval.segmentation.ignore_index={explicit} but "
+            f"criterion.ignore_index={criterion_value}."
+        )
+    return int(explicit)
 
 
 def evaluate_intrinsic_dim(

--- a/tests/test_segmentation.py
+++ b/tests/test_segmentation.py
@@ -143,6 +143,51 @@ def test_build_seg_probe_requires_spatial_layers(mock_backbone):
         )
 
 
+def test_build_seg_solver_uses_criterion_ignore_index(mock_backbone):
+    """Metrics inherit the loss ignore_index when no separate override is set."""
+    eval_cfg = OmegaConf.create(
+        {
+            "segmentation": {
+                "layers": ["layer1"],
+                "head_type": "linear",
+                "criterion": {"_target_": "torch.nn.CrossEntropyLoss", "ignore_index": 7},
+                "lr_scheduler": "none",
+            }
+        }
+    )
+    _, solver = _build_seg_probe_and_solver(
+        mock_backbone,
+        num_classes=NUM_CLASSES,
+        eval_cfg=eval_cfg,
+        device=torch.device("cpu"),
+        lr=1e-3,
+    )
+    assert solver.ignore_index == 7
+
+
+def test_build_seg_solver_rejects_ignore_index_mismatch(mock_backbone):
+    """Loss and metric ignore indices must not silently diverge."""
+    eval_cfg = OmegaConf.create(
+        {
+            "segmentation": {
+                "layers": ["layer1"],
+                "head_type": "linear",
+                "ignore_index": 255,
+                "criterion": {"_target_": "torch.nn.CrossEntropyLoss", "ignore_index": 7},
+                "lr_scheduler": "none",
+            }
+        }
+    )
+    with pytest.raises(ValueError, match="ignore_index mismatch"):
+        _build_seg_probe_and_solver(
+            mock_backbone,
+            num_classes=NUM_CLASSES,
+            eval_cfg=eval_cfg,
+            device=torch.device("cpu"),
+            lr=1e-3,
+        )
+
+
 def test_probe_dry_run_exception_handling():
     """Test that dry_run_channels catches exceptions from the backbone."""
 


### PR DESCRIPTION
## Summary
- resolve one ignore_index value for segmentation loss and metrics
- inherit criterion.ignore_index when no separate segmentation override is set
- reject conflicting ignore_index settings instead of reporting mismatched metrics

## Tests
- uv run pytest --no-cov tests/test_segmentation.py -q