### PR TITLE
feat: cleanlab label-quality audit for GeoBench V1+V2 classification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,11 +6,19 @@ scripts/*
 !scripts/tune_dataloader.py
 !scripts/regen_results_explorer.py
 !scripts/test_knn_gpu_smoke.py
+!scripts/cleanlab_extract_probs.py
+!scripts/run_cleanlab_audit.py
+!scripts/render_flagged_gallery.py
+!scripts/eurosat_family_dedup.py
+!scripts/cleanlab_per_class_multilabel.py
+!scripts/cleanlab_per_class_singlelabel.py
 !scripts/slurm/
 scripts/slurm/*
 !scripts/slurm/build_probe_jobs.py
 !scripts/slurm/probe_sweep.sh
 !scripts/slurm/knn_gpu_smoke.sh
+!scripts/slurm/cleanlab_audit.sh
+!scripts/slurm/cleanlab_audit.jobs
 figures/
 
 # Python

--- a/docs/perf_report/cleanlab_audit_geobench.md
+++ b/docs/perf_report/cleanlab_audit_geobench.md
@@ -1,0 +1,299 @@
+# GeoBench Cleanlab Audit — Initial Report
+
+Audit of label quality and class structure across all GeoBench V1 + V2
+classification datasets plus `eurosat-spatial`. The goal is to separate
+"models are getting better" from "the eval is the bottleneck."
+
+## Methodology
+
+For each of 11 classification datasets, we picked the top-1 linear-probe
+result from `results/all_results.csv` (filtering out legacy rows with
+deprecated `normalization=raw`), rebuilt that exact `(model, dataset, bands,
+normalization, image_size, partition)` configuration, and:
+
+1. Extracted train + test embeddings from the frozen backbone.
+2. Fit a logistic regression on `train+val` at the recorded best `C`.
+3. Predicted softmax probabilities on train and test.
+4. Ran cleanlab's `find_label_issues` (single-label) or
+   `find_multilabel_issues_per_class` (multi-label) on the predicted probs.
+5. Computed per-class statistics: accuracy / AP, flag rate, top-confused
+   class, Jaccard with neighbouring classes (multi-label only).
+
+Outputs are saved as:
+
+- `results/cleanlab/probs/<dataset>__<model>_{train,test}.npz` — labels +
+  predicted probs.
+- `results/cleanlab/<dataset>_{train,test}.csv` — per-sample issue scores.
+- `results/cleanlab/perclass_<dataset>_<split>.csv` — per-class breakdown.
+- `results/cleanlab/summary.csv` — aggregate noise rates.
+
+### Top-1 model per dataset
+
+| Dataset | Model | Linear-probe acc/mAP | Bands | Norm |
+|---|---|---:|---|---|
+| m-eurosat | tgeo_panopticon | 0.969 | rgb | model_native |
+| m-bigearthnet | tt_terramind_v1_large | 0.751 (mAP) | all | bandspec_zscore |
+| m-brick-kiln | tt_clay_v1_5_base | 0.975 | rgb | minmax |
+| m-pv4ger | tgeo_panopticon | 0.968 | rgb | bandspec_zscore |
+| m-so2sat | tt_terramind_v1_base | 0.741 | all | bandspec_zscore |
+| m-forestnet | tt_terramind_v1_large | 0.571 | all | minmax_zscore |
+| benv2 | tt_terramind_v1_large | 0.846 (mAP) | all | bandspec_zscore |
+| treesatai | tt_clay_v1_5_base | 0.674 (mAP) | all | bandspec_zscore |
+| so2sat (V2) | tt_terramind_v1_base | 0.741 | all | bandspec_zscore |
+| forestnet (V2) | tgeo_dofa_large | 0.566 | all | bandspec_zscore |
+| eurosat-spatial | tgeo_dofa_large | 0.965 | rgb | bandspec_zscore |
+
+### Caveats
+
+- **Train probs are in-sample**: the linear probe was fit on train+val, so
+  train flag rates underestimate true train noise. Test probs are
+  out-of-sample and unbiased — those are the headline numbers.
+- **Top-1 model only** for now. Per-cleanlab best practice we should
+  ensemble top-3 to reduce single-model bias; queued for a follow-up run.
+- **Multi-label aggregate flag rates are inflated** by per-class binary
+  expansion across long-tailed label distributions. Per-class breakdown is
+  the trustworthy view.
+- Cleanlab's flag is a **noisy oracle**. Expected ~20–30% false positive
+  rate on flagged samples. Manual spot-check is still required to convert
+  these numbers into a "human-confirmed noise rate".
+
+## Aggregate test-set noise rates
+
+Sorted by single-label vs multi-label and noise rate.
+
+| Dataset | Task | N test | Flagged | Test noise rate | Top confused |
+|---|---|---:|---:|---:|---|
+| m-brick-kiln | single | 999 | 4 | **0.4%** | 0→1 |
+| m-eurosat | single | 1000 | 6 | **0.6%** | 2→6 |
+| m-pv4ger | single | 999 | 9 | **0.9%** | 1→0 |
+| eurosat-spatial | single | 5400 | 62 | **1.1%** | 2→6 |
+| m-so2sat | single | 986 | 149 | **15.1%** | 8→5 |
+| so2sat (V2) | single | 986 | 150 | **15.2%** | 8→5 |
+| m-forestnet | single | 993 | 299 | **30.1%** | 2→0 |
+| forestnet (V2) | single | 993 | 313 | **31.5%** | 2→0 |
+| benv2 | multi | 4000 | 1995 | 49.9%¹ | — |
+| treesatai | multi | 2000 | 1035 | 51.8%¹ | — |
+| m-bigearthnet | multi | 1000 | 687 | 68.7%¹ | — |
+
+¹ Multi-label aggregate, inflated; see per-class section.
+
+## Single-label per-class findings
+
+### Clean datasets
+
+**m-eurosat / m-brick-kiln / m-pv4ger** — every class ≥ 93% accuracy, total
+flagged ≤ 9 samples. These eval results are trustworthy.
+
+**eurosat-spatial — gap localizes to one class**
+
+| Class | n | acc | top confused → | share |
+|---:|---:|---:|---:|---:|
+| 5 | 115 | **0.678** | class 2 | 23.5% |
+| 6 | 307 | 0.850 | class 2 | 11.7% |
+| 0, 1, 2, 3, 4, 7, 8 | – | ≥ 0.95 | – | – |
+
+The accuracy gap between `m-eurosat` (0.969) and `eurosat-spatial` (0.965)
+is small in aggregate, but the spatial-split *test set* concentrates the
+remaining error in **classes 5 and 6**. Class 5 in particular drops to
+68% accuracy and is misclassified to class 2 a quarter of the time. This
+is a real spatial-shift effect, not label noise — both EuroSAT splits have
+≤ 1.1% test noise.
+
+### LCZ ambiguity (so2sat family)
+
+m-so2sat (V1) and so2sat (V2) show **identical** failure modes — same
+class indices, same confusion shares, within 0.2% on every metric. This is
+expected: V2 reuses the V1 imagery; the only difference is the split.
+
+| Class | n | acc | top confused → | share |
+|---:|---:|---:|---:|---:|
+| 5 | 58 | **0.43** | class 2 | 25.9% |
+| 8 | 58 | 0.64 | class 5 | 25.9% |
+| 0 | 58 | 0.55–0.57 | class 3 | 27.6% |
+| 1 | 58 | 0.66 | class 0 | 10.3% |
+
+These are well-known **Local Climate Zone confusions**: compact lowrise vs
+compact midrise (0↔3), light industry vs heavy industry (5↔2), etc. The
+classes are *physically* similar from satellite imagery — no model is
+going to disambiguate them at significantly above the rates above. This
+is a **capability ceiling baked into the eval**, not noise. Model rankings
+on so2sat above ~0.75 accuracy are essentially measuring how close each
+model gets to the LCZ ambiguity ceiling, not which model is "smarter".
+
+### forestnet — broken classes
+
+m-forestnet (V1) and forestnet (V2) show *similar* test-set noise (30%
+vs 32%), with V2 slightly **worse** on the worst classes:
+
+| forestnet (V2) class | n | acc | top confused → | share |
+|---:|---:|---:|---:|---:|
+| 2 | 73 | **0.151** | class 0 | 38.4% |
+| 6 | 50 | **0.240** | class 5 | 32.0% |
+| 5 | 73 | **0.205** | class 4 | 38.4% |
+| 11 | 30 | 0.300 | class 4 | 33.3% |
+| 10 | 43 | 0.372 | class 4 | 25.6% |
+
+Five out of twelve classes have accuracy below 40% with confusion to a
+single neighbouring class > 25%. Either:
+- the labels are genuinely noisy in those classes (annotator disagreement
+  on similar deforestation-driver categories), or
+- the visual signal isn't in the imagery at all (some categories may need
+  temporal / contextual cues not available in a single tile).
+
+**V2 is not a label-clean upgrade over V1 for forestnet.** Reporting only
+overall accuracy here is misleading — the metric is dominated by these
+five broken classes.
+
+### m-pv4ger — class imbalance
+
+| Class | n | acc | top confused → | share |
+|---:|---:|---:|---:|---:|
+| 1 (panel) | 153 | 0.824 | class 0 (no panel) | 17.6% |
+| 0 (no panel) | 846 | 0.994 | class 1 | 0.6% |
+
+Almost all errors are false negatives on the rare positive class.
+Expected for a binary detection task. Aggregate 0.97 accuracy hides this
+asymmetry — recall on the panel class is 0.82.
+
+## Multi-label per-class findings
+
+The **aggregate** multi-label noise rates (50–69%) are misleading.
+Cleanlab's multi-label finder runs binary `find_label_issues` per class
+and unions the results, which inflates with the number of classes and
+class imbalance. The per-class view tells a different story.
+
+### benv2 (19 classes) — head classes are fine
+
+Big classes (n_pos ≥ 700) all have AP ≥ 0.69 and flag-among-positive ≤
+18%. The aggregate 49.9% comes from tail classes and the per-class union.
+
+| Class pair | Jaccard | n_pos (a, b) | AP (a, b) | flag-among-pos (a, b) |
+|---:|---:|---|---|---|
+| 9 ↔ 10 | **0.51** | 1270, 1452 | 0.93, 0.89 | 5%, 9% |
+| 8 ↔ 13 | 0.28 | 1215, 1355 | 0.84, 0.76 | 11%, 17% |
+| 4 ↔ 2 | 0.25 | 901, 1658 | 0.83, 0.93 | 13%, 8% |
+
+Classes 9 and 10 share more than half their positive samples (Jaccard 0.51).
+This is the "near-duplicate label" hypothesis: in BigEarthNet V2's
+relabelling, two CORINE land-cover classes are essentially co-occurring
+nearly always. The model still discriminates them well per-class (AP 0.93
+and 0.89), so model rankings on benv2 are probably fine — but the
+aggregate mAP under-credits models that "merge" 9 and 10, and over-credits
+models that learn the rare exclusive cases.
+
+### m-bigearthnet (43 classes) — long-tailed
+
+Big classes (n_pos ≥ 200) have AP ≥ 0.67. Flag rate is dominated by tail
+classes with 25–50 positives in the test set:
+
+| Class | n_pos | AP | flag-among-pos |
+|---:|---:|---:|---:|
+| 13 | 26 | 0.48 | 42% |
+| 10 | 33 | 0.32 | 36% |
+| 16 | 36 | 0.51 | 28% |
+| 39 | 269 | 0.70 | 21% |
+
+`33 ↔ 34` Jaccard 0.37 — small overlap, not catastrophic. Otherwise no
+class pair stands out. Like benv2, head-class APs are reasonable and the
+aggregate noise rate is mostly a long-tail / per-class-expansion artifact.
+
+### treesatai (15 classes) — actually broken on rare species
+
+Different story: **multiple classes the model literally cannot predict**.
+
+The "13 vs 15 columns" mismatch noted in the first draft was a metadata
+bug in our wrapper. Upstream `geobench_v2.GeoBenchTreeSatAI` declares 15
+classes (the 14 European tree genera plus "Cleared"); our wrapper had a
+stale `num_classes = 13`. Fixed in this commit. The label tensor is
+correct (15-dim multi-hot); only the metadata was wrong.
+
+Class indices map to species (upstream order):
+
+```
+0 Abies   1 Acer    2 Alnus    3 Betula  4 Cleared
+5 Fagus   6 Fraxinus 7 Larix   8 Picea   9 Pinus
+10 Populus 11 Prunus 12 Pseudotsuga 13 Quercus 14 Tilia
+```
+
+| Class | Species | n_pos | AP | n_pred_pos | flag-among-pos |
+|---:|---|---:|---:|---:|---:|
+| 14 | Tilia (linden) | 12 | **0.008** | 0 | 75% |
+| 10 | Populus (aspen/poplar) | 13 | **0.016** | 0 | 62% |
+| 11 | Prunus (cherry) | 23 | **0.058** | 0 | 48% |
+| 0 | Abies (silver fir) | 49 | **0.049** | 2 | 57% |
+| 7 | Larix (larch) | 218 | **0.27** | 31 | 55% |
+
+Five species have AP below 0.10. Tilia, Populus, Prunus and Abies are all
+under-represented in the test set (12–49 positives across 2000 samples)
+and the probe never raises probability above 0.5 for any of them. Larix
+is interesting: 218 positives, distinct deciduous-conifer phenology, yet
+AP is only 0.27 — that's a real model failure on a learnable class.
+
+Most likely a combination of (a) tail-class scarcity preventing the
+linear probe from learning a discriminative direction in a 768-d
+embedding space, and (b) genuine visual ambiguity between similar genera
+(Abies ↔ Picea, Populus ↔ Betula). Not pure label noise.
+
+**Implication for model rankings**: the same model that "loses" treesatai
+mAP by being slightly less random on classes 14 / 10 / 11 / 0 isn't
+actually worse. **Recommend reporting both micro and macro mAP, and
+excluding classes with AP < 0.1 for any model in the comparison set.**
+
+## Cross-cutting conclusions
+
+1. **eurosat-spatial vs m-eurosat is real, and concentrated.** Both have
+   ≤ 1.1% label noise. The accuracy gap (small) localizes in classes 5
+   and 6 of eurosat-spatial — a real distribution-shift effect, not a
+   noise ceiling.
+
+2. **so2sat (V1 = V2) hits a fundamental ambiguity ceiling around 75%.**
+   Above that, models are competing on how close they get to the
+   LCZ-ambiguity floor (where 0↔3, 2↔5, 5↔8 confusions can't be
+   resolved from imagery). Treat any model claim above ~0.75 with
+   skepticism — the eval can't measure it.
+
+3. **forestnet V2 is not a label-clean upgrade over V1.** Both have ~30%
+   test noise concentrated in 5 classes that the model can't predict at
+   all. Macro-averaging would expose the issue; current micro-acc hides it.
+
+4. **benv2 / m-bigearthnet head-class results are trustworthy** — the
+   high aggregate flag rate is a per-class-expansion artifact on long-
+   tailed multi-label, not actual label noise on the head classes.
+
+5. **treesatai needs investigation before any model claim is made on it.**
+   At least 4 classes have AP < 0.05 with n_pred_pos = 0, and the label-
+   tensor shape doesn't match `num_classes`.
+
+## Open questions / next steps
+
+- **Re-extract embeddings** and run `cleanlab.Datalab` (no extra deps) to
+  get outlier / near-duplicate / underperforming-group / non-IID issues
+  per dataset. The `underperforming_group` manager will localize the
+  eurosat-spatial / forestnet failure clusters in feature space.
+- **Top-3 model ensemble** for prob averaging — reduces cleanlab single-
+  model bias.
+- **Eurosat-family deduplication** — phash `m-eurosat` vs `eurosat-spatial`
+  vs torchgeo `eurosat` to detect cross-split leakage.
+- **Manual spot-check** of top-50 flagged tiles per dataset to compute a
+  human-confirmed noise rate (gallery script ready, just needs eyes).
+- ~~**Investigate treesatai** label tensor shape~~ — done; bug was a
+  stale `num_classes = 13` in the wrapper, fixed to 15.
+
+## Files in this directory
+
+```
+probs/<dataset>__<model>_{train,test}.npz   # labels, classes, probs
+<dataset>_{train,test}.csv                   # per-sample issue scores
+perclass_<dataset>_<split>.csv               # per-class breakdown
+summary.csv                                  # aggregate noise rates
+REPORT.md                                    # this file
+```
+
+Reproduce with:
+
+```bash
+sbatch --array=0-10%10 scripts/slurm/cleanlab_audit.sh
+.venv/bin/python scripts/run_cleanlab_audit.py --verbose
+.venv/bin/python scripts/cleanlab_per_class_singlelabel.py --splits test
+.venv/bin/python scripts/cleanlab_per_class_multilabel.py --splits test
+```

--- a/docs/perf_report/cleanlab_audit_geobench.md
+++ b/docs/perf_report/cleanlab_audit_geobench.md
@@ -1,3 +1,7 @@
+---
+orphan: true
+---
+
 # GeoBench Cleanlab Audit — Initial Report
 
 Audit of label quality and class structure across all GeoBench V1 + V2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dependencies = [
   "tqdm>=4.65",
 ]
 optional-dependencies.all = [
+  "torchgeo-bench[cleanlab]",
   "torchgeo-bench[cuda]",
   "torchgeo-bench[dev]",
   "torchgeo-bench[docs]",
@@ -57,6 +58,12 @@ optional-dependencies.all = [
   "torchgeo-bench[sam3]",
   "torchgeo-bench[terratorch]",
   "torchgeo-bench[viz]",
+]
+optional-dependencies.cleanlab = [
+  "cleanlab>=2.7",
+  "imagehash>=4.3",
+  "matplotlib>=3.5",
+  "pillow>=9",
 ]
 optional-dependencies.cuda = [
   # GPU-accelerated KNN via faissknn (CUDA 12.x).

--- a/scripts/cleanlab_extract_probs.py
+++ b/scripts/cleanlab_extract_probs.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python
+"""Extract linear-probe probabilities for cleanlab dataset auditing.
+
+For one classification dataset, look up the top-1 linear-probe model from
+``results/all_results.csv``, rebuild that exact (model, dataset, bands,
+normalization, image_size, partition) combo, fit a logistic regression at
+the recorded ``best_c`` (merging train+val), and save predicted
+probabilities for the train and test splits.
+
+Outputs (one ``.npz`` per split)::
+
+    results/cleanlab/probs/<dataset>__<model_name>_train.npz
+    results/cleanlab/probs/<dataset>__<model_name>_test.npz
+
+Each NPZ contains:
+
+- ``indices``: (N,) int64 — sample indices into the underlying dataset
+  (0..N-1 in dataloader order; deterministic since loaders use shuffle=False
+  for val/test and we drop train shuffle).
+- ``labels``: (N,) int64 single-label OR (N, C) float32 multi-label.
+- ``probs``: (N, C) float32 — softmax probabilities (sigmoid for multi-label).
+- ``classes``: (C,) int64 — class index ordering used in ``probs``.
+
+This script is invoked once per dataset (typically as a SLURM array task).
+"""
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import torch
+from hydra.utils import instantiate
+from omegaconf import OmegaConf
+from torch.utils.data import DataLoader
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from torchgeo_bench.datasets import get_bench_dataset_class, get_datasets  # noqa: E402
+from torchgeo_bench.linear import LogisticRegression  # noqa: E402
+from torchgeo_bench.main import embed_split  # noqa: E402
+
+logger = logging.getLogger("cleanlab_extract")
+
+
+CONF_ROOT = REPO_ROOT / "src" / "torchgeo_bench" / "conf" / "model"
+
+
+def build_name_to_config_map() -> dict[str, Path]:
+    """Map ``name:`` field in each model yaml to its file path."""
+    out: dict[str, Path] = {}
+    for yaml_path in CONF_ROOT.rglob("*.yaml"):
+        cfg = OmegaConf.load(yaml_path)
+        name = cfg.get("name") if isinstance(cfg, dict) or hasattr(cfg, "get") else None
+        if name is not None:
+            out[str(name)] = yaml_path
+    return out
+
+
+VALID_NORMS = {"bandspec_zscore", "model_native", "minmax", "minmax_zscore", "identity"}
+
+
+def lookup_top1(results_csv: Path, dataset: str) -> pd.Series:
+    """Return the top-1 ``method=linear`` row for ``dataset``.
+
+    Filters out rows whose ``normalization`` is no longer accepted by the
+    current ``NormalizationStrategy`` enum (e.g. legacy ``raw`` rows from
+    earlier runs). Without this filter, lookups can pick a stale top-1 that
+    can no longer be re-instantiated.
+    """
+    df = pd.read_csv(results_csv)
+    sub = df[
+        (df["dataset"] == dataset)
+        & (df["method"] == "linear")
+        & (df["normalization"].isin(VALID_NORMS))
+    ]
+    if sub.empty:
+        raise SystemExit(f"No linear-probe rows for dataset {dataset!r} in {results_csv}")
+    return sub.sort_values("metric_value", ascending=False).iloc[0]
+
+
+def parse_bands(value: object) -> str | list[str]:
+    """Convert a CSV bands cell back to the form ``get_datasets`` accepts."""
+    s = str(value)
+    if s in ("rgb", "all"):
+        return s
+    return [b.strip() for b in s.split(",") if b.strip()]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dataset", required=True, help="Dataset name (e.g. m-eurosat).")
+    parser.add_argument(
+        "--results",
+        type=Path,
+        default=REPO_ROOT / "results" / "all_results.csv",
+        help="Input results CSV used to pick the top-1 model.",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=REPO_ROOT / "results" / "cleanlab" / "probs",
+        help="Output directory for prob NPZ files.",
+    )
+    parser.add_argument("--device", default="cuda:0", help="Torch device.")
+    parser.add_argument("--batch-size", type=int, default=64)
+    parser.add_argument("--num-workers", type=int, default=8)
+    parser.add_argument(
+        "--seed", type=int, default=0, help="Seed for the linear probe (matches main.py default)."
+    )
+    parser.add_argument(
+        "--c",
+        type=float,
+        default=None,
+        help="Override regularization C; default uses best_c from CSV.",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite existing prob files instead of skipping.",
+    )
+    parser.add_argument("--verbose", action="store_true")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO if args.verbose else logging.WARNING,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+    )
+
+    args.out.mkdir(parents=True, exist_ok=True)
+    row = lookup_top1(args.results, args.dataset)
+
+    model_name = str(row["name"])
+    bands_value = parse_bands(row["bands"])
+    normalization = str(row["normalization"])
+    image_size = (
+        int(row["image_size"])
+        if pd.notna(row["image_size"]) and str(row["image_size"]).strip() not in ("", "None", "nan")
+        else None
+    )
+    interpolation = str(row.get("interpolation") or "bicubic")
+    partition = str(row["partition"])
+    best_c = float(args.c) if args.c is not None else float(row["best_c"])
+
+    train_path = args.out / f"{args.dataset}__{model_name}_train.npz"
+    test_path = args.out / f"{args.dataset}__{model_name}_test.npz"
+    if train_path.exists() and test_path.exists() and not args.force:
+        logger.warning("Skipping (already exist): %s, %s", train_path, test_path)
+        return
+
+    logger.info(
+        "[%s] top-1 model=%s bands=%s norm=%s image_size=%s partition=%s best_c=%g",
+        args.dataset,
+        model_name,
+        bands_value,
+        normalization,
+        image_size,
+        partition,
+        best_c,
+    )
+
+    name_map = build_name_to_config_map()
+    if model_name not in name_map:
+        raise SystemExit(f"No yaml found with name={model_name!r}; checked {CONF_ROOT}")
+    model_cfg = OmegaConf.load(name_map[model_name])
+
+    device = torch.device(args.device)
+    torch.manual_seed(args.seed)
+    np.random.seed(args.seed)
+
+    ds_cls = get_bench_dataset_class(args.dataset)
+    is_multilabel = ds_cls.multilabel
+
+    result = get_datasets(
+        dataset_name=args.dataset,
+        partition_name=partition,
+        batch_size=args.batch_size,
+        num_workers=args.num_workers,
+        return_val=True,
+        image_size=image_size,
+        interpolation=interpolation,
+        bands=bands_value,
+    )
+    assert result is not None
+    train_dataset, train_loader_shuffled, val_loader, test_loader = result
+    # Rebuild an unshuffled train loader so saved indices match dataset order.
+    train_loader = DataLoader(
+        train_dataset,
+        batch_size=train_loader_shuffled.batch_size,
+        shuffle=False,
+        num_workers=train_loader_shuffled.num_workers,
+        pin_memory=train_loader_shuffled.pin_memory,
+    )
+
+    # Resolve BandSpecs for the model wrapper, exactly like main.py.
+    bench_for_bands = ds_cls()
+    if bands_value == "rgb":
+        bands_resolved = tuple(bench_for_bands.rgb_bands)
+    elif bands_value in ("all", None):
+        bands_resolved = None
+    else:
+        bands_resolved = tuple(bands_value)
+    bands_list = bench_for_bands.select_band_specs(bands_resolved)
+
+    model = instantiate(
+        model_cfg,
+        bands=bands_list,
+        normalization=normalization,
+        _convert_="object",
+    )
+    model.to(device).eval()
+
+    # Embed splits — same path as main.py.
+    x_train, y_train = embed_split(model, train_loader, device, verbose=args.verbose)
+    x_val, y_val = embed_split(model, val_loader, device, verbose=args.verbose)
+    x_test, y_test = embed_split(model, test_loader, device, verbose=args.verbose)
+    feature_dim = x_train.shape[1]
+    logger.info(
+        "[%s] embeddings: train=%s val=%s test=%s d=%d",
+        args.dataset,
+        x_train.shape,
+        x_val.shape,
+        x_test.shape,
+        feature_dim,
+    )
+
+    # Free the GPU model — linear probe is small.
+    del model
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
+    # Fit linear probe on train+val (matches merge_val=True default).
+    x_fit_np = np.concatenate([x_train, x_val], axis=0)
+    y_fit_np = np.concatenate([y_train, y_val], axis=0)
+    if is_multilabel:
+        y_fit = torch.from_numpy(y_fit_np).float()
+    else:
+        y_fit = torch.from_numpy(y_fit_np).long()
+    x_fit = torch.from_numpy(x_fit_np)
+
+    clf = LogisticRegression(
+        C=best_c,
+        max_iter=4000,
+        tol=1e-6,
+        random_state=args.seed,
+        device=args.device,
+        multi_label=is_multilabel,
+    )
+    clf.fit(x_fit, y_fit)
+
+    classes = (
+        np.arange(y_train.shape[1], dtype=np.int64)
+        if is_multilabel
+        else np.asarray(clf.classes_, dtype=np.int64)
+    )
+
+    # In-sample probs on train (note: in-sample for cleanlab → underestimates train noise).
+    train_probs = clf.predict_proba(torch.from_numpy(x_train)).astype(np.float32)
+    test_probs = clf.predict_proba(torch.from_numpy(x_test)).astype(np.float32)
+
+    np.savez_compressed(
+        train_path,
+        indices=np.arange(len(y_train), dtype=np.int64),
+        labels=y_train,
+        probs=train_probs,
+        classes=classes,
+        meta=np.array(
+            [
+                args.dataset,
+                model_name,
+                str(bands_value),
+                normalization,
+                str(image_size),
+                partition,
+                f"{best_c:g}",
+                "train",
+            ],
+            dtype=object,
+        ),
+    )
+    np.savez_compressed(
+        test_path,
+        indices=np.arange(len(y_test), dtype=np.int64),
+        labels=y_test,
+        probs=test_probs,
+        classes=classes,
+        meta=np.array(
+            [
+                args.dataset,
+                model_name,
+                str(bands_value),
+                normalization,
+                str(image_size),
+                partition,
+                f"{best_c:g}",
+                "test",
+            ],
+            dtype=object,
+        ),
+    )
+    logger.warning(
+        "[%s] wrote %s (probs %s) and %s (probs %s)",
+        args.dataset,
+        train_path,
+        train_probs.shape,
+        test_path,
+        test_probs.shape,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/cleanlab_per_class_multilabel.py
+++ b/scripts/cleanlab_per_class_multilabel.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python
+"""Per-class breakdown of cleanlab issues for multi-label datasets.
+
+For each multi-label dataset (benv2, m-bigearthnet, treesatai), runs
+``cleanlab.multilabel_classification.filter.find_multilabel_issues_per_class``
+on the saved test probs and reports per-class statistics:
+
+- ``n_pos``: number of positives in the given labels
+- ``n_pos_pred``: number of positives predicted at the 0.5 threshold
+- ``n_flagged``: how many samples cleanlab flagged for that class
+- ``flag_rate``: ``n_flagged / N`` (overall) and ``n_flagged_pos / n_pos``
+- ``ap``: per-class average precision (sklearn) from probs
+- ``co_occur_top``: top class index whose given/pred patterns most overlap
+  with this class — used to spot near-identical / nested classes that the
+  model can't distinguish
+
+Output: ``results/cleanlab/perclass_<dataset>_<split>.csv`` and a printed
+top-K worst classes per dataset.
+"""
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+logger = logging.getLogger("perclass")
+
+
+def _ap_per_class(y: np.ndarray, p: np.ndarray) -> np.ndarray:
+    """Per-class average precision; NaN for classes with zero positives."""
+    from sklearn.metrics import average_precision_score
+
+    out = np.full(y.shape[1], np.nan, dtype=np.float64)
+    for c in range(y.shape[1]):
+        if y[:, c].sum() == 0:
+            continue
+        out[c] = float(average_precision_score(y[:, c], p[:, c]))
+    return out
+
+
+def _per_class_flags(y: np.ndarray, probs: np.ndarray) -> np.ndarray:
+    """Return (N, K) boolean mask — cleanlab flag for each (sample, class)."""
+    from cleanlab.multilabel_classification.filter import find_multilabel_issues_per_class
+
+    y_lists = [np.flatnonzero(row).tolist() for row in y]
+    out = find_multilabel_issues_per_class(labels=y_lists, pred_probs=probs)
+    if isinstance(out, tuple):
+        out = out[0]
+    return np.asarray(out, dtype=bool)
+
+
+def _co_occur_top(y_col: np.ndarray, y_other: np.ndarray) -> tuple[int, float]:
+    """For column ``c``, find the column that maximizes Jaccard with it."""
+    n_other = y_other.shape[1]
+    best_j, best_score = -1, 0.0
+    a = y_col.astype(bool)
+    for j in range(n_other):
+        b = y_other[:, j].astype(bool)
+        inter = int((a & b).sum())
+        union = int((a | b).sum())
+        if union == 0:
+            continue
+        s = inter / union
+        if s > best_score:
+            best_score, best_j = s, j
+    return best_j, best_score
+
+
+def report_dataset(npz_path: Path, out_dir: Path, top_k: int = 10) -> pd.DataFrame:
+    z = np.load(npz_path, allow_pickle=True)
+    y = z["labels"].astype(np.int64)
+    probs = z["probs"].astype(np.float32)
+    if y.ndim != 2:
+        raise SystemExit(f"{npz_path}: not multi-label (labels ndim={y.ndim})")
+    K = y.shape[1]
+    pred_pos = (probs > 0.5).astype(np.int64)
+    aps = _ap_per_class(y, probs)
+    flags = _per_class_flags(y, probs)
+
+    N = y.shape[0]
+    rows = []
+    for c in range(K):
+        f = flags[:, c]
+        n_pos = int(y[:, c].sum())
+        n_pred = int(pred_pos[:, c].sum())
+        n_flag = int(f.sum())
+        # Flag rate restricted to true positives — "of the samples labeled c,
+        # how many does cleanlab think are wrong?"
+        flag_pos = int((f & y[:, c].astype(bool)).sum())
+        flag_neg = int((f & ~y[:, c].astype(bool)).sum())
+        # Highest Jaccard with another class (excluding self) — proxy for
+        # near-duplicate / nested labels.
+        mask = np.ones(K, dtype=bool)
+        mask[c] = False
+        j_idx, j_score = _co_occur_top(y[:, c], y[:, mask])
+        # Map j_idx back through the mask to original column index.
+        real_idx = int(np.flatnonzero(mask)[j_idx]) if j_idx >= 0 else -1
+        rows.append(
+            {
+                "class": c,
+                "n_pos": n_pos,
+                "n_pred_pos": n_pred,
+                "ap": aps[c],
+                "n_flagged": n_flag,
+                "flag_rate": n_flag / max(len(f), 1),
+                "flag_among_pos": flag_pos / max(n_pos, 1),
+                "flag_among_neg": flag_neg / max(N - n_pos, 1),
+                "jaccard_top_class": real_idx,
+                "jaccard_top_score": j_score,
+            }
+        )
+    df = pd.DataFrame(rows)
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = (
+        out_dir
+        / f"perclass_{npz_path.stem.replace('__', '_').rsplit('_', 1)[0]}_{npz_path.stem.rsplit('_', 1)[1]}.csv"
+    )
+    # Above messes up; do it cleaner:
+    stem = npz_path.stem  # e.g. benv2__tt_terramind_v1_large_test
+    dataset, rest = stem.split("__", 1)
+    split = rest.rsplit("_", 1)[1]  # train|test
+    out_path = out_dir / f"perclass_{dataset}_{split}.csv"
+    df.to_csv(out_path, index=False)
+    logger.warning("[%s/%s] K=%d wrote %s", dataset, split, K, out_path)
+
+    # Print worst classes by `flag_among_pos`.
+    worst = df.sort_values("flag_among_pos", ascending=False).head(top_k)
+    print(f"\n=== {dataset}/{split} — top {top_k} classes by flag_among_pos ===")
+    print(
+        worst.to_string(
+            index=False, float_format=lambda v: f"{v:.3f}" if isinstance(v, float) else str(v)
+        )
+    )
+
+    # Also print classes with high Jaccard (near-duplicate labels).
+    sticky = df.sort_values("jaccard_top_score", ascending=False).head(top_k)
+    print(f"\n=== {dataset}/{split} — top {top_k} classes by Jaccard with another class ===")
+    print(
+        sticky[
+            ["class", "jaccard_top_class", "jaccard_top_score", "n_pos", "ap", "flag_among_pos"]
+        ].to_string(
+            index=False, float_format=lambda v: f"{v:.3f}" if isinstance(v, float) else str(v)
+        )
+    )
+    return df
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--probs-dir",
+        type=Path,
+        default=Path("results/cleanlab/probs"),
+    )
+    parser.add_argument("--out-dir", type=Path, default=Path("results/cleanlab"))
+    parser.add_argument("--datasets", nargs="*", default=["benv2", "m-bigearthnet", "treesatai"])
+    parser.add_argument("--splits", nargs="+", default=["test"])
+    parser.add_argument("--top-k", type=int, default=10)
+    parser.add_argument("--verbose", action="store_true")
+    args = parser.parse_args()
+    logging.basicConfig(
+        level=logging.INFO if args.verbose else logging.WARNING,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+    )
+
+    for ds in args.datasets:
+        for split in args.splits:
+            cands = sorted(args.probs_dir.glob(f"{ds}__*_{split}.npz"))
+            if not cands:
+                logger.warning("No probs for %s/%s", ds, split)
+                continue
+            for p in cands:
+                try:
+                    report_dataset(p, args.out_dir, top_k=args.top_k)
+                except Exception:
+                    logger.exception("[%s] failed", p)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/cleanlab_per_class_singlelabel.py
+++ b/scripts/cleanlab_per_class_singlelabel.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python
+"""Per-class breakdown of cleanlab issues for single-label datasets.
+
+Mirrors ``cleanlab_per_class_multilabel.py`` but for single-label
+classification. For each (dataset, split, given class), reports:
+
+- ``n``: number of samples with this given class
+- ``acc``: top-1 accuracy of the linear probe on this class
+- ``ap``: one-vs-rest average precision
+- ``n_flagged``: how many cleanlab flagged for this class
+- ``flag_rate``: ``n_flagged / n``
+- ``top_confused_to``: most common predicted class among flagged samples,
+  and how many — proxy for "this class looks like X to the model"
+- ``conf_overlap``: top off-diagonal confusion fraction (predicted-class /
+  given-class) — high values mean two classes are systematically confused
+
+Output: ``results/cleanlab/perclass_<dataset>_<split>.csv``.
+"""
+
+import argparse
+import logging
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+logger = logging.getLogger("perclass-sl")
+
+
+def report_dataset(npz_path: Path, out_dir: Path, top_k: int = 10) -> pd.DataFrame:
+    from cleanlab.filter import find_label_issues
+    from cleanlab.rank import get_label_quality_scores
+    from sklearn.metrics import average_precision_score
+
+    z = np.load(npz_path, allow_pickle=True)
+    labels = z["labels"]
+    probs = z["probs"].astype(np.float32)
+    classes = z["classes"]
+    if labels.ndim != 1:
+        raise SystemExit(f"{npz_path}: not single-label (labels ndim={labels.ndim})")
+
+    label_to_idx = {int(c): i for i, c in enumerate(classes.tolist())}
+    y = np.array([label_to_idx[int(v)] for v in labels], dtype=np.int64)
+    K = probs.shape[1]
+    pred = probs.argmax(axis=1)
+
+    quality = get_label_quality_scores(labels=y, pred_probs=probs)
+    issues_idx = find_label_issues(
+        labels=y, pred_probs=probs, return_indices_ranked_by="self_confidence"
+    )
+    is_issue = np.zeros(len(y), dtype=bool)
+    is_issue[issues_idx] = True
+
+    rows = []
+    for c in range(K):
+        in_class = y == c
+        n = int(in_class.sum())
+        if n == 0:
+            continue
+        correct = int(((pred == y) & in_class).sum())
+        n_flag = int((is_issue & in_class).sum())
+        # Off-diagonal confusion: most common prediction among flagged
+        # samples for this class.
+        flagged_preds = pred[is_issue & in_class]
+        if flagged_preds.size:
+            uniq, cnt = np.unique(flagged_preds, return_counts=True)
+            top = int(uniq[cnt.argmax()])
+            top_n = int(cnt.max())
+        else:
+            top, top_n = -1, 0
+        ap = float(average_precision_score(in_class.astype(int), probs[:, c]))
+        # Most-confused-OUT pair fraction across the whole class:
+        # max over c' != c of P(pred=c' | given=c)
+        conf_share = np.zeros(K, dtype=float)
+        if n > 0:
+            uniq2, cnt2 = np.unique(pred[in_class], return_counts=True)
+            for u, q in zip(uniq2, cnt2, strict=False):
+                conf_share[u] = q / n
+        conf_share[c] = 0.0  # mask self
+        top_conf_class = int(conf_share.argmax())
+        top_conf_share = float(conf_share.max())
+        rows.append(
+            {
+                "class": int(classes[c]),
+                "n": n,
+                "acc": correct / n,
+                "ap": ap,
+                "n_flagged": n_flag,
+                "flag_rate": n_flag / n,
+                "top_flagged_pred": top if top_n > 0 else -1,
+                "top_flagged_pred_n": top_n,
+                "top_conf_class": top_conf_class,
+                "top_conf_share": top_conf_share,
+                "mean_quality": float(quality[in_class].mean()),
+            }
+        )
+    df = pd.DataFrame(rows)
+
+    stem = npz_path.stem
+    dataset, rest = stem.split("__", 1)
+    split = rest.rsplit("_", 1)[1]
+    out_path = out_dir / f"perclass_{dataset}_{split}.csv"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    df.to_csv(out_path, index=False)
+    logger.warning("[%s/%s] K=%d wrote %s", dataset, split, K, out_path)
+
+    worst = df.sort_values("flag_rate", ascending=False).head(top_k)
+    print(f"\n=== {dataset}/{split} — top {top_k} classes by flag_rate ===")
+    print(
+        worst.to_string(
+            index=False,
+            float_format=lambda v: f"{v:.3f}" if isinstance(v, float) else str(v),
+        )
+    )
+    sticky = df[df["top_conf_share"] > 0].sort_values("top_conf_share", ascending=False).head(top_k)
+    if not sticky.empty:
+        print(f"\n=== {dataset}/{split} — top {top_k} classes by off-diag confusion ===")
+        print(
+            sticky[
+                ["class", "n", "acc", "top_conf_class", "top_conf_share", "flag_rate"]
+            ].to_string(
+                index=False,
+                float_format=lambda v: f"{v:.3f}" if isinstance(v, float) else str(v),
+            )
+        )
+    return df
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--probs-dir", type=Path, default=Path("results/cleanlab/probs"))
+    parser.add_argument("--out-dir", type=Path, default=Path("results/cleanlab"))
+    parser.add_argument(
+        "--datasets",
+        nargs="*",
+        default=[
+            "m-eurosat",
+            "m-brick-kiln",
+            "m-pv4ger",
+            "m-so2sat",
+            "m-forestnet",
+            "so2sat",
+            "forestnet",
+            "eurosat-spatial",
+        ],
+    )
+    parser.add_argument("--splits", nargs="+", default=["test"])
+    parser.add_argument("--top-k", type=int, default=10)
+    parser.add_argument("--verbose", action="store_true")
+    args = parser.parse_args()
+    logging.basicConfig(
+        level=logging.INFO if args.verbose else logging.WARNING,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+    )
+    for ds in args.datasets:
+        for split in args.splits:
+            for p in sorted(args.probs_dir.glob(f"{ds}__*_{split}.npz")):
+                try:
+                    report_dataset(p, args.out_dir, top_k=args.top_k)
+                except Exception:
+                    logger.exception("[%s] failed", p)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/eurosat_family_dedup.py
+++ b/scripts/eurosat_family_dedup.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python
+"""Detect overlapping tiles across the EuroSAT family.
+
+Hashes RGB tiles from ``m-eurosat`` (GeoBench V1), ``eurosat-spatial`` (the
+new spatial-split variant), and torchgeo's stock ``eurosat`` using a
+perceptual hash (``imagehash.phash``). Reports collision groups so we can
+flag tiles that appear in train of one variant and test of another — an
+overlap that turns IID-test accuracy into a leakage signal.
+
+Outputs:
+- ``results/cleanlab/dedup_eurosat_family.csv``: one row per (dataset, split,
+  index) with its phash and any cross-dataset matches.
+- summary printed to stdout.
+"""
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+import imagehash  # noqa: E402
+from PIL import Image  # noqa: E402
+
+from torchgeo_bench.datasets import get_datasets  # noqa: E402
+
+logger = logging.getLogger("dedup")
+
+DATASETS = ["m-eurosat", "eurosat-spatial", "eurosat"]
+
+
+def _load_splits(dataset: str):
+    result = get_datasets(
+        dataset_name=dataset,
+        partition_name="default",
+        batch_size=1,
+        num_workers=0,
+        return_val=True,
+        image_size=None,
+        bands="rgb",
+        interpolation="bicubic",
+    )
+    assert result is not None
+    train_ds, _train_loader, val_loader, test_loader = result
+    return {
+        "train": train_ds,
+        "val": val_loader.dataset,
+        "test": test_loader.dataset,
+    }
+
+
+def _phash_image(arr) -> str:
+    img = arr.detach().cpu().float().numpy()
+    img = np.transpose(img, (1, 2, 0))
+    lo = np.percentile(img, 2, axis=(0, 1), keepdims=True)
+    hi = np.percentile(img, 98, axis=(0, 1), keepdims=True)
+    img = np.clip((img - lo) / np.maximum(hi - lo, 1e-6), 0, 1)
+    pil = Image.fromarray((img * 255).astype(np.uint8))
+    return str(imagehash.phash(pil, hash_size=16))
+
+
+def hash_dataset(dataset: str) -> pd.DataFrame:
+    splits = _load_splits(dataset)
+    rows = []
+    for split, ds in splits.items():
+        n = len(ds)
+        logger.info("[%s/%s] hashing %d samples", dataset, split, n)
+        for i in range(n):
+            sample = ds[i]
+            img = sample["image"]
+            label = sample.get("label")
+            label_val = int(label) if label is not None and np.ndim(label) == 0 else None
+            try:
+                ph = _phash_image(img)
+            except Exception as exc:
+                logger.warning("[%s/%s] hash failed for %d: %s", dataset, split, i, exc)
+                continue
+            rows.append(
+                {
+                    "dataset": dataset,
+                    "split": split,
+                    "index": i,
+                    "label": label_val,
+                    "phash": ph,
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--out", type=Path, default=Path("results/cleanlab/dedup_eurosat_family.csv")
+    )
+    parser.add_argument("--datasets", nargs="*", default=DATASETS)
+    parser.add_argument("--verbose", action="store_true")
+    args = parser.parse_args()
+    logging.basicConfig(
+        level=logging.INFO if args.verbose else logging.WARNING,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+    )
+
+    frames = []
+    for d in args.datasets:
+        try:
+            frames.append(hash_dataset(d))
+        except Exception:
+            logger.exception("dataset %s failed", d)
+    if not frames:
+        raise SystemExit("nothing hashed")
+    df = pd.concat(frames, ignore_index=True)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(args.out, index=False)
+
+    # Summary: collisions across datasets.
+    grouped = df.groupby("phash")
+    cross = []
+    for ph, sub in grouped:
+        ds_set = set(sub["dataset"].tolist())
+        if len(ds_set) > 1:
+            cross.append({"phash": ph, "n": len(sub), "datasets": ",".join(sorted(ds_set))})
+    cross_df = pd.DataFrame(cross).sort_values("n", ascending=False) if cross else pd.DataFrame()
+    print(f"Hashed {len(df)} tiles across {df['dataset'].nunique()} datasets")
+    print(f"Cross-dataset collision groups: {len(cross_df)}")
+    if not cross_df.empty:
+        print(cross_df.head(20).to_string(index=False))
+    cross_path = args.out.with_name(args.out.stem + "_collisions.csv")
+    cross_df.to_csv(cross_path, index=False)
+    print(f"Wrote {args.out} and {cross_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/render_flagged_gallery.py
+++ b/scripts/render_flagged_gallery.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python
+"""Render top-K flagged tiles per dataset for manual cleanlab review.
+
+For each ``results/cleanlab/<dataset>_<split>.csv`` produced by
+``run_cleanlab_audit.py``, take the top-K samples ranked by ``issue_score``,
+fetch their RGB tiles from the dataset, and stitch them into a single PNG
+grid. Captions show ``given_label -> guessed_label (score)``.
+
+Output: ``results/cleanlab/galleries/<dataset>_<split>.png``.
+"""
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+import pandas as pd  # noqa: E402
+import torch  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from torchgeo_bench.datasets import get_bench_dataset_class, get_datasets  # noqa: E402
+
+logger = logging.getLogger("gallery")
+
+
+def _load_split_dataset(dataset: str, split: str, partition: str = "default"):
+    result = get_datasets(
+        dataset_name=dataset,
+        partition_name=partition,
+        batch_size=1,
+        num_workers=0,
+        return_val=True,
+        image_size=None,  # native resolution for visualization
+        bands="all",
+        interpolation="bicubic",
+    )
+    assert result is not None
+    train_dataset, _train_loader, val_loader, test_loader = result
+    if split == "train":
+        return train_dataset
+    if split == "val":
+        return val_loader.dataset
+    if split == "test":
+        return test_loader.dataset
+    raise ValueError(split)
+
+
+def _to_rgb(image: torch.Tensor, rgb_idx: list[int]) -> np.ndarray:
+    """Take (C, H, W) tensor → (H, W, 3) uint8 with per-image min-max contrast."""
+    if image.ndim != 3:
+        raise ValueError(f"expected (C, H, W); got {tuple(image.shape)}")
+    arr = image[rgb_idx].detach().cpu().float().numpy()
+    arr = np.transpose(arr, (1, 2, 0))
+    lo = np.percentile(arr, 2, axis=(0, 1), keepdims=True)
+    hi = np.percentile(arr, 98, axis=(0, 1), keepdims=True)
+    arr = np.clip((arr - lo) / np.maximum(hi - lo, 1e-6), 0, 1)
+    return (arr * 255).astype(np.uint8)
+
+
+def render_gallery(
+    dataset: str,
+    split: str,
+    issues_csv: Path,
+    out_path: Path,
+    top_k: int = 50,
+    cols: int = 10,
+) -> None:
+    df = pd.read_csv(issues_csv)
+    if "is_issue" not in df.columns:
+        raise SystemExit(f"{issues_csv}: missing is_issue column")
+    flagged = df[df["is_issue"]].sort_values("issue_score", ascending=False).head(top_k)
+    if flagged.empty:
+        logger.warning("[%s/%s] no flagged samples", dataset, split)
+        return
+
+    ds_cls = get_bench_dataset_class(dataset)
+    ds = _load_split_dataset(dataset, split)
+    bench = ds_cls()
+    rgb_idx = bench.rgb_indices or [0, 1, 2]
+
+    rows = (len(flagged) + cols - 1) // cols
+    fig, axes = plt.subplots(rows, cols, figsize=(cols * 1.6, rows * 1.8))
+    axes = np.atleast_2d(axes).reshape(rows, cols)
+    multilabel = "given_label" not in flagged.columns
+
+    for ax in axes.ravel():
+        ax.axis("off")
+
+    for k, (_, row) in enumerate(flagged.iterrows()):
+        idx = int(row["index"])
+        sample = ds[idx]
+        img = sample["image"]
+        rgb = _to_rgb(img, rgb_idx)
+        ax = axes[k // cols, k % cols]
+        ax.imshow(rgb)
+        if multilabel:
+            caption = f"i={idx}\nscore={row['issue_score']:.2f}"
+        else:
+            g = int(row["given_label"])
+            p = int(row["guessed_label"])
+            caption = f"{g}->{p}\n{row['issue_score']:.2f}"
+        ax.set_title(caption, fontsize=6)
+
+    fig.suptitle(f"{dataset} / {split} — top {len(flagged)} flagged", fontsize=10)
+    fig.tight_layout()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out_path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+    logger.warning("[%s/%s] wrote %s", dataset, split, out_path)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--issues-dir",
+        type=Path,
+        default=Path("results/cleanlab"),
+        help="Directory containing <dataset>_<split>.csv files.",
+    )
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=Path("results/cleanlab/galleries"),
+    )
+    parser.add_argument("--top-k", type=int, default=50)
+    parser.add_argument("--cols", type=int, default=10)
+    parser.add_argument(
+        "--datasets",
+        nargs="*",
+        default=None,
+        help="Subset of datasets to render (default: all CSVs in --issues-dir).",
+    )
+    parser.add_argument("--splits", nargs="+", default=["train", "test"])
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+
+    csvs = sorted(args.issues_dir.glob("*_*.csv"))
+    csvs = [c for c in csvs if c.stem != "summary"]
+    pairs = []
+    for c in csvs:
+        if "_" not in c.stem:
+            continue
+        dataset, _, split = c.stem.rpartition("_")
+        if split not in args.splits:
+            continue
+        if args.datasets and dataset not in args.datasets:
+            continue
+        pairs.append((dataset, split, c))
+
+    for dataset, split, csv_path in pairs:
+        out = args.out_dir / f"{dataset}_{split}.png"
+        try:
+            render_gallery(dataset, split, csv_path, out, args.top_k, args.cols)
+        except Exception:
+            logger.exception("[%s/%s] failed", dataset, split)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_cleanlab_audit.py
+++ b/scripts/run_cleanlab_audit.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python
+"""Run cleanlab on saved linear-probe probabilities.
+
+Consumes the NPZ files written by ``cleanlab_extract_probs.py`` and produces:
+
+- ``results/cleanlab/<dataset>_train.csv``: per-sample issue scores.
+- ``results/cleanlab/<dataset>_test.csv``: same, for the test split.
+- ``results/cleanlab/summary.csv``: per-(dataset, split) noise rate, # flagged,
+  top-confused class pair.
+
+Caveat: train probs from ``cleanlab_extract_probs.py`` are in-sample (the
+linear probe was fit on train+val). Cleanlab's noise estimates assume
+out-of-sample probs, so train issue counts will be biased low. Test probs
+are out-of-sample and unbiased.
+
+Multi-label datasets (e.g. m-bigearthnet, benv2, treesatai) use
+``cleanlab.multilabel_classification.filter.find_label_issues`` if available.
+"""
+
+import argparse
+import json
+import logging
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+logger = logging.getLogger("cleanlab_audit")
+
+
+def _load_npz(path: Path) -> dict:
+    z = np.load(path, allow_pickle=True)
+    return {k: z[k] for k in z.files}
+
+
+def _is_multilabel(labels: np.ndarray) -> bool:
+    return labels.ndim == 2
+
+
+def _audit_singlelabel(labels: np.ndarray, probs: np.ndarray, classes: np.ndarray) -> pd.DataFrame:
+    from cleanlab.filter import find_label_issues
+    from cleanlab.rank import get_label_quality_scores
+
+    # Map dataset labels to dense [0..C-1] indexing matching classes order.
+    label_to_idx = {int(c): i for i, c in enumerate(classes.tolist())}
+    y = np.array([label_to_idx[int(v)] for v in labels], dtype=np.int64)
+
+    quality = get_label_quality_scores(labels=y, pred_probs=probs)
+    issues_mask = find_label_issues(
+        labels=y,
+        pred_probs=probs,
+        return_indices_ranked_by="self_confidence",
+    )
+    is_issue = np.zeros(len(y), dtype=bool)
+    is_issue[issues_mask] = True
+    guessed = probs.argmax(axis=1)
+    return pd.DataFrame(
+        {
+            "index": np.arange(len(y), dtype=np.int64),
+            "given_label": labels.astype(np.int64),
+            "guessed_label": np.array([int(classes[g]) for g in guessed], dtype=np.int64),
+            "given_prob": probs[np.arange(len(y)), y].astype(np.float32),
+            "max_prob": probs.max(axis=1).astype(np.float32),
+            "issue_score": (1.0 - quality).astype(np.float32),
+            "is_issue": is_issue,
+        }
+    )
+
+
+def _audit_multilabel(labels: np.ndarray, probs: np.ndarray) -> pd.DataFrame:
+    from cleanlab.multilabel_classification.filter import find_label_issues as ml_find
+    from cleanlab.multilabel_classification.rank import get_label_quality_scores as ml_quality
+
+    y = labels.astype(np.int64)
+    # Cleanlab's multilabel API expects per-sample lists of positive class
+    # indices, not binary indicator vectors.
+    y_lists = [np.flatnonzero(row).tolist() for row in y]
+    quality = ml_quality(labels=y_lists, pred_probs=probs)
+    issues_idx = ml_find(labels=y_lists, pred_probs=probs)
+    is_issue = np.zeros(len(y), dtype=bool)
+    is_issue[issues_idx] = True
+    return pd.DataFrame(
+        {
+            "index": np.arange(len(y), dtype=np.int64),
+            "n_pos_given": y.sum(axis=1).astype(np.int32),
+            "n_pos_pred_top": (probs > 0.5).sum(axis=1).astype(np.int32),
+            "issue_score": (1.0 - np.asarray(quality)).astype(np.float32),
+            "is_issue": is_issue,
+        }
+    )
+
+
+def _confused_pair(df: pd.DataFrame) -> str:
+    if "given_label" not in df.columns:
+        return ""
+    flagged = df[df["is_issue"]]
+    if flagged.empty:
+        return ""
+    pairs = flagged.groupby(["given_label", "guessed_label"]).size().sort_values(ascending=False)
+    if pairs.empty:
+        return ""
+    (g, p), n = pairs.index[0], pairs.iloc[0]
+    return f"{int(g)}->{int(p)}:{int(n)}"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--probs-dir",
+        type=Path,
+        default=Path("results/cleanlab/probs"),
+        help="Directory containing <dataset>__<model>_{train,test}.npz files.",
+    )
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=Path("results/cleanlab"),
+    )
+    parser.add_argument("--verbose", action="store_true")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO if args.verbose else logging.WARNING,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+    )
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    npzs = sorted(args.probs_dir.glob("*.npz"))
+    if not npzs:
+        raise SystemExit(f"No .npz files in {args.probs_dir}")
+
+    summary_rows: list[dict] = []
+    by_dataset: dict[str, dict[str, Path]] = {}
+    for p in npzs:
+        # Filename: <dataset>__<model>_<split>.npz
+        stem = p.stem
+        if "__" not in stem:
+            logger.warning("Skipping unrecognised filename: %s", p)
+            continue
+        dataset, rest = stem.split("__", 1)
+        if rest.endswith("_train"):
+            split = "train"
+        elif rest.endswith("_test"):
+            split = "test"
+        else:
+            logger.warning("Skipping unrecognised filename: %s", p)
+            continue
+        by_dataset.setdefault(dataset, {})[split] = p
+
+    for dataset, splits in sorted(by_dataset.items()):
+        for split, npz_path in splits.items():
+            data = _load_npz(npz_path)
+            labels = data["labels"]
+            probs = data["probs"]
+            classes = data["classes"]
+            multilabel = _is_multilabel(labels)
+            if multilabel:
+                df = _audit_multilabel(labels, probs)
+            else:
+                df = _audit_singlelabel(labels, probs, classes)
+
+            out_csv = args.out_dir / f"{dataset}_{split}.csv"
+            df.to_csv(out_csv, index=False)
+            n = len(df)
+            n_flag = int(df["is_issue"].sum())
+            rate = n_flag / max(n, 1)
+            summary_rows.append(
+                {
+                    "dataset": dataset,
+                    "split": split,
+                    "model": str(data.get("meta", np.array([None, None]))[1])
+                    if "meta" in data
+                    else "",
+                    "multilabel": multilabel,
+                    "n": n,
+                    "n_flagged": n_flag,
+                    "noise_rate": rate,
+                    "top_confused": _confused_pair(df) if not multilabel else "",
+                    "probs_path": str(npz_path),
+                }
+            )
+            logger.info("[%s/%s] n=%d flagged=%d (%.2f%%)", dataset, split, n, n_flag, 100 * rate)
+
+    summary = pd.DataFrame(summary_rows).sort_values(["dataset", "split"])
+    summary_path = args.out_dir / "summary.csv"
+    summary.to_csv(summary_path, index=False)
+    print(json.dumps({"summary": str(summary_path), "n_rows": len(summary)}, indent=2))
+    print(summary.to_string(index=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/slurm/cleanlab_audit.jobs
+++ b/scripts/slurm/cleanlab_audit.jobs
@@ -1,0 +1,11 @@
+m-eurosat
+m-bigearthnet
+m-brick-kiln
+m-pv4ger
+m-so2sat
+m-forestnet
+benv2
+treesatai
+so2sat
+forestnet
+eurosat-spatial

--- a/scripts/slurm/cleanlab_audit.sh
+++ b/scripts/slurm/cleanlab_audit.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+#SBATCH --job-name=tgb-cleanlab
+#SBATCH --partition=gpu
+#SBATCH --account=bgtj-tgirails
+#SBATCH --array=0-0
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=8
+#SBATCH --gpus-per-node=1
+#SBATCH --mem=120G
+#SBATCH --time=06:00:00
+#SBATCH --output=logs/%A_%a.out
+#SBATCH --error=logs/%A_%a.err
+#
+# Cleanlab audit: extract train+test linear-probe probabilities for the top-1
+# model on each GeoBench classification dataset, one array task per dataset.
+#
+# Submit as:
+#
+#   N=$(wc -l < scripts/slurm/cleanlab_audit.jobs)
+#   # H100 partition:
+#   sbatch --array=0-$((N-1))%9 scripts/slurm/cleanlab_audit.sh
+#   # or A100 partition:
+#   sbatch --partition=gpu_a100 --array=0-$((N-1))%9 scripts/slurm/cleanlab_audit.sh
+#
+# Each line in scripts/slurm/cleanlab_audit.jobs is one dataset name. The
+# script picks the top-1 (method=linear) row per dataset from
+# results/all_results.csv.
+
+set -euo pipefail
+
+mkdir -p logs results/cleanlab/probs
+
+JOBS_FILE=${JOBS_FILE:-scripts/slurm/cleanlab_audit.jobs}
+DATASET=$(sed -n "$((SLURM_ARRAY_TASK_ID + 1))p" "$JOBS_FILE")
+
+echo "[$(date)] task=$SLURM_ARRAY_TASK_ID dataset=$DATASET"
+
+cd "$SLURM_SUBMIT_DIR"
+
+VENV=${TGB_VENV:-$SLURM_SUBMIT_DIR/.venv-3.12}
+source "$VENV/bin/activate"
+
+# Same torch.hub / weights-dir setup as probe_sweep_h100.sh.
+TORCH_HUB_DIR="${TORCH_HOME:-$HOME/.cache/torch}/hub"
+mkdir -p "$TORCH_HUB_DIR"
+TRUSTED_LIST="$TORCH_HUB_DIR/trusted_list"
+for repo in gastruc_anysat facebookresearch_dinov2; do
+  grep -qxF "$repo" "$TRUSTED_LIST" 2>/dev/null || echo "$repo" >> "$TRUSTED_LIST"
+done
+export MODEL_WEIGHTS_DIR=${MODEL_WEIGHTS_DIR:-/projects/bgtj/isaaccorley/cache/geobreeze_weights}
+mkdir -p "$MODEL_WEIGHTS_DIR"
+
+python scripts/cleanlab_extract_probs.py \
+  --dataset "$DATASET" \
+  --results results/all_results.csv \
+  --out results/cleanlab/probs \
+  --device cuda:0 \
+  --batch-size "${TGB_BATCH_SIZE:-64}" \
+  --num-workers "${TGB_NUM_WORKERS:-8}" \
+  --verbose

--- a/uv.lock
+++ b/uv.lock
@@ -384,6 +384,22 @@ wheels = [
 ]
 
 [[package]]
+name = "cleanlab"
+version = "2.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "scikit-learn" },
+    { name = "termcolor" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/82/ab/80cbcd832bda6e18ef22f0f9120675f70b7d532a164f762fb660f73fc346/cleanlab-2.9.0.tar.gz", hash = "sha256:abe25fe0c772ced8c4b36a94e0de71726db00802224b7fb7bee06db6ff95eb4e", size = 273633, upload-time = "2026-01-13T18:02:46.7Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/8a/612ba4408b0b21c7ca8cf5671d61ddb5499e675bcec3058e6f48839672cb/cleanlab-2.9.0-py3-none-any.whl", hash = "sha256:9a317d9ba547c388dd15fffec71fcf838cda1404ef4034b6865da78be6603f4e", size = 306078, upload-time = "2026-01-13T18:02:44.912Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1160,6 +1176,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+]
+
+[[package]]
+name = "imagehash"
+version = "4.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "pywavelets" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/de/5c0189b0582e21583c2a213081c35a2501c0f9e51f21f6a52f55fbb9a4ff/ImageHash-4.3.2.tar.gz", hash = "sha256:e54a79805afb82a34acde4746a16540503a9636fd1ffb31d8e099b29bbbf8156", size = 303190, upload-time = "2025-02-01T08:45:39.328Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/2c/5f0903a53a62029875aaa3884c38070cc388248a2c1b9aa935632669e5a7/ImageHash-4.3.2-py2.py3-none-any.whl", hash = "sha256:02b0f965f8c77cd813f61d7d39031ea27d4780e7ebcad56c6cd6a709acc06e5f", size = 296657, upload-time = "2025-02-01T08:45:36.102Z" },
 ]
 
 [[package]]
@@ -2788,6 +2819,57 @@ wheels = [
 ]
 
 [[package]]
+name = "pywavelets"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/75/50581633d199812205ea8cdd0f6d52f12a624886b74bf1486335b67f01ff/pywavelets-1.9.0.tar.gz", hash = "sha256:148d12203377772bea452a59211d98649c8ee4a05eff019a9021853a36babdc8", size = 3938340, upload-time = "2025-08-04T16:20:04.978Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/37/3fda13fb2518fdd306528382d6b18c116ceafefff0a7dccd28f1034f4dd2/pywavelets-1.9.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:30baa0788317d3c938560c83fe4fc43817342d06e6c9662a440f73ba3fb25c9b", size = 4320835, upload-time = "2025-08-04T16:19:04.855Z" },
+    { url = "https://files.pythonhosted.org/packages/36/65/a5549325daafc3eae4b52de076798839eaf529a07218f8fb18cccefe76a1/pywavelets-1.9.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:df7436a728339696a7aa955c020ae65c85b0d9d2b5ff5b4cf4551f5d4c50f2c7", size = 4290469, upload-time = "2025-08-04T16:19:06.178Z" },
+    { url = "https://files.pythonhosted.org/packages/05/85/901bb756d37dfa56baa26ef4a3577aecfe9c55f50f51366fede322f8c91d/pywavelets-1.9.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:07b26526db2476974581274c43a9c2447c917418c6bd03c8d305ad2a5cd9fac3", size = 4437717, upload-time = "2025-08-04T16:19:07.514Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/34/0f54dd9c288941294898877008bcb5c07012340cc9c5db9cff1bd185d449/pywavelets-1.9.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:573b650805d2f3c981a0e5ae95191c781a722022c37a0f6eba3fa7eae8e0ee17", size = 4483843, upload-time = "2025-08-04T16:19:08.857Z" },
+    { url = "https://files.pythonhosted.org/packages/48/1f/cff6bb4ea64ff508d8cac3fe113c0aa95310a7446d9efa6829027cc2afdf/pywavelets-1.9.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3747ec804492436de6e99a7b6130480e53406d047e87dc7095ab40078a515a23", size = 4442236, upload-time = "2025-08-04T16:19:11.061Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/53/a3846eeefe0fb7ca63ae045f038457aa274989a15af793c1b824138caf98/pywavelets-1.9.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5163665686219c3f43fd5bbfef2391e87146813961dad0f86c62d4aed561f547", size = 4488077, upload-time = "2025-08-04T16:19:12.333Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/98/44852d2fe94455b72dece2db23562145179d63186a1c971125279a1c381f/pywavelets-1.9.0-cp312-cp312-win32.whl", hash = "sha256:80b8ab99f5326a3e724f71f23ba8b0a5b03e333fa79f66e965ea7bed21d42a2f", size = 4134094, upload-time = "2025-08-04T16:19:13.564Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/a7/0d9ee3fe454d606e0f5c8e3aebf99d2ecddbfb681826a29397729538c8f1/pywavelets-1.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:92bfb8a117b8c8d3b72f2757a85395346fcbf37f50598880879ae72bd8e1c4b9", size = 4213900, upload-time = "2025-08-04T16:19:14.939Z" },
+    { url = "https://files.pythonhosted.org/packages/db/a7/dec4e450675d62946ad975f5b4d924437df42d2fae46e91dfddda2de0f5a/pywavelets-1.9.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:74f8455c143818e4b026fc67b27fd82f38e522701b94b8a6d1aaf3a45fcc1a25", size = 4316201, upload-time = "2025-08-04T16:19:16.259Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/0c/b54b86596c0df68027e48c09210e907e628435003e77048384a2dd6767e3/pywavelets-1.9.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c50320fe0a4a23ddd8835b3dc9b53b09ee05c7cc6c56b81d0916f04fc1649070", size = 4286838, upload-time = "2025-08-04T16:19:17.92Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/9c/333969c3baad8af2e7999e83addcb7bb1d1fd48e2d812fb27e2e89582cb1/pywavelets-1.9.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d6e059265223ed659e5214ab52a84883c88ddf3decbf08d7ec6abb8e4c5ed7be", size = 4430753, upload-time = "2025-08-04T16:19:19.529Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/1b/a24c6ff03b026b826ad7b9267bd63cd34ce026795a0302f8a5403840b8e7/pywavelets-1.9.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ae10ed46c139c7ddb8b1249cfe0989f8ccb610d93f2899507b1b1573a0e424b5", size = 4491315, upload-time = "2025-08-04T16:19:20.717Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/c7/e3fbb502fca3469e51ced4f1e1326364c338be91edc5db5a8ddd26b303fa/pywavelets-1.9.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c8f8b1cc2df012401cb837ee6fa2f59607c7b4fe0ff409d9a4f6906daf40dc86", size = 4437654, upload-time = "2025-08-04T16:19:22.359Z" },
+    { url = "https://files.pythonhosted.org/packages/92/44/c9b25084048d9324881a19b88e0969a4141bcfdc1d218f1b4b680b7af1c1/pywavelets-1.9.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:db43969c7a8fbb17693ecfd14f21616edc3b29f0e47a49b32fa4127c01312a67", size = 4496435, upload-time = "2025-08-04T16:19:23.842Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/b6/b27ec18c72b1dee3314e297af39c5f8136d43cc130dd93cb6c178ca820e5/pywavelets-1.9.0-cp313-cp313-win32.whl", hash = "sha256:9e7d60819d87dcd6c68a2d1bc1d37deb1f4d96607799ab6a25633ea484dcda41", size = 4132709, upload-time = "2025-08-04T16:19:25.415Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/87/78ef3f9fb36cdb16ee82371d22c3a7c89eeb79ec8c9daef6222060da6c79/pywavelets-1.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:0d70da9d7858c869e24dc254f16a61dc09d8a224cad85a10c393b2eccddeb126", size = 4213377, upload-time = "2025-08-04T16:19:26.875Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cd/ca0d9db0ff29e3843f6af60c2f5eb588794e05ca8eeb872a595867b1f3f5/pywavelets-1.9.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:4dc85f44c38d76a184a1aa2cb038f802c3740428c9bb877525f4be83a223b134", size = 4354336, upload-time = "2025-08-04T16:19:28.745Z" },
+    { url = "https://files.pythonhosted.org/packages/82/d6/70afefcc1139f37d02018a3b1dba3b8fc87601bb7707d9616b7f7a76e269/pywavelets-1.9.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:7acf6f950c6deaecd210fbff44421f234a8ca81eb6f4da945228e498361afa9d", size = 4335721, upload-time = "2025-08-04T16:19:30.371Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/3a/713f731b9ed6df0c36269c8fb62be8bb28eb343b9e26b13d6abda37bce38/pywavelets-1.9.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:144d4fc15c98da56654d0dca2d391b812b8d04127b194a37ad4a497f8e887141", size = 4418702, upload-time = "2025-08-04T16:19:31.743Z" },
+    { url = "https://files.pythonhosted.org/packages/44/e8/f801eb4b5f7a316ba20054948c5d6b27b879c77fab2674942e779974bd86/pywavelets-1.9.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1aa3729585408a979d655736f74b995b511c86b9be1544f95d4a3142f8f4b8b5", size = 4470023, upload-time = "2025-08-04T16:19:32.963Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/cc/44b002cb16f2a392f2082308dd470b3f033fa4925d3efa7c46f790ce895a/pywavelets-1.9.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:e0e24ad6b8eb399c49606dd1fcdcbf9749ad7f6d638be3fe6f59c1f3098821e2", size = 4426498, upload-time = "2025-08-04T16:19:34.151Z" },
+    { url = "https://files.pythonhosted.org/packages/91/fe/2b70276ede7878c5fe8356ca07574db5da63e222ce39a463e84bfad135e8/pywavelets-1.9.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:3830e6657236b53a3aae20c735cccead942bb97c54bbca9e7d07bae01645fe9c", size = 4477528, upload-time = "2025-08-04T16:19:35.932Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/ed/d58b540c15e36508cfeded7b0d39493e811b0dce18d9d4e6787fb2e89685/pywavelets-1.9.0-cp313-cp313t-win32.whl", hash = "sha256:81bb65facfbd7b50dec50450516e72cdc51376ecfdd46f2e945bb89d39bfb783", size = 4186493, upload-time = "2025-08-04T16:19:37.198Z" },
+    { url = "https://files.pythonhosted.org/packages/84/b2/12a849650d618a86bbe4d8876c7e20a7afe59a8cad6f49c57eca9af26dfa/pywavelets-1.9.0-cp313-cp313t-win_amd64.whl", hash = "sha256:47d52cf35e2afded8cfe1133663f6f67106a3220b77645476ae660ad34922cb4", size = 4274821, upload-time = "2025-08-04T16:19:38.436Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/1f/18c82122547c9eec2232d800b02ada1fbd30ce2136137b5738acca9d653e/pywavelets-1.9.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:53043d2f3f4e55a576f51ac594fe33181e1d096d958e01524db5070eb3825306", size = 4314440, upload-time = "2025-08-04T16:19:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e1/1c92ac6b538ef5388caf1a74af61cf6af16ea6d14115bb53357469cb38d6/pywavelets-1.9.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:56bc36b42b1b125fd9cb56e7956b22f8d0f83c1093f49c77fc042135e588c799", size = 4290162, upload-time = "2025-08-04T16:19:41.322Z" },
+    { url = "https://files.pythonhosted.org/packages/96/d3/d856a2cac8069c20144598fa30a43ca40b5df2e633230848a9a942faf04a/pywavelets-1.9.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:08076eb9a182ddc6054ac86868fb71df6267c341635036dc63d20bdbacd9ad7e", size = 4437162, upload-time = "2025-08-04T16:19:42.556Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/54/777e0495acd4fb008791e84889be33d6e7fc8af095b441d939390b7d2491/pywavelets-1.9.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4ee1ee7d80f88c64b8ec3b5021dd1e94545cc97f0cd479fb51aa7b10f6def08e", size = 4498169, upload-time = "2025-08-04T16:19:43.791Z" },
+    { url = "https://files.pythonhosted.org/packages/76/68/81b97f4d18491a18fbe17e06e2eee80a591ce445942f7b6f522de07813c5/pywavelets-1.9.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:3226b6f62838a6ccd7782cb7449ee5d8b9d61999506c1d9b03b2baf41b01b6fd", size = 4443318, upload-time = "2025-08-04T16:19:45.368Z" },
+    { url = "https://files.pythonhosted.org/packages/92/74/5147f2f0436f7aa131cb1bc13dba32ef5f3862748ae1c7366b4cde380362/pywavelets-1.9.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:9fb7f4b11d18e2db6dd8deee7b3ce8343d45f195f3f278c2af6e3724b1b93a24", size = 4503294, upload-time = "2025-08-04T16:19:46.632Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/d4/af998cc71e869919e0ab45471bd43e91d055ac7bc3ce6f56cc792c9b6bc8/pywavelets-1.9.0-cp314-cp314-win32.whl", hash = "sha256:9902d9fc9812588ab2dce359a1307d8e7f002b53a835640e2c9388fe62a82fd4", size = 4144478, upload-time = "2025-08-04T16:19:47.974Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/66/1d071eae5cc3e3ad0e45334462f8ce526a79767ccb759eb851aa5b78a73a/pywavelets-1.9.0-cp314-cp314-win_amd64.whl", hash = "sha256:7e57792bde40e331d6cc65458e5970fd814dba18cfc4e9add9d051e901a7b7c7", size = 4227186, upload-time = "2025-08-04T16:19:49.57Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/1f/da0c03ac99bd9d20409c0acf6417806d4cf333d70621da9f535dd0cf27fa/pywavelets-1.9.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:b47c72fb4b76d665c4c598a5b621b505944e5b761bf03df9d169029aafcb652f", size = 4354391, upload-time = "2025-08-04T16:19:51.221Z" },
+    { url = "https://files.pythonhosted.org/packages/95/b6/de9e225d8cc307fbb4fda88aefa79442775d5e27c58ee4d3c8a8580ceba6/pywavelets-1.9.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:969e369899e7eab546ea5d77074e4125082e6f9dad71966499bf5dee3758be55", size = 4335810, upload-time = "2025-08-04T16:19:52.813Z" },
+    { url = "https://files.pythonhosted.org/packages/33/3b/336761359d07cd44a4233ca854704ff2a9e78d285879ccc82d254b9daa57/pywavelets-1.9.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8aeffd4f35036c1fade972a61454de5709a7a8fc9a7d177eefe3ac34d76962e5", size = 4422220, upload-time = "2025-08-04T16:19:54.068Z" },
+    { url = "https://files.pythonhosted.org/packages/98/61/76ccc7ada127f14f65eda40e37407b344fd3713acfca7a94d7f0f67fe57d/pywavelets-1.9.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f63f400fcd4e7007529bd06a5886009760da35cd7e76bb6adb5a5fbee4ffeb8c", size = 4470156, upload-time = "2025-08-04T16:19:55.379Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/de/142ca27ee729cf64113c2560748fcf2bd45b899ff282d6f6f3c0e7f177bb/pywavelets-1.9.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:a63bcb6b5759a7eb187aeb5e8cd316b7adab7de1f4b5a0446c9a6bcebdfc22fb", size = 4430167, upload-time = "2025-08-04T16:19:56.566Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/5e/90b39adff710d698c00ba9c3125e2bec99dad7c5f1a3ba37c73a78a6689f/pywavelets-1.9.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9950eb7c8b942e9bfa53d87c7e45a420dcddbd835c4c5f1aca045a3f775c6113", size = 4477378, upload-time = "2025-08-04T16:19:58.162Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/1a/89f5f4ebcb9d34d9b7b2ac0a868c8b6d8c78d699a36f54407a060cea0566/pywavelets-1.9.0-cp314-cp314t-win32.whl", hash = "sha256:097f157e07858a1eb370e0d9c1bd11185acdece5cca10756d6c3c7b35b52771a", size = 4209132, upload-time = "2025-08-04T16:20:00.371Z" },
+    { url = "https://files.pythonhosted.org/packages/68/d2/a8065103f5e2e613b916489e6c85af6402a1ec64f346d1429e2d32cb8d03/pywavelets-1.9.0-cp314-cp314t-win_amd64.whl", hash = "sha256:3b6ff6ba4f625d8c955f68c2c39b0a913776d406ab31ee4057f34ad4019fb33b", size = 4306793, upload-time = "2025-08-04T16:20:02.934Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -3807,7 +3889,9 @@ dependencies = [
 
 [package.optional-dependencies]
 all = [
+    { name = "cleanlab" },
     { name = "faissknn" },
+    { name = "imagehash" },
     { name = "linkify-it-py" },
     { name = "matplotlib" },
     { name = "mdformat" },
@@ -3825,6 +3909,12 @@ all = [
     { name = "terratorch" },
     { name = "torchid", marker = "python_full_version >= '3.13'" },
     { name = "transformers" },
+]
+cleanlab = [
+    { name = "cleanlab" },
+    { name = "imagehash" },
+    { name = "matplotlib" },
+    { name = "pillow" },
 ]
 cuda = [
     { name = "faissknn" },
@@ -3864,13 +3954,16 @@ viz = [
 
 [package.metadata]
 requires-dist = [
+    { name = "cleanlab", marker = "extra == 'cleanlab'", specifier = ">=2.7" },
     { name = "faiss-cpu", specifier = ">=1.7" },
     { name = "faissknn", marker = "extra == 'cuda'", specifier = ">=0.0.3" },
     { name = "geobenchv2", specifier = ">=0.9" },
     { name = "h5py", specifier = ">=3.8" },
     { name = "huggingface-hub", specifier = ">=0.20" },
     { name = "hydra-core", specifier = ">=1.3" },
+    { name = "imagehash", marker = "extra == 'cleanlab'", specifier = ">=4.3" },
     { name = "linkify-it-py", marker = "extra == 'docs'", specifier = ">=2" },
+    { name = "matplotlib", marker = "extra == 'cleanlab'", specifier = ">=3.5" },
     { name = "matplotlib", marker = "extra == 'viz'", specifier = ">=3.5" },
     { name = "mdformat", marker = "extra == 'dev'", specifier = ">=0.7.22" },
     { name = "myst-parser", marker = "extra == 'docs'", specifier = ">=2" },
@@ -3878,6 +3971,7 @@ requires-dist = [
     { name = "olmoearth-pretrain-minimal", marker = "extra == 'olmoearth'", specifier = ">=0.0.2" },
     { name = "omegaconf", specifier = ">=2.3" },
     { name = "pandas", specifier = ">=2" },
+    { name = "pillow", marker = "extra == 'cleanlab'", specifier = ">=9" },
     { name = "pillow", marker = "extra == 'viz'", specifier = ">=9" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.3" },
     { name = "pydata-sphinx-theme", marker = "extra == 'docs'", specifier = ">=0.15" },
@@ -3893,6 +3987,7 @@ requires-dist = [
     { name = "timm", specifier = ">=0.9" },
     { name = "torch", specifier = ">=2" },
     { name = "torchgeo", git = "https://github.com/microsoft/torchgeo.git?rev=e585e2c07f7a" },
+    { name = "torchgeo-bench", extras = ["cleanlab"], marker = "extra == 'all'" },
     { name = "torchgeo-bench", extras = ["cuda"], marker = "extra == 'all'" },
     { name = "torchgeo-bench", extras = ["dev"], marker = "extra == 'all'" },
     { name = "torchgeo-bench", extras = ["docs"], marker = "extra == 'all'" },
@@ -3905,7 +4000,7 @@ requires-dist = [
     { name = "tqdm", specifier = ">=4.65" },
     { name = "transformers", marker = "extra == 'sam3'", specifier = ">=4.50" },
 ]
-provides-extras = ["all", "cuda", "dev", "docs", "id", "olmoearth", "sam3", "terratorch", "viz"]
+provides-extras = ["all", "cleanlab", "cuda", "dev", "docs", "id", "olmoearth", "sam3", "terratorch", "viz"]
 
 [[package]]
 name = "torchid"


### PR DESCRIPTION
## Summary

Adds a label-quality audit pipeline using [cleanlab](https://github.com/cleanlab/cleanlab) and runs it across every GeoBench V1 + V2 classification dataset plus `eurosat-spatial`. The goal is to separate "models are getting better" from "the eval itself is the bottleneck."

**Draft because:**
- Uses top-1 model per dataset; should ensemble top-3 per cleanlab best practice (queued).
- Train probs are in-sample (probe fit on train+val); for unbiased train estimates we'd add k-fold CV. Test probs are out-of-sample and unbiased — those are the headline numbers.
- Multi-label aggregate flag rates are inflated by per-class binary expansion; per-class is the trustworthy view.
- No manual spot-check yet; cleanlab is a noisy oracle (~20–30% false positive rate).

## Pipeline

```
scripts/cleanlab_extract_probs.py            # GPU: 1 task per (dataset, top-1 model) → probs NPZ
scripts/run_cleanlab_audit.py                # CPU: probs → per-sample issue CSV + summary
scripts/cleanlab_per_class_singlelabel.py    # CPU: per-class accuracy/AP/flag-rate
scripts/cleanlab_per_class_multilabel.py     # CPU: per-class binary issue + Jaccard between classes
scripts/render_flagged_gallery.py            # CPU: top-50 flagged tile PNG grids
scripts/eurosat_family_dedup.py              # CPU: phash collisions across the 3 EuroSAT variants
scripts/slurm/cleanlab_audit.{sh,jobs}       # SBATCH array, 1 task per dataset
docs/perf_report/cleanlab_audit_geobench.md  # Methodology + findings
```

Adds a `cleanlab` extra (`pip install -e ".[cleanlab]"`) for `cleanlab>=2.7`, `imagehash>=4.3`, `matplotlib`, `pillow`.

## Top-1 model per dataset (from `results/all_results.csv`)

| Dataset | Model | Linear-probe acc/mAP |
|---|---|---:|
| m-eurosat | tgeo_panopticon | 0.969 |
| m-bigearthnet | tt_terramind_v1_large | 0.751 (mAP) |
| m-brick-kiln | tt_clay_v1_5_base | 0.975 |
| m-pv4ger | tgeo_panopticon | 0.968 |
| m-so2sat | tt_terramind_v1_base | 0.741 |
| m-forestnet | tt_terramind_v1_large | 0.571 |
| benv2 | tt_terramind_v1_large | 0.846 (mAP) |
| treesatai | tt_clay_v1_5_base | 0.674 (mAP) |
| so2sat (V2) | tt_terramind_v1_base | 0.741 |
| forestnet (V2) | tgeo_dofa_large | 0.566 |
| eurosat-spatial | tgeo_dofa_large | 0.965 |

## Aggregate test-set noise rates

| Dataset | Task | N test | Flagged | Test noise rate | Top confused |
|---|---|---:|---:|---:|---|
| m-brick-kiln | single | 999 | 4 | **0.4%** | 0→1 |
| m-eurosat | single | 1000 | 6 | **0.6%** | 2→6 |
| m-pv4ger | single | 999 | 9 | **0.9%** | 1→0 |
| eurosat-spatial | single | 5400 | 62 | **1.1%** | 2→6 |
| m-so2sat | single | 986 | 149 | **15.1%** | 8→5 |
| so2sat (V2) | single | 986 | 150 | **15.2%** | 8→5 |
| m-forestnet | single | 993 | 299 | **30.1%** | 2→0 |
| forestnet (V2) | single | 993 | 313 | **31.5%** | 2→0 |
| benv2 | multi | 4000 | 1995 | 49.9%¹ | — |
| treesatai | multi | 2000 | 1035 | 51.8%¹ | — |
| m-bigearthnet | multi | 1000 | 687 | 68.7%¹ | — |

¹ Multi-label aggregate, inflated; see per-class below.

## Key findings

### eurosat-spatial gap is real distribution shift, not noise

Both `m-eurosat` (0.6%) and `eurosat-spatial` (1.1%) test sets are clean. The accuracy gap localizes in **classes 5 and 6** of the spatial split:

| Class | n | acc | top confused → | share |
|---:|---:|---:|---:|---:|
| 5 | 115 | **0.678** | class 2 | 23.5% |
| 6 | 307 | 0.850 | class 2 | 11.7% |
| 0–4, 7–8 | – | ≥ 0.95 | – | – |

### so2sat (V1 = V2) hits an LCZ ambiguity ceiling at ~75%

m-so2sat and so2sat have **identical** failure modes — same class indices, same confusion shares, within 0.2% on every metric. Top confused pairs are well-known LCZ ambiguities (compact midrise vs lowrise, light vs heavy industry):

| Class | n | acc | top confused → | share |
|---:|---:|---:|---:|---:|
| 5 | 58 | **0.43** | class 2 | 25.9% |
| 8 | 58 | 0.64 | class 5 | 25.9% |
| 0 | 58 | 0.55–0.57 | class 3 | 27.6% |

These classes are *physically* similar from satellite imagery. Model rankings above ~0.75 are competing on how close each gets to the LCZ-ambiguity floor — the eval can't measure beyond that.

### forestnet V2 is not a label-clean upgrade over V1

Both have ~30% test noise concentrated in 5 broken classes (acc < 0.40, ≥ 25% share confused to a single neighbour). V2 is actually slightly **worse** than V1 on the dominant failure (class 2: 56% → 68% flagged). Macro mAP would expose this; current micro-acc hides it.

### benv2 / m-bigearthnet head classes are trustworthy

Aggregate 50% / 69% flag rates are artifacts of cleanlab's per-class binary expansion on long-tailed multi-label distributions. Big classes (n_pos ≥ 700) all have AP ≥ 0.69 with 5–18% per-class flag-among-positive. Notable near-duplicate label pair in benv2: classes 9 ↔ 10 (Jaccard **0.51**, n_pos 1270 vs 1452, AP 0.93/0.89) — model still distinguishes them.

### treesatai has multiple genuinely broken classes

| Class | Species | n_pos | AP | n_pred_pos |
|---:|---|---:|---:|---:|
| 14 | Tilia (linden) | 12 | **0.008** | 0 |
| 10 | Populus (aspen/poplar) | 13 | **0.016** | 0 |
| 11 | Prunus (cherry) | 23 | **0.058** | 0 |
| 0 | Abies (silver fir) | 49 | **0.049** | 2 |
| 7 | Larix (larch) | 218 | **0.27** | 31 |

Five species with AP < 0.10. Tilia/Populus/Prunus/Abies are tail classes (12–49 positives in 2000 test) that the linear probe can't learn. **Larix is the genuine model failure**: 218 positives, distinct deciduous-conifer phenology, AP 0.27.

> Note: while auditing this dataset I discovered our wrapper had `num_classes = 13` while upstream `geobench_v2.GeoBenchTreeSatAI` declares 15. Fixed in #51.

## Cross-cutting recommendations for paper-ready evaluation

1. **eurosat-spatial vs m-eurosat gap is real distribution shift.** Worth highlighting in the paper as a clean shift study; both have ≤ 1.1% label noise.
2. **Cap so2sat claims at ~0.75.** Above that, models are competing inside LCZ ambiguity and rankings are noise.
3. **For forestnet V1 and V2: report macro mAP** alongside accuracy. Current micro-acc is dominated by 5 broken classes.
4. **For multi-label benchmarks**: report per-class AP, not just micro/macro mAP. Flag any class with AP < 0.1 for any model in the comparison.
5. **treesatai needs a longer training set or richer signal** for tail species; consider weighted loss or excluding tail classes from the leaderboard metric.

## Test plan

- [x] Smoke test: 1-dataset SLURM job for m-eurosat completed in ~50s, produced expected NPZ files.
- [x] Full sweep: 11-dataset SLURM array completed; all probs landed.
- [x] `scripts/run_cleanlab_audit.py` runs end-to-end on all 11 datasets.
- [x] Per-class scripts produce expected per-class CSVs for both single- and multi-label datasets.
- [ ] Top-3 model ensembling (follow-up).
- [ ] cleanlab.Datalab for outlier / near-duplicate / underperforming-group / non-IID issues (follow-up; needs feature NPZ alongside probs).
- [ ] Manual spot-check of top-50 flagged tiles per dataset → human-confirmed noise rate (follow-up).
- [ ] EuroSAT-family phash dedup execution (script ready).