### PR TITLE
perf: drop redundant copies, vectorize resume scan, trim comments

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,8 @@ permissions:
   contents: read
 
 jobs:
-  # ----------------------------------------------------------------------
   # Build job: runs untrusted code (build backends, transitive build deps)
   # but has no publish credentials. Its only output is the dist/ artifact.
-  # ----------------------------------------------------------------------
   build:
     name: Build sdist + wheel
     runs-on: ubuntu-latest
@@ -40,12 +38,10 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
-  # ----------------------------------------------------------------------
   # Publish job: never installs anything from PyPI, never executes any
   # third-party code beyond actions/download-artifact and the official
   # pypa/gh-action-pypi-publish action. It is the only job that holds the
   # OIDC token used to authenticate with PyPI's trusted publisher.
-  # ----------------------------------------------------------------------
   publish:
     name: Publish to PyPI
     needs: build

--- a/scripts/analyze_geobench_classes.py
+++ b/scripts/analyze_geobench_classes.py
@@ -126,7 +126,6 @@ def analyze_dataset(
 
             desc = f"{dataset_name}/{split}"
             for batch in tqdm(dataloader, desc=desc, disable=not verbose):
-                # Get labels or masks
                 if task_type == "classification":
                     if "label" in batch:
                         values = batch["label"]
@@ -143,7 +142,6 @@ def analyze_dataset(
                 if values is None:
                     continue
 
-                # Convert to tensor if needed
                 if isinstance(values, list):
                     values = (
                         torch.stack(values)
@@ -151,17 +149,14 @@ def analyze_dataset(
                         else torch.tensor(values)
                     )
 
-                # Get unique values
                 unique = torch.unique(values).tolist()
                 split_result["unique_values"].update(unique)
                 results["all_unique_values"].update(unique)
 
-                # Update counts
                 for val in unique:
                     count = (values == val).sum().item()
                     results["value_counts"][val] += count
 
-                # Track min/max
                 val_min = values.min().item()
                 val_max = values.max().item()
                 if split_result["min_value"] is None or val_min < split_result["min_value"]:

--- a/src/torchgeo_bench/linear.py
+++ b/src/torchgeo_bench/linear.py
@@ -298,9 +298,9 @@ class LogisticRegression:
         with torch.inference_mode():
             logits = self._model(X_tensor)
             if self.multi_label:
-                probs = torch.sigmoid(logits).detach().cpu().numpy()
+                probs = torch.sigmoid(logits).cpu().numpy()
             else:
-                probs = torch.softmax(logits, dim=1).detach().cpu().numpy()
+                probs = torch.softmax(logits, dim=1).cpu().numpy()
         return probs
 
     def decision_function(self, X: Tensor) -> np.ndarray:
@@ -321,7 +321,7 @@ class LogisticRegression:
         X_tensor = X.to(self.device, dtype=torch.float32, non_blocking=True).contiguous()
         self._model.eval()
         with torch.inference_mode():
-            logits = self._model(X_tensor).detach().cpu().numpy()
+            logits = self._model(X_tensor).cpu().numpy()
         return logits
 
     def __repr__(self) -> str:  # pragma: no cover

--- a/src/torchgeo_bench/main.py
+++ b/src/torchgeo_bench/main.py
@@ -657,22 +657,23 @@ def main(cfg: DictConfig) -> None:
     completed_runs: set[tuple[str, ...]] = set()
     if cfg.resume and os.path.exists(output_path):
         existing_df = pd.read_csv(cfg.output)
-        # Track (dataset, method, model, name, normalization, image_size,
-        # interpolation, partition, bands) tuples
-        for _, row in existing_df.iterrows():
-            completed_runs.add(
-                (
-                    str(row.get("dataset", "")),
-                    str(row.get("method", "")),
-                    str(row.get("model", "")),
-                    str(row.get("name", "")),
-                    str(row.get("normalization", "")),
-                    str(row.get("image_size", "")),
-                    str(row.get("interpolation", "")),
-                    str(row.get("partition", "")),
-                    str(row.get("bands", "")),
-                )
-            )
+        key_cols = (
+            "dataset",
+            "method",
+            "model",
+            "name",
+            "normalization",
+            "image_size",
+            "interpolation",
+            "partition",
+            "bands",
+        )
+        for col in key_cols:
+            if col not in existing_df.columns:
+                existing_df[col] = ""
+        completed_runs = set(
+            map(tuple, existing_df[list(key_cols)].fillna("").astype(str).to_numpy())
+        )
         logger.info(f"Resume mode: Found {len(completed_runs)} existing results in {cfg.output}")
         logger.info("Will skip already-computed (dataset, method, model, config) combinations.")
 

--- a/src/torchgeo_bench/models/rcf.py
+++ b/src/torchgeo_bench/models/rcf.py
@@ -112,7 +112,9 @@ class RCF(nn.Module):
                 (num_patches, num_channels, kernel_size, kernel_size), dtype=np.float32
             )
             idxs = torch.randint(0, len(dataset), (num_patches,), generator=generator).tolist()
-            ys = torch.randint(0, height - kernel_size, (num_patches,), generator=generator).tolist()
+            ys = torch.randint(
+                0, height - kernel_size, (num_patches,), generator=generator
+            ).tolist()
             xs = torch.randint(0, width - kernel_size, (num_patches,), generator=generator).tolist()
 
             for i, (di, y, x) in enumerate(zip(idxs, ys, xs)):

--- a/src/torchgeo_bench/models/rcf.py
+++ b/src/torchgeo_bench/models/rcf.py
@@ -111,13 +111,13 @@ class RCF(nn.Module):
             patches = np.zeros(
                 (num_patches, num_channels, kernel_size, kernel_size), dtype=np.float32
             )
-            idxs = torch.randint(0, len(dataset), (num_patches,), generator=generator).numpy()
-            ys = torch.randint(0, height - kernel_size, (num_patches,), generator=generator).numpy()
-            xs = torch.randint(0, width - kernel_size, (num_patches,), generator=generator).numpy()
+            idxs = torch.randint(0, len(dataset), (num_patches,), generator=generator).tolist()
+            ys = torch.randint(0, height - kernel_size, (num_patches,), generator=generator).tolist()
+            xs = torch.randint(0, width - kernel_size, (num_patches,), generator=generator).tolist()
 
-            for i in range(num_patches):
-                img = dataset[idxs[i]]["image"]
-                patches[i] = img[:, ys[i] : ys[i] + kernel_size, xs[i] : xs[i] + kernel_size]
+            for i, (di, y, x) in enumerate(zip(idxs, ys, xs)):
+                img = dataset[di]["image"]
+                patches[i] = img[:, y : y + kernel_size, x : x + kernel_size]
 
             patches = self._normalize(patches)
             self.weights = torch.tensor(patches)
@@ -229,8 +229,8 @@ class _NormalizingDatasetView(Dataset):
     def __init__(self, base: Dataset, mean: torch.Tensor, std: torch.Tensor) -> None:
         self._base = base
         # Per-channel (C, 1, 1) tensors for sample-level normalization.
-        self._mean = mean.detach().clone().view(-1, 1, 1).cpu().float()
-        self._std = std.detach().clone().clamp_min(1e-8).view(-1, 1, 1).cpu().float()
+        self._mean = mean.detach().view(-1, 1, 1).cpu().float()
+        self._std = std.detach().clamp_min(1e-8).view(-1, 1, 1).cpu().float()
 
     def __len__(self) -> int:
         return len(self._base)  # type: ignore[arg-type]

--- a/src/torchgeo_bench/utils.py
+++ b/src/torchgeo_bench/utils.py
@@ -46,14 +46,14 @@ def extract_features(
         with torch.no_grad(), torch.inference_mode():
             features = model(images)
             if isinstance(features, torch.Tensor):
-                features = features.detach().cpu().numpy()
+                features = features.cpu().numpy()
             else:
                 if "norm" in features:
-                    features = features["norm"].detach().cpu().numpy()
+                    features = features["norm"].cpu().numpy()
                 elif "global_pool" in features:
-                    features = features["global_pool"].detach().cpu().numpy()
+                    features = features["global_pool"].cpu().numpy()
                 elif "head.global_pool" in features:
-                    features = features["head.global_pool"].detach().cpu().numpy().squeeze()
+                    features = features["head.global_pool"].cpu().numpy().squeeze()
                 else:
                     raise ValueError(f"Unexpected features format: {features.keys()}")
 


### PR DESCRIPTION
## Summary
- Drop redundant `.detach()` calls inside `inference_mode()` blocks (`linear.py`, `utils.py`)
- Drop `.detach().clone()` → `.detach()` on detached buffer mean/std (`models/rcf.py`)
- RCF patch-sampling loop: `.numpy()` → `.tolist()` + `enumerate(zip(...))` (fewer copies)
- Vectorize `df.iterrows()` resume-scan in `main.py` using `astype(str).to_numpy()`
- Cut 4 self-narrating comments in `scripts/analyze_geobench_classes.py`
- Strip 2 banner-divider blocks in `.github/workflows/release.yml` (kept security rationale)

No dep changes — investigated `geobenchv2` / `faiss-cpu` / `huggingface-hub` for wheel-size cuts, all are actually required by core features.

## Test plan
- [x] `ruff check` clean on edited files
- [x] `pytest tests/test_logistic_regression_parity.py tests/test_multilabel.py tests/test_bench_model.py tests/test_band_mapping.py` — 33/33 pass
- [ ] Full CI green