### PR TITLE
fix(datasets): treesatai num_classes 13 -> 15

### DIFF
--- a/src/torchgeo_bench/datasets/treesatai.py
+++ b/src/torchgeo_bench/datasets/treesatai.py
@@ -5,16 +5,19 @@ from .geobench_v2 import _V2Dataset
 
 
 class TreeSatAI(_V2Dataset):
-    """Aerial + Sentinel-2 + SAR tree species classification (13 classes).
+    """Aerial + Sentinel-2 + SAR tree species classification (15 classes).
 
     Multi-sensor dataset with aerial RGB+NIR, 12 Sentinel-2 bands, and 3 SAR bands.
+    Class indices follow the upstream ``GeoBenchTreeSatAI.classes`` ordering:
+    Abies, Acer, Alnus, Betula, Cleared, Fagus, Fraxinus, Larix, Picea, Pinus,
+    Populus, Prunus, Pseudotsuga, Quercus, Tilia.
     """
 
     band_order_strategy = "by_sensor"
 
     name = "treesatai"
     task = "classification"
-    num_classes = 13
+    num_classes = 15
     multilabel = True
     rgb_bands = ["red", "green", "blue"]
     split_sizes = {"train": 4000, "val": 1000, "test": 2000}


### PR DESCRIPTION
## Summary

`src/torchgeo_bench/datasets/treesatai.py` declared `num_classes = 13`, but the upstream `geobench_v2.datasets.GeoBenchTreeSatAI` exposes **15 classes** (14 European tree genera + `Cleared`). Label tensors emitted by the loader have always been 15-dim (multi-hot, matching upstream); only our wrapper metadata was stale.

```
0 Abies   1 Acer    2 Alnus    3 Betula  4 Cleared
5 Fagus   6 Fraxinus 7 Larix   8 Picea   9 Pinus
10 Populus 11 Prunus 12 Pseudotsuga 13 Quercus 14 Tilia
```

## Impact

- **Classification probes**: unaffected. `LogisticRegression.fit` infers output dim from the label tensor, so prior runs trained 15-class probes regardless of `num_classes`.
- **Segmentation**: would have been wrong, but treesatai is classification-only — never reached.
- **Downstream tooling** that reads `ds_cls.num_classes` for visualization or class-name lookup was off by 2.

No saved results need re-running.

## How it surfaced

Found while running per-class label-quality audits on GeoBench V2 multi-label datasets — saw 15 columns in the saved probability matrix vs 13 declared classes, traced to upstream.

## Test plan

- [x] `pytest tests/ -k tree` — passes (split-size assertion already correct)
- [x] Verify `TreeSatAI().num_classes == 15` and `multilabel == True`
- [x] `get_datasets("treesatai", ...)` still returns 15-dim label vectors (unchanged)