### PR TITLE
ci: cache .venv on uv.lock hash

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,8 +16,16 @@ jobs:
       - uses: astral-sh/setup-uv@v8.0.0
         with:
           enable-cache: true
+      # Cache `.venv` keyed on uv.lock + python version + OS. When the lock
+      # hasn't changed (the common case on a feature branch), `uv sync
+      # --frozen` becomes a near-no-op and shaves ~30s off this job.
+      - name: Cache .venv
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-py3.12-${{ hashFiles('uv.lock') }}-dev
       - name: Install dependencies
-        run: uv sync --extra dev
+        run: uv sync --extra dev --frozen
       - name: Run tests
         # `-n auto` parallelises across the runner's CPUs (typically 4 on
         # GitHub-hosted ubuntu-latest). `--dist=loadfile` groups tests by
@@ -33,7 +41,12 @@ jobs:
       - uses: astral-sh/setup-uv@v8.0.0
         with:
           enable-cache: true
+      - name: Cache .venv
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-py3.12-${{ hashFiles('uv.lock') }}-dev
       - name: Install dependencies
-        run: uv sync --extra dev
+        run: uv sync --extra dev --frozen
       - name: Run pre-commit
         run: uv run pre-commit run --all-files -v

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,5 +48,13 @@ jobs:
           key: venv-${{ runner.os }}-py3.12-${{ hashFiles('uv.lock') }}-dev
       - name: Install dependencies
         run: uv sync --extra dev --frozen
+      # Cache the pre-commit hook environments (~/.cache/pre-commit/),
+      # keyed on the pinned hook revisions in .pre-commit-config.yaml.
+      # Saves ~20-30s on every CI run by skipping hook-env setup.
+      - name: Cache pre-commit hooks
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
       - name: Run pre-commit
         run: uv run pre-commit run --all-files -v


### PR DESCRIPTION
## Summary

After #56 the CI test job timing was:

```
Install dependencies: 37s   ← what this PR cuts
Run tests:            32s
```

`astral-sh/setup-uv@v8` with `enable-cache: true` caches `~/.cache/uv` (downloaded wheels/sdists), so `uv sync` doesn't re-download — but it still has to install each cached wheel into a fresh `.venv/`. That's where the 37s goes.

This PR caches `.venv/` itself, keyed on `(runner.os, python-version, hashFiles('uv.lock'))`. On a cache hit `uv sync --frozen` is a near-no-op. First run after a lock change is identical to today (cache miss).

Also switches `uv sync` to `--frozen` to enforce lock-only resolution — CI can no longer silently bump a transitive dep if the lock is stale.

Applied to both `test` and `pre-commit` jobs since both call `uv sync --extra dev`.

## Expected impact

| Step | Today | With cache hit |
|---|---|---|
| Set up uv | 2s | 2s |
| Cache `.venv` | — | 1–3s (restore) |
| Install dependencies | 37s | <5s |
| Run tests | 32s | 32s |
| **Total** | **~71s** | **~40s** |

About 30s shaved off every CI run with no change in correctness.

## Test plan

- [x] YAML syntax check.
- [ ] CI run shows cache miss on this PR (first time the key exists), then the next push to the same branch should hit the cache.
- [ ] Lock change (e.g. adding a dep) correctly invalidates the cache.