### PR TITLE
ci(release): split build and publish into isolated jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,28 +5,61 @@ on:
     tags:
       - "v*"
 
+# Default workflow-level permissions: read-only. Jobs that need more
+# request the specific permission they need (and nothing else).
+permissions:
+  contents: read
+
 jobs:
-  release:
+  # ----------------------------------------------------------------------
+  # Build job: runs untrusted code (build backends, transitive build deps)
+  # but has no publish credentials. Its only output is the dist/ artifact.
+  # ----------------------------------------------------------------------
+  build:
+    name: Build sdist + wheel
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - name: Install uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
+        with:
+          enable-cache: true
+      - name: Build distributions
+        # NOTE: no `uv sync --extra dev` — PEP 517 builds use isolated
+        # build envs, and shrinking the host env minimises the surface
+        # area available to a hypothetically-malicious build dep.
+        run: uv build
+      - name: Upload distributions
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+          retention-days: 7
+
+  # ----------------------------------------------------------------------
+  # Publish job: never installs anything from PyPI, never executes any
+  # third-party code beyond actions/download-artifact and the official
+  # pypa/gh-action-pypi-publish action. It is the only job that holds the
+  # OIDC token used to authenticate with PyPI's trusted publisher.
+  # ----------------------------------------------------------------------
+  publish:
     name: Publish to PyPI
+    needs: build
     runs-on: ubuntu-latest
     environment:
       name: pypi
+      url: https://pypi.org/p/torchgeo-bench
     permissions:
-      contents: read
-      id-token: write
+      id-token: write   # OIDC for PyPI trusted publisher
     steps:
-      - uses: actions/checkout@v6
-
-      - name: Install uv and setup the python version
-        uses: astral-sh/setup-uv@v8.0.0
+      - name: Download distributions
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6
         with:
-          enable-cache: true
-
-      - name: Install the project
-        run: uv sync --extra dev
-
-      - name: Build wheel
-        run: uv build
-
-      - name: Publish package
-        run: uv publish
+          name: dist
+          path: dist/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1


### PR DESCRIPTION
## Summary

Hardens the PyPI publishing workflow against the Ultralytics-style supply-chain attack: a malicious build-time transitive dependency running arbitrary code in the same job that holds publish credentials, then exfiltrating them and racing a poisoned wheel to PyPI.

The fix is workflow-shape, not tool choice — same pattern applies to `uv`, `pip`, `hatch`, `flit`, etc.

## Threat model (before)

The previous single-job `release.yml` did `uv sync --extra dev` (hundreds of dev-extra packages + transitives), then `uv publish` (uses the OIDC token from the same env). A compromised transitive dep — typosquat, account hijack, dependency confusion, even a transitive sub-dep we never pinned — gets read access to:

- the OIDC token (`ACTIONS_ID_TOKEN_REQUEST_TOKEN` / `..._URL`),
- the `GITHUB_TOKEN`,
- whatever else is in `env` at exec time,

and can either exfiltrate them or race the legitimate publish with a poisoned artifact.

This is exactly the Ultralytics 2024 incident pattern.

## Fix

Four independent layers, each useful on its own:

1. **Split build and publish into separate jobs.**
   - `build`: no `id-token`, no secrets. Output: `dist/` artifact only. Can run any untrusted code without consequence.
   - `publish`: no checkout, no installs from PyPI, no environment dev deps. Only downloads the already-built artifact and runs the publish action.
2. **Drop `uv sync --extra dev`.** PEP 517 builds use isolated build envs; the host env doesn't need the dev extra installed.
3. **Use `pypa/gh-action-pypi-publish`** instead of `uv publish`. Minimal surface area; audited; designed specifically for OIDC trusted publishing.
4. **Pin every action to a full commit SHA**, not a major tag. Tags can be repointed by an attacker who compromises a maintainer (e.g. `tj-actions/changed-files` 2025); SHAs cannot.

Also: workflow-level `permissions: contents: read` default; each job requests only what it needs. The publish job has *only* `id-token: write`.

## Why this is materially safer

- A malicious build-time dependency now runs in a job with no PyPI credentials and no publishing permission. Best case for the attacker: read-only access to a `dist/` they helped build.
- The publish job never installs anything from PyPI and only runs two well-known, pinned-by-SHA actions. The token only ever exists in this minimal job.

## Test plan

- [x] YAML syntax check: `python -c 'import yaml; yaml.safe_load(open(".github/workflows/release.yml"))'` passes.
- [ ] Workflow only runs on `v*` tag push, so no CI run is triggered by this PR; the next tag release will exercise it end-to-end.
- [ ] After merge, on the next `v*` tag we expect: `build` job uploads `dist/`, `publish` job downloads `dist/`, action authenticates via OIDC to `https://pypi.org/p/torchgeo-bench`, wheel + sdist appear on PyPI.

## Bonus (out of scope, easy follow-ups)

- Add `attestations: true` to the publish action + `attestations: write` permission to generate Sigstore attestations PyPI now displays.
- Add a `verify` job between build and publish that `twine check`s the artifact and installs it into a fresh venv.
- Add `concurrency: pypi-publish` to prevent two tag pushes racing.

These don't change the threat model, only widen the safety net.

## References

- pypa/gh-action-pypi-publish: https://github.com/pypa/gh-action-pypi-publish
- PyPI trusted publishers: https://docs.pypi.org/trusted-publishers/
- Ultralytics 2024 incident: https://blog.pypi.org/posts/2024-12-11-ultralytics-attack-analysis/