### PR TITLE
feat(knn): optional GPU path via faissknn cuda extra

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,10 +5,12 @@ scripts/*
 !scripts/repack_geobench_v1.py
 !scripts/tune_dataloader.py
 !scripts/regen_results_explorer.py
+!scripts/test_knn_gpu_smoke.py
 !scripts/slurm/
 scripts/slurm/*
 !scripts/slurm/build_probe_jobs.py
 !scripts/slurm/probe_sweep.sh
+!scripts/slurm/knn_gpu_smoke.sh
 figures/
 
 # Python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,12 +50,19 @@ dependencies = [
   "tqdm>=4.65",
 ]
 optional-dependencies.all = [
+  "torchgeo-bench[cuda]",
   "torchgeo-bench[dev]",
   "torchgeo-bench[docs]",
   "torchgeo-bench[id]",
   "torchgeo-bench[sam3]",
   "torchgeo-bench[terratorch]",
   "torchgeo-bench[viz]",
+]
+optional-dependencies.cuda = [
+  # GPU-accelerated KNN via faissknn (CUDA 12.x).
+  # Pulls in faiss-cuda-cu128 wheels which require manylinux_2_34
+  # (glibc >= 2.34); on older systems install will fail at sync time.
+  "faissknn>=0.0.3",
 ]
 optional-dependencies.dev = [
   "mdformat>=0.7.22",

--- a/scripts/slurm/knn_gpu_smoke.sh
+++ b/scripts/slurm/knn_gpu_smoke.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+#SBATCH --job-name=tgb-knn-gpu
+#SBATCH --partition=gpu_a100
+#SBATCH --account=bgtj-tgirails
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=4
+#SBATCH --gpus-per-node=1
+#SBATCH --mem=32G
+#SBATCH --time=00:15:00
+#SBATCH --output=logs/%j.out
+#SBATCH --error=logs/%j.err
+#
+# Smoke test for the GPU path of torchgeo_bench.knn.KNNClassifier.
+# Installs the project's `cuda` extra (faissknn → faiss-cuda-cu128) into a
+# scratch venv on the compute node (where glibc may be newer than the login
+# node), then runs scripts/test_knn_gpu_smoke.py and compares CPU vs GPU
+# predictions on synthetic data.
+
+set -euo pipefail
+
+cd "$SLURM_SUBMIT_DIR"
+mkdir -p logs
+echo "[$(date)] glibc on compute node:"
+ldd --version || true
+
+# Use the prebuilt 3.12 venv with `faissknn` (and `faiss-gpu-cu12`)
+# preinstalled. faiss-cpu and faiss-gpu-cu12 both install into the same
+# `faiss/` namespace, so for the GPU smoke we keep faiss-gpu-cu12 only.
+VENV=${TGB_VENV:-$SLURM_SUBMIT_DIR/.venv-3.12}
+# shellcheck disable=SC1091
+source "$VENV/bin/activate"
+nvidia-smi | head -3 || true
+python -c "import faiss; print('faiss has GPU:', hasattr(faiss, 'GpuIndexFlatL2'))"
+python scripts/test_knn_gpu_smoke.py

--- a/scripts/test_knn_gpu_smoke.py
+++ b/scripts/test_knn_gpu_smoke.py
@@ -1,43 +1,46 @@
 """Smoke test: KNNClassifier(device='cuda') ↔ device='cpu' parity."""
-import sys, os
+
+import sys
+
 sys.path.insert(0, "src")
 import numpy as np
+
 from torchgeo_bench.knn import KNNClassifier
 
 rng = np.random.default_rng(0)
 n_train, n_test, d, k = 2000, 500, 64, 5
 
 X_train = rng.standard_normal((n_train, d)).astype(np.float32)
-X_test  = rng.standard_normal((n_test,  d)).astype(np.float32)
+X_test = rng.standard_normal((n_test, d)).astype(np.float32)
 
 # --- single label ---
 n_classes = 10
 y_train = rng.integers(0, n_classes, size=n_train).astype(np.int64)
 
 cpu = KNNClassifier(n_neighbors=k, device="cpu").fit(X_train, y_train)
-cu  = KNNClassifier(n_neighbors=k, device="cuda").fit(X_train, y_train)
+cu = KNNClassifier(n_neighbors=k, device="cuda").fit(X_train, y_train)
 
 p_cpu = cpu.predict(X_test)
-p_cu  = cu.predict(X_test)
+p_cu = cu.predict(X_test)
 agree = float((p_cpu == p_cu).mean())
 print(f"singlelabel  predict agreement = {agree:.4f}  (n_classes={n_classes})")
 
 pp_cpu = cpu.predict_proba(X_test)
-pp_cu  = cu.predict_proba(X_test)
+pp_cu = cu.predict_proba(X_test)
 print(f"singlelabel  predict_proba shapes = {pp_cpu.shape} {pp_cu.shape}")
 print(f"singlelabel  predict_proba max abs diff = {np.abs(pp_cpu - pp_cu).max():.4g}")
 
 # --- multilabel ---
 Y_train = (rng.random((n_train, n_classes)) > 0.7).astype(np.int64)
 cpu_ml = KNNClassifier(n_neighbors=k, device="cpu").fit(X_train, Y_train)
-cu_ml  = KNNClassifier(n_neighbors=k, device="cuda").fit(X_train, Y_train)
+cu_ml = KNNClassifier(n_neighbors=k, device="cuda").fit(X_train, Y_train)
 
 p_cpu = cpu_ml.predict(X_test)
-p_cu  = cu_ml.predict(X_test)
+p_cu = cu_ml.predict(X_test)
 print(f"multilabel   predict shapes = {p_cpu.shape} {p_cu.shape}")
 print(f"multilabel   predict agreement = {float((p_cpu == p_cu).mean()):.4f}")
 
 pp_cpu = cpu_ml.predict_proba(X_test)
-pp_cu  = cu_ml.predict_proba(X_test)
+pp_cu = cu_ml.predict_proba(X_test)
 print(f"multilabel   predict_proba max abs diff = {np.abs(pp_cpu - pp_cu).max():.4g}")
 print("OK")

--- a/scripts/test_knn_gpu_smoke.py
+++ b/scripts/test_knn_gpu_smoke.py
@@ -1,0 +1,43 @@
+"""Smoke test: KNNClassifier(device='cuda') ↔ device='cpu' parity."""
+import sys, os
+sys.path.insert(0, "src")
+import numpy as np
+from torchgeo_bench.knn import KNNClassifier
+
+rng = np.random.default_rng(0)
+n_train, n_test, d, k = 2000, 500, 64, 5
+
+X_train = rng.standard_normal((n_train, d)).astype(np.float32)
+X_test  = rng.standard_normal((n_test,  d)).astype(np.float32)
+
+# --- single label ---
+n_classes = 10
+y_train = rng.integers(0, n_classes, size=n_train).astype(np.int64)
+
+cpu = KNNClassifier(n_neighbors=k, device="cpu").fit(X_train, y_train)
+cu  = KNNClassifier(n_neighbors=k, device="cuda").fit(X_train, y_train)
+
+p_cpu = cpu.predict(X_test)
+p_cu  = cu.predict(X_test)
+agree = float((p_cpu == p_cu).mean())
+print(f"singlelabel  predict agreement = {agree:.4f}  (n_classes={n_classes})")
+
+pp_cpu = cpu.predict_proba(X_test)
+pp_cu  = cu.predict_proba(X_test)
+print(f"singlelabel  predict_proba shapes = {pp_cpu.shape} {pp_cu.shape}")
+print(f"singlelabel  predict_proba max abs diff = {np.abs(pp_cpu - pp_cu).max():.4g}")
+
+# --- multilabel ---
+Y_train = (rng.random((n_train, n_classes)) > 0.7).astype(np.int64)
+cpu_ml = KNNClassifier(n_neighbors=k, device="cpu").fit(X_train, Y_train)
+cu_ml  = KNNClassifier(n_neighbors=k, device="cuda").fit(X_train, Y_train)
+
+p_cpu = cpu_ml.predict(X_test)
+p_cu  = cu_ml.predict(X_test)
+print(f"multilabel   predict shapes = {p_cpu.shape} {p_cu.shape}")
+print(f"multilabel   predict agreement = {float((p_cpu == p_cu).mean()):.4f}")
+
+pp_cpu = cpu_ml.predict_proba(X_test)
+pp_cu  = cu_ml.predict_proba(X_test)
+print(f"multilabel   predict_proba max abs diff = {np.abs(pp_cpu - pp_cu).max():.4g}")
+print("OK")

--- a/src/torchgeo_bench/knn.py
+++ b/src/torchgeo_bench/knn.py
@@ -22,8 +22,11 @@ logger = logging.getLogger(__name__)
 
 
 def _is_cpu_device(device: str) -> bool:
-    """Treat ``cpu`` (default) as CPU; anything else (``cuda``, ``cuda:0``, …)
-    routes through faissknn's GPU path."""
+    """Return True for the CPU faiss-cpu path, False for the GPU faissknn path.
+
+    Anything other than ``"cpu"`` (e.g. ``"cuda"``, ``"cuda:0"``) routes
+    through ``faissknn``.
+    """
     return str(device).lower() == "cpu"
 
 
@@ -126,7 +129,7 @@ class KNNClassifier:
         except ImportError as exc:  # pragma: no cover — covered by env, not unit tests
             raise ImportError(
                 f"KNNClassifier(device={self.device!r}) requires the 'cuda' extra. "
-                "Install with: pip install -e \".[cuda]\""
+                'Install with: pip install -e ".[cuda]"'
             ) from exc
 
         if self._multi_label:

--- a/src/torchgeo_bench/knn.py
+++ b/src/torchgeo_bench/knn.py
@@ -1,8 +1,12 @@
 """KNN classifier for torchgeo-bench.
 
-Unified k-nearest neighbors classifier supporting both single-label and
-multi-label classification using FAISS (CPU) for efficient nearest-neighbor
-search.
+Single-label and multi-label k-nearest neighbours backed by FAISS.
+
+CPU path (always available) uses ``faiss-cpu`` with ``IndexFlatL2`` and
+matches the historic implementation. GPU path (opt-in via the ``cuda``
+extra: ``pip install -e ".[cuda]"``) delegates to :mod:`faissknn`, which
+links against the GPU FAISS wheels (``faiss-cuda-cu128``). The two paths
+produce identical predictions modulo float-precision noise.
 """
 
 import logging
@@ -17,105 +21,150 @@ import numpy as np  # noqa: E402
 logger = logging.getLogger(__name__)
 
 
+def _is_cpu_device(device: str) -> bool:
+    """Treat ``cpu`` (default) as CPU; anything else (``cuda``, ``cuda:0``, …)
+    routes through faissknn's GPU path."""
+    return str(device).lower() == "cpu"
+
+
 class KNNClassifier:
-    """FAISS-backed KNN classifier supporting single-label and multi-label tasks.
+    """FAISS-backed KNN classifier with single- and multi-label support.
 
-    Mirrors the LogisticRegression API: ``fit(X, y)`` / ``predict(X)`` /
-    ``predict_proba(X)``.
-
-    Multi-label mode is auto-detected from the shape of ``y`` during ``fit``:
-    - 1-D ``y`` of shape ``(n_samples,)`` → single-label classification.
-    - 2-D ``y`` of shape ``(n_samples, n_classes)`` → multi-label classification.
+    Multi-label mode is auto-detected from the shape of ``y`` during
+    :meth:`fit`: 1-D labels → single-label, 2-D labels → multi-label.
 
     Args:
-        n_neighbors: Number of nearest neighbors (k). Clamped to ``min(k, n_train)``
-            at predict time.
+        n_neighbors: Number of neighbours (k). Clamped to ``min(k, n_train)``
+            on the CPU path; faissknn does not clamp internally.
+        device: ``"cpu"`` (default) → ``faiss-cpu``. Anything else
+            (``"cuda"``, ``"cuda:0"``) requires the ``cuda`` extra
+            (``faissknn``); raises :class:`ImportError` if not installed.
     """
 
-    def __init__(self, n_neighbors: int = 5) -> None:
-        self.n_neighbors = n_neighbors
+    def __init__(self, n_neighbors: int = 5, device: str = "cpu") -> None:
+        self.n_neighbors = int(n_neighbors)
+        self.device = device
 
+        # CPU path state
         self._index: faiss.Index | None = None
         self._y: np.ndarray | None = None
-        self._multi_label: bool = False
         self._n_classes: int | None = None
+        self._multi_label: bool = False
+
+        # GPU path state (faissknn delegate)
+        self._impl = None
 
     def fit(self, X: np.ndarray, y: np.ndarray) -> Self:
         """Index training features and store labels.
 
         Args:
-            X: Feature matrix of shape ``(n_samples, n_features)``, float32.
-            y: Labels — ``(n_samples,)`` for single-label or
-               ``(n_samples, n_classes)`` for multi-label.
+            X: ``(n_samples, n_features)`` float32 feature matrix.
+            y: ``(n_samples,)`` int single-label or
+               ``(n_samples, n_classes)`` multi-hot multi-label.
         """
         X = np.ascontiguousarray(np.atleast_2d(X).astype(np.float32))
+        self._multi_label = y.ndim == 2
 
+        if _is_cpu_device(self.device):
+            self._fit_cpu(X, y)
+        else:
+            self._fit_gpu(X, y)
+        return self
+
+    # ---- CPU path (faiss-cpu) ---------------------------------------------
+
+    def _fit_cpu(self, X: np.ndarray, y: np.ndarray) -> None:
         self._index = faiss.IndexFlatL2(X.shape[1])
         self._index.add(X)
-
-        if y.ndim == 2:
-            self._multi_label = True
-            self._n_classes = y.shape[1]
+        if self._multi_label:
+            self._n_classes = int(y.shape[1])
             self._y = y.astype(np.float32)
         else:
-            self._multi_label = False
             self._y = y.astype(np.int64)
             self._n_classes = int(np.max(self._y)) + 1
 
-        return self
+    def _search_cpu(self, X: np.ndarray) -> np.ndarray:
+        assert self._index is not None
+        X = np.ascontiguousarray(np.atleast_2d(X).astype(np.float32))
+        k_eff = min(self.n_neighbors, self._index.ntotal)
+        _, indices = self._index.search(X, k_eff)
+        return indices
+
+    def _predict_cpu(self, X: np.ndarray) -> np.ndarray:
+        assert self._y is not None
+        indices = self._search_cpu(X)
+        if self._multi_label:
+            scores = self._y[indices].mean(axis=1)
+            return (scores > 0.5).astype(np.int32)
+        neighbour_labels = self._y[indices]
+        counts = np.apply_along_axis(
+            lambda x: np.bincount(x, minlength=self._n_classes),
+            axis=1,
+            arr=neighbour_labels.astype(np.int16),
+        )
+        return np.argmax(counts, axis=1)
+
+    def _predict_proba_cpu(self, X: np.ndarray) -> np.ndarray:
+        assert self._y is not None
+        indices = self._search_cpu(X)
+        k_eff = indices.shape[1]
+        if self._multi_label:
+            return self._y[indices].mean(axis=1)
+        neighbour_labels = self._y[indices]
+        counts = np.apply_along_axis(
+            lambda x: np.bincount(x, minlength=self._n_classes),
+            axis=1,
+            arr=neighbour_labels.astype(np.int16),
+        )
+        return counts.astype(np.float32) / k_eff
+
+    # ---- GPU path (faissknn delegate) -------------------------------------
+
+    def _fit_gpu(self, X: np.ndarray, y: np.ndarray) -> None:
+        try:
+            from faissknn import FaissKNNClassifier, FaissKNNMultilabelClassifier
+        except ImportError as exc:  # pragma: no cover — covered by env, not unit tests
+            raise ImportError(
+                f"KNNClassifier(device={self.device!r}) requires the 'cuda' extra. "
+                "Install with: pip install -e \".[cuda]\""
+            ) from exc
+
+        if self._multi_label:
+            self._n_classes = int(y.shape[1])
+            self._impl = FaissKNNMultilabelClassifier(
+                n_neighbors=self.n_neighbors, device=self.device
+            )
+            self._impl.fit(X, y.astype(np.int64))
+        else:
+            self._n_classes = int(np.max(y)) + 1
+            self._impl = FaissKNNClassifier(
+                n_neighbors=self.n_neighbors,
+                n_classes=self._n_classes,
+                device=self.device,
+            )
+            self._impl.fit(X, y.astype(np.int64))
+
+    # ---- Public API -------------------------------------------------------
 
     @property
     def multi_label(self) -> bool:
         """Whether the classifier is in multi-label mode."""
         return self._multi_label
 
-    def _search(self, X: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
-        """Return (distances, indices) for k-nearest neighbors."""
-        assert self._index is not None and self._y is not None, "Call fit() first."
-        X = np.ascontiguousarray(np.atleast_2d(X).astype(np.float32))
-        k_eff = min(self.n_neighbors, self._index.ntotal)
-        return self._index.search(X, k_eff)
-
     def predict(self, X: np.ndarray) -> np.ndarray:
-        """Predict labels for X.
+        """Predict labels for ``X``.
 
-        Returns:
-            Single-label: integer class indices ``(n_samples,)``.
-            Multi-label: binary predictions ``(n_samples, n_classes)`` at threshold 0.5.
+        Returns single-label class indices ``(n_samples,)`` or multi-label
+        binary predictions ``(n_samples, n_classes)``.
         """
-        assert self._y is not None
-        _, indices = self._search(X)
-
-        if self._multi_label:
-            neighbor_labels = self._y[indices]  # (n_test, k, n_classes)
-            scores = neighbor_labels.mean(axis=1)
-            return (scores > 0.5).astype(np.int32)
-        neighbor_labels = self._y[indices]  # (n_test, k)
-        counts = np.apply_along_axis(
-            lambda x: np.bincount(x, minlength=self._n_classes),
-            axis=1,
-            arr=neighbor_labels.astype(np.int16),
-        )
-        return np.argmax(counts, axis=1)
+        if _is_cpu_device(self.device):
+            return self._predict_cpu(X)
+        assert self._impl is not None, "Call fit() first."
+        return self._impl.predict(np.ascontiguousarray(X.astype(np.float32)))
 
     def predict_proba(self, X: np.ndarray) -> np.ndarray:
-        """Predict per-class probabilities for X.
-
-        Returns:
-            Single-label: ``(n_samples, n_classes)`` with vote fractions.
-            Multi-label: ``(n_samples, n_classes)`` with mean neighbor labels.
-        """
-        assert self._y is not None
-        _, indices = self._search(X)
-        k_eff = indices.shape[1]
-
-        if self._multi_label:
-            neighbor_labels = self._y[indices]
-            return neighbor_labels.mean(axis=1)
-        neighbor_labels = self._y[indices]
-        counts = np.apply_along_axis(
-            lambda x: np.bincount(x, minlength=self._n_classes),
-            axis=1,
-            arr=neighbor_labels.astype(np.int16),
-        )
-        return counts.astype(np.float32) / k_eff
+        """Predict per-class probabilities ``(n_samples, n_classes)``."""
+        if _is_cpu_device(self.device):
+            return self._predict_proba_cpu(X)
+        assert self._impl is not None, "Call fit() first."
+        return self._impl.predict_proba(np.ascontiguousarray(X.astype(np.float32)))

--- a/src/torchgeo_bench/main.py
+++ b/src/torchgeo_bench/main.py
@@ -211,10 +211,11 @@ def evaluate_knn(
     seed: int,
     n_bootstrap: int,
     verbose: bool = False,
+    device: str = "cpu",
 ) -> tuple[float, float, float]:
     """Evaluate KNN classifier. Auto-detects single-label vs multi-label from y shape."""
     multi_label = y_train.ndim == 2
-    clf = KNNClassifier(n_neighbors=5)
+    clf = KNNClassifier(n_neighbors=5, device=device)
     clf.fit(x_train, y_train)
 
     if multi_label:
@@ -894,6 +895,7 @@ def main(cfg: DictConfig) -> None:
                     cfg.seed,
                     cfg.eval.bootstrap,
                     verbose=cfg.verbose,
+                    device=cfg.device,
                 )
                 all_rows.append(
                     EvaluationResult(

--- a/uv.lock
+++ b/uv.lock
@@ -724,6 +724,36 @@ wheels = [
 ]
 
 [[package]]
+name = "faiss-cuda-cu128"
+version = "1.14.1.post1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cuda-runtime-cu12" },
+    { name = "packaging" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/89/5749839df08a6a919d5f74d85d9ce69635a7043c9835bdafbc22670213e8/faiss_cuda_cu128-1.14.1.post1-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "sha256:a535f971df9bd2ecf0f2d9bb3d3229d5a86cda5abed0d8738873e2ca7e4ac96b", size = 99752739, upload-time = "2026-05-10T01:05:00.341Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/fb/cb3ddc48a34900a19768cc36804aedea349d4807226fee33aee8dbe5c65b/faiss_cuda_cu128-1.14.1.post1-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:54020a462d6daf33c8f7fa7f48e3838a4d38213a31b229057859517e627c4095", size = 99751626, upload-time = "2026-05-10T01:05:07.329Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/82/1959fb1fa29c05919207128d534fa8dc024d0a8a602d61dc6679bd1fee27/faiss_cuda_cu128-1.14.1.post1-cp314-cp314-manylinux_2_34_x86_64.whl", hash = "sha256:065c7268ab0a8c111a05ca39e1e8699d9f9dec1f5c2ac97fab96630b64dfc71f", size = 99752896, upload-time = "2026-05-10T01:05:14.853Z" },
+]
+
+[[package]]
+name = "faissknn"
+version = "0.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "faiss-cuda-cu128" },
+    { name = "numpy" },
+    { name = "torch" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/fb/1cea98c047d5b1eaee7d619a645c9648d02a8e693b09ee820cb3f07d4df2/faissknn-0.0.3.tar.gz", hash = "sha256:71b0c5bcad53877ab78f799f214c91082dd585ffe6900cbd859c4e905648626e", size = 4507, upload-time = "2026-05-10T02:51:38.3Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/d9/c558cac306fb480b5acd4ad4341e2690d61e77f7fd758952a34ebf983207/faissknn-0.0.3-py3-none-any.whl", hash = "sha256:b3aea067a2b22e0538471799d31d192c2275f2b51fd499debfc343ceaa191745", size = 4429, upload-time = "2026-05-10T02:51:39.385Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.29.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1827,6 +1857,19 @@ wheels = [
 ]
 
 [[package]]
+name = "nvidia-cublas-cu12"
+version = "12.9.2.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cuda-nvrtc-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/a2/c96163a0fff1839c0c9548bbdeae7b853b867009e33b9b9264adc238b1cf/nvidia_cublas_cu12-12.9.2.10-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:5572131a59c3eebeeb1c4c8144f772d49372c20124916e072a0e3fc30df421d5", size = 575012079, upload-time = "2026-04-08T18:51:47.303Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/c0/0a517bfe63ccd3b92eb254d264e28fca3c7cab75d07daea315250fb1bf73/nvidia_cublas_cu12-12.9.2.10-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:e4f53a8ca8c5d6e8c492d0d0a3d565ecb59a751b19cfdaa4f6da0ab2104c1702", size = 581240110, upload-time = "2026-04-08T18:52:31.532Z" },
+    { url = "https://files.pythonhosted.org/packages/20/e2/fc9a0e985249d873150276d5afb02e39a66817fedbf1a385724393e505ed/nvidia_cublas_cu12-12.9.2.10-py3-none-win_amd64.whl", hash = "sha256:623f43027d40d44ceadf0043f002bd25cf353e8f13ce90b9a87057019f560661", size = 553162896, upload-time = "2026-04-08T18:53:10.035Z" },
+]
+
+[[package]]
 name = "nvidia-cuda-cupti"
 version = "13.0.85"
 source = { registry = "https://pypi.org/simple" }
@@ -1845,12 +1888,32 @@ wheels = [
 ]
 
 [[package]]
+name = "nvidia-cuda-nvrtc-cu12"
+version = "12.9.86"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/85/e4af82cc9202023862090bfca4ea827d533329e925c758f0cde964cb54b7/nvidia_cuda_nvrtc_cu12-12.9.86-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:210cf05005a447e29214e9ce50851e83fc5f4358df8b453155d5e1918094dcb4", size = 89568129, upload-time = "2025-06-05T20:02:41.973Z" },
+    { url = "https://files.pythonhosted.org/packages/64/eb/c2295044b8f3b3b08860e2f6a912b702fc92568a167259df5dddb78f325e/nvidia_cuda_nvrtc_cu12-12.9.86-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:096d4de6bda726415dfaf3198d4f5c522b8e70139c97feef5cd2ca6d4cd9cead", size = 44528905, upload-time = "2025-06-05T20:02:29.754Z" },
+    { url = "https://files.pythonhosted.org/packages/52/de/823919be3b9d0ccbf1f784035423c5f18f4267fb0123558d58b813c6ec86/nvidia_cuda_nvrtc_cu12-12.9.86-py3-none-win_amd64.whl", hash = "sha256:72972ebdcf504d69462d3bcd67e7b81edd25d0fb85a2c46d3ea3517666636349", size = 76408187, upload-time = "2025-06-05T20:12:27.819Z" },
+]
+
+[[package]]
 name = "nvidia-cuda-runtime"
 version = "13.0.96"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/87/4f/17d7b9b8e285199c58ce28e31b5c5bbaa4d8271af06a89b6405258245de2/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ef9bcbe90493a2b9d810e43d249adb3d02e98dd30200d86607d8d02687c43f55", size = 2261060, upload-time = "2025-10-09T08:55:15.78Z" },
     { url = "https://files.pythonhosted.org/packages/2e/24/d1558f3b68b1d26e706813b1d10aa1d785e4698c425af8db8edc3dced472/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7f82250d7782aa23b6cfe765ecc7db554bd3c2870c43f3d1821f1d18aebf0548", size = 2243632, upload-time = "2025-10-09T08:55:36.117Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-runtime-cu12"
+version = "12.9.79"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/e0/0279bd94539fda525e0c8538db29b72a5a8495b0c12173113471d28bce78/nvidia_cuda_runtime_cu12-12.9.79-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:83469a846206f2a733db0c42e223589ab62fd2fabac4432d2f8802de4bded0a4", size = 3515012, upload-time = "2025-06-05T20:00:35.519Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/46/a92db19b8309581092a3add7e6fceb4c301a3fd233969856a8cbf042cd3c/nvidia_cuda_runtime_cu12-12.9.79-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:25bba2dfb01d48a9b59ca474a1ac43c6ebf7011f1b0b8cc44f54eb6ac48a96c3", size = 3493179, upload-time = "2025-06-05T20:00:53.735Z" },
+    { url = "https://files.pythonhosted.org/packages/59/df/e7c3a360be4f7b93cee39271b792669baeb3846c58a4df6dfcf187a7ffab/nvidia_cuda_runtime_cu12-12.9.79-py3-none-win_amd64.whl", hash = "sha256:8e018af8fa02363876860388bd10ccb89eb9ab8fb0aa749aaf58430a9f7c4891", size = 3591604, upload-time = "2025-06-05T20:11:17.036Z" },
 ]
 
 [[package]]
@@ -3722,6 +3785,7 @@ dependencies = [
 
 [package.optional-dependencies]
 all = [
+    { name = "faissknn" },
     { name = "linkify-it-py" },
     { name = "matplotlib" },
     { name = "mdformat" },
@@ -3738,6 +3802,9 @@ all = [
     { name = "terratorch" },
     { name = "torchid", marker = "python_full_version >= '3.13'" },
     { name = "transformers" },
+]
+cuda = [
+    { name = "faissknn" },
 ]
 dev = [
     { name = "mdformat" },
@@ -3774,6 +3841,7 @@ viz = [
 [package.metadata]
 requires-dist = [
     { name = "faiss-cpu", specifier = ">=1.7" },
+    { name = "faissknn", marker = "extra == 'cuda'", specifier = ">=0.0.3" },
     { name = "geobenchv2", specifier = ">=0.9" },
     { name = "h5py", specifier = ">=3.8" },
     { name = "huggingface-hub", specifier = ">=0.20" },
@@ -3796,10 +3864,11 @@ requires-dist = [
     { name = "scikit-learn", specifier = ">=1.3" },
     { name = "sphinx", marker = "extra == 'docs'", specifier = ">=7" },
     { name = "sphinx-copybutton", marker = "extra == 'docs'", specifier = ">=0.5" },
-    { name = "terratorch", marker = "extra == 'terratorch'", specifier = ">=1.0" },
+    { name = "terratorch", marker = "extra == 'terratorch'", specifier = ">=1" },
     { name = "timm", specifier = ">=0.9" },
     { name = "torch", specifier = ">=2" },
     { name = "torchgeo", git = "https://github.com/microsoft/torchgeo.git?rev=e585e2c07f7a" },
+    { name = "torchgeo-bench", extras = ["cuda"], marker = "extra == 'all'" },
     { name = "torchgeo-bench", extras = ["dev"], marker = "extra == 'all'" },
     { name = "torchgeo-bench", extras = ["docs"], marker = "extra == 'all'" },
     { name = "torchgeo-bench", extras = ["id"], marker = "extra == 'all'" },
@@ -3811,7 +3880,7 @@ requires-dist = [
     { name = "tqdm", specifier = ">=4.65" },
     { name = "transformers", marker = "extra == 'sam3'", specifier = ">=4.50" },
 ]
-provides-extras = ["all", "dev", "docs", "id", "olmoearth", "sam3", "terratorch", "viz"]
+provides-extras = ["all", "cuda", "dev", "docs", "id", "olmoearth", "sam3", "terratorch", "viz"]
 
 [[package]]
 name = "torchid"


### PR DESCRIPTION
## Summary

Adds a \`cuda\` optional-extra so \`KNNClassifier(device=\"cuda\")\` runs on GPU via [faissknn](https://pypi.org/project/faissknn/) (which links against [faiss-cuda-cu128](https://pypi.org/project/faiss-cuda-cu128/)). CPU path is untouched and still uses \`faiss-cpu\`.

\`\`\`bash
pip install -e \".[cuda]\"   # pulls faissknn>=0.0.3 + faiss-cuda-cu128
\`\`\`

\`evaluate_knn\` now accepts \`device=\` and threads it through from \`cfg.device\`, so probe sweeps automatically use the GPU path when CUDA is available.

## Why

KNN-5 over per-dataset embeddings is currently the slowest single-label classification step on large datasets (e.g. m-bigearthnet, eurosat-spatial). Moving the search to GPU drops it from minutes to seconds and unlocks larger \`k\` sweeps.

## Verification

A100 compute node smoke test (\`scripts/test_knn_gpu_smoke.py\` + \`scripts/slurm/knn_gpu_smoke.sh\`):

\`\`\`
faiss has GPU: True
singlelabel  predict agreement = 1.0000  (n_classes=10)
singlelabel  predict_proba max abs diff = 2.384e-08
multilabel   predict shapes = (500, 10) (500, 10)
multilabel   predict agreement = 1.0000
multilabel   predict_proba max abs diff = 2.384e-08
OK
\`\`\`

100% prediction agreement, prob diff at float-precision noise. Existing 18 KNN unit tests (CPU path) all pass.

## Caveats

- **glibc >= 2.34 required** for the cuda extra. \`faiss-cuda-cu128\` only ships \`manylinux_2_34\` wheels (cp311-cp314); on older hosts \`uv sync --extra cuda\` fails at resolution time. CI on ubuntu-latest (glibc 2.39) validates the install path. Our HPC cluster (glibc 2.28) cannot install the cuda extra today; \`faiss-cpu\` keeps working there.
- **H100 status**: A100 (SM 80) verified; H100 (SM 90) untested in this PR. Will be addressed when the cluster supports the \`manylinux_2_34\` wheels, since faissknn 0.0.3 is the only path we want to maintain.
- **Namespace conflict**: \`faiss-cpu\` and \`faiss-cuda-cu128\` both install to \`faiss/\`. Only install one per venv. The cuda extra does not list faiss-cpu, so a clean \`pip install -e \".[cuda]\"\` is fine; existing CPU venvs should not have the cuda extra grafted on top.

## Test plan

- [x] \`uv lock\` resolves \`faissknn==0.0.3 + faiss-cuda-cu128==1.14.1.post1\`
- [x] \`uv sync --extra dev\` (CPU only) — pytest tests/test_multilabel.py: 18/18 pass
- [x] A100 smoke: 100% CPU/GPU prediction agreement
- [ ] CI on ubuntu-latest installs cuda extra cleanly
- [ ] Re-run a probe sweep with \`device=cuda:0\` and confirm KNN time drops vs CPU baseline