### PR TITLE
feat: track backbone throughput, peak GPU mem, latency, params, GMACs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ optional-dependencies.all = [
   "torchgeo-bench[dev]",
   "torchgeo-bench[docs]",
   "torchgeo-bench[id]",
+  "torchgeo-bench[perf]",
   "torchgeo-bench[sam3]",
   "torchgeo-bench[terratorch]",
   "torchgeo-bench[viz]",
@@ -92,6 +93,9 @@ optional-dependencies.id = [
 ]
 optional-dependencies.olmoearth = [
   "olmoearth-pretrain-minimal>=0.0.2",
+]
+optional-dependencies.perf = [
+  "fvcore>=0.1.5",
 ]
 optional-dependencies.sam3 = [
   "transformers>=4.50",

--- a/scripts/slurm/probe_sweep.sh
+++ b/scripts/slurm/probe_sweep.sh
@@ -65,4 +65,5 @@ torchgeo-bench run \
   dataset.normalization="${NORM}" \
   resume=true \
   output=results/all_results.csv \
-  eval.intrinsic_dim.enabled=true
+  eval.intrinsic_dim.enabled=true \
+  eval.model_perf.enabled=true

--- a/src/torchgeo_bench/conf/config.yaml
+++ b/src/torchgeo_bench/conf/config.yaml
@@ -40,6 +40,15 @@ eval:
     max_samples: 10000               # null disables subsampling
     device: null                     # null = auto (cuda if available, else cpu)
 
+  # Backbone performance metrics (throughput, peak GPU mem, latency,
+  # params, GMACs). One row per metric with method="model_perf".
+  # GMACs requires fvcore (`pip install 'torchgeo-bench[perf]'`); other
+  # metrics work without extra deps.
+  model_perf:
+    enabled: false
+    n_warmup: 3                      # forward passes discarded before timing
+    n_measure: 20                    # timed forward passes
+
   segmentation:
     head_type: "fpn"
     layers: []                 # must be overridden per model for segmentation datasets

--- a/src/torchgeo_bench/main.py
+++ b/src/torchgeo_bench/main.py
@@ -26,6 +26,7 @@ from torchgeo_bench.datasets import (
 from torchgeo_bench.intrinsic_dim import compute_intrinsic_dim
 from torchgeo_bench.knn import KNNClassifier
 from torchgeo_bench.linear import LogisticRegression
+from torchgeo_bench.model_perf import measure_model_perf
 from torchgeo_bench.models.interface import BenchModel
 from torchgeo_bench.segmentation_probe import (
     SegmentationProbe,
@@ -491,6 +492,51 @@ def evaluate_intrinsic_dim(
     return rows
 
 
+def evaluate_model_perf(
+    model: BenchModel,
+    sample_loader: DataLoader,
+    device: torch.device,
+    n_warmup: int,
+    n_measure: int,
+    common_meta: dict,
+    feature_dim: int,
+    n_counts: dict[str, int],
+) -> list[dict]:
+    """Measure backbone throughput / memory / GMACs and return CSV rows.
+
+    One row per metric, with ``method="model_perf"``.
+    """
+    try:
+        sample = next(iter(sample_loader))["image"].to(device)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(f"[model-perf] could not fetch sample batch: {exc}; skipping")
+        return []
+
+    metrics = measure_model_perf(model, sample, device, n_warmup=n_warmup, n_measure=n_measure)
+    rows: list[dict] = []
+    for name, value in metrics.items():
+        if value is None:
+            continue
+        rows.append(
+            EvaluationResult(
+                **common_meta,
+                method="model_perf",
+                metric_name=name,
+                metric_value=float(value),
+                ci_lower=0.0,
+                ci_upper=0.0,
+                feature_dim=feature_dim,
+                best_c=None,
+                best_lr=None,
+                best_batch_size=None,
+                n_train=n_counts.get("train", 0),
+                n_val=n_counts.get("val", 0),
+                n_test=n_counts.get("test", 0),
+            ).to_row()
+        )
+    return rows
+
+
 def evaluate_segmentation(
     model: torch.nn.Module,
     train_loader: DataLoader,
@@ -714,6 +760,7 @@ def main(cfg: DictConfig) -> None:
         seg_method = f"seg-{eval_cfg_merged.segmentation.head_type}"
         seg_key = (ds_name, seg_method, cfg.model._target_, cfg.model.name, *config_tuple)
         id_key = (ds_name, "intrinsic_dim", cfg.model._target_, cfg.model.name, *config_tuple)
+        perf_key = (ds_name, "model_perf", cfg.model._target_, cfg.model.name, *config_tuple)
 
         try:
             result = get_datasets(
@@ -878,8 +925,11 @@ def main(cfg: DictConfig) -> None:
             id_cfg = getattr(cfg.eval, "intrinsic_dim", None)
             id_enabled = bool(id_cfg and id_cfg.get("enabled", False))
             skip_id = (not id_enabled) or (cfg.resume and id_key in completed_runs)
+            perf_cfg = getattr(cfg.eval, "model_perf", None)
+            perf_enabled = bool(perf_cfg and perf_cfg.get("enabled", False))
+            skip_perf = (not perf_enabled) or (cfg.resume and perf_key in completed_runs)
 
-            if skip_knn and skip_linear and skip_id:
+            if skip_knn and skip_linear and skip_id and skip_perf:
                 continue
 
             x_train, y_train = embed_split(model, train_loader, device, verbose=cfg.verbose)
@@ -967,6 +1017,23 @@ def main(cfg: DictConfig) -> None:
                     verbose=cfg.verbose,
                 )
                 all_rows.extend(id_rows)
+
+            if not skip_perf:
+                perf_rows = evaluate_model_perf(
+                    model=model,
+                    sample_loader=train_loader,
+                    device=torch.device(cfg.device),
+                    n_warmup=int(perf_cfg.get("n_warmup", 3)),
+                    n_measure=int(perf_cfg.get("n_measure", 20)),
+                    common_meta=common_meta,
+                    feature_dim=feature_dim,
+                    n_counts={
+                        "train": len(x_train),
+                        "val": len(x_val),
+                        "test": len(x_test),
+                    },
+                )
+                all_rows.extend(perf_rows)
 
         append_rows_atomic(output_path, all_rows)
         all_rows.clear()

--- a/src/torchgeo_bench/model_perf.py
+++ b/src/torchgeo_bench/model_perf.py
@@ -1,0 +1,107 @@
+"""Backbone-only performance metrics for benchmark models.
+
+Measured once per (model, dataset, bands) combination, isolated from
+dataloader overhead. Reports:
+
+- ``throughput_samples_per_sec`` — sustained samples/s on a fixed batch
+- ``latency_ms_per_batch_p50`` — median per-batch forward latency
+- ``peak_gpu_mem_gb`` — peak CUDA memory during measurement
+- ``params_m`` — total parameter count (millions)
+- ``gmacs`` — multiply-accumulate count for one sample, via ``fvcore`` if
+  installed; ``None`` otherwise
+
+GMACs depend on ``fvcore`` (in the ``[perf]`` extra). All other metrics
+work without extra deps.
+"""
+
+import logging
+import time
+from statistics import median
+
+import torch
+from torch import nn
+
+logger = logging.getLogger(__name__)
+
+
+def _count_params(model: nn.Module) -> float:
+    total = sum(p.numel() for p in model.parameters())
+    return total / 1e6
+
+
+def _count_gmacs(model: nn.Module, sample: torch.Tensor) -> float | None:
+    try:
+        from fvcore.nn import FlopCountAnalysis
+    except ImportError:
+        logger.info("fvcore not installed — GMACs unavailable (`pip install fvcore`).")
+        return None
+
+    one = sample[:1]
+    try:
+        flop = FlopCountAnalysis(model, one)
+        flop.unsupported_ops_warnings(False)
+        flop.uncalled_modules_warnings(False)
+        return float(flop.total()) / 1e9
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(f"fvcore FlopCountAnalysis failed: {exc}")
+        return None
+
+
+def measure_model_perf(
+    model: nn.Module,
+    sample_batch: torch.Tensor,
+    device: torch.device,
+    n_warmup: int = 3,
+    n_measure: int = 20,
+) -> dict[str, float | None]:
+    """Run forward-only timing + memory profiling on a fixed batch.
+
+    Args:
+        model: BenchModel (its ``forward`` goes through normalization +
+            ``_forward_patch_features``).
+        sample_batch: representative batch shaped ``(B, C, H, W)``, already
+            on ``device``.
+        device: torch device used for the measurement.
+        n_warmup: forward passes discarded before timing.
+        n_measure: timed forward passes.
+
+    Returns:
+        Mapping with keys ``throughput_samples_per_sec``,
+        ``latency_ms_per_batch_p50``, ``peak_gpu_mem_gb``, ``params_m``,
+        ``gmacs`` (GMACs may be ``None``).
+    """
+    model.eval()
+    batch_size = sample_batch.shape[0]
+    is_cuda = device.type == "cuda"
+
+    with torch.inference_mode():
+        for _ in range(n_warmup):
+            model(sample_batch)
+
+        if is_cuda:
+            torch.cuda.synchronize(device)
+            torch.cuda.reset_peak_memory_stats(device)
+
+        per_batch_ms: list[float] = []
+        t0 = time.perf_counter()
+        for _ in range(n_measure):
+            tb0 = time.perf_counter()
+            model(sample_batch)
+            if is_cuda:
+                torch.cuda.synchronize(device)
+            per_batch_ms.append((time.perf_counter() - tb0) * 1000.0)
+        total_s = time.perf_counter() - t0
+
+    throughput = (batch_size * n_measure) / total_s
+    latency_p50 = median(per_batch_ms)
+    peak_gb = torch.cuda.max_memory_allocated(device) / 1024**3 if is_cuda else None
+    gmacs = _count_gmacs(model, sample_batch)
+    params_m = _count_params(model)
+
+    return {
+        "throughput_samples_per_sec": float(throughput),
+        "latency_ms_per_batch_p50": float(latency_p50),
+        "peak_gpu_mem_gb": float(peak_gb) if peak_gb is not None else None,
+        "params_m": float(params_m),
+        "gmacs": gmacs,
+    }

--- a/uv.lock
+++ b/uv.lock
@@ -932,6 +932,22 @@ http = [
 ]
 
 [[package]]
+name = "fvcore"
+version = "0.1.5.post20221221"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "iopath" },
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "pyyaml" },
+    { name = "tabulate" },
+    { name = "termcolor" },
+    { name = "tqdm" },
+    { name = "yacs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a5/93/d056a9c4efc6c79ba7b5159cc66bb436db93d2cc46dca18ed65c59cc8e4e/fvcore-0.1.5.post20221221.tar.gz", hash = "sha256:f2fb0bb90572ae651c11c78e20493ed19b2240550a7e4bbb2d6de87bdd037860", size = 50217, upload-time = "2022-12-21T08:10:53.563Z" }
+
+[[package]]
 name = "geobenchv2"
 version = "0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -1244,6 +1260,17 @@ sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
+
+[[package]]
+name = "iopath"
+version = "0.1.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "portalocker" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/73/b3d451dfc523756cf177d3ebb0af76dc7751b341c60e2a21871be400ae29/iopath-0.1.10.tar.gz", hash = "sha256:3311c16a4d9137223e20f141655759933e1eda24f8bff166af834af3c645ef01", size = 42226, upload-time = "2022-07-09T19:00:50.866Z" }
 
 [[package]]
 name = "jinja2"
@@ -2273,6 +2300,18 @@ wheels = [
 ]
 
 [[package]]
+name = "portalocker"
+version = "3.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/77/65b857a69ed876e1951e88aaba60f5ce6120c33703f7cb61a3c894b8c1b6/portalocker-3.2.0.tar.gz", hash = "sha256:1f3002956a54a8c3730586c5c77bf18fae4149e07eaf1c29fc3faf4d5a3f89ac", size = 95644, upload-time = "2025-06-14T13:20:40.03Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/a6/38c8e2f318bf67d338f4d629e93b0b4b9af331f455f0390ea8ce4a099b26/portalocker-3.2.0-py3-none-any.whl", hash = "sha256:3cdc5f565312224bc570c49337bd21428bba0ef363bbcf58b9ef4a9f11779968", size = 22424, upload-time = "2025-06-14T13:20:38.083Z" },
+]
+
+[[package]]
 name = "pre-commit"
 version = "4.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2867,6 +2906,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ca/5e/90b39adff710d698c00ba9c3125e2bec99dad7c5f1a3ba37c73a78a6689f/pywavelets-1.9.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9950eb7c8b942e9bfa53d87c7e45a420dcddbd835c4c5f1aca045a3f775c6113", size = 4477378, upload-time = "2025-08-04T16:19:58.162Z" },
     { url = "https://files.pythonhosted.org/packages/f1/1a/89f5f4ebcb9d34d9b7b2ac0a868c8b6d8c78d699a36f54407a060cea0566/pywavelets-1.9.0-cp314-cp314t-win32.whl", hash = "sha256:097f157e07858a1eb370e0d9c1bd11185acdece5cca10756d6c3c7b35b52771a", size = 4209132, upload-time = "2025-08-04T16:20:00.371Z" },
     { url = "https://files.pythonhosted.org/packages/68/d2/a8065103f5e2e613b916489e6c85af6402a1ec64f346d1429e2d32cb8d03/pywavelets-1.9.0-cp314-cp314t-win_amd64.whl", hash = "sha256:3b6ff6ba4f625d8c955f68c2c39b0a913776d406ab31ee4057f34ad4019fb33b", size = 4306793, upload-time = "2025-08-04T16:20:02.934Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/ab/01ea1943d4eba0f850c3c61e78e8dd59757ff815ff3ccd0a84de5f541f42/pywin32-311-cp312-cp312-win32.whl", hash = "sha256:750ec6e621af2b948540032557b10a2d43b0cee2ae9758c54154d711cc852d31", size = 8706543, upload-time = "2025-07-14T20:13:20.765Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a8/a0e8d07d4d051ec7502cd58b291ec98dcc0c3fff027caad0470b72cfcc2f/pywin32-311-cp312-cp312-win_amd64.whl", hash = "sha256:b8c095edad5c211ff31c05223658e71bf7116daa0ecf3ad85f3201ea3190d067", size = 9495040, upload-time = "2025-07-14T20:13:22.543Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/3a/2ae996277b4b50f17d61f0603efd8253cb2d79cc7ae159468007b586396d/pywin32-311-cp312-cp312-win_arm64.whl", hash = "sha256:e286f46a9a39c4a18b319c28f59b61de793654af2f395c102b4f819e584b5852", size = 8710102, upload-time = "2025-07-14T20:13:24.682Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700, upload-time = "2025-07-14T20:13:26.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700, upload-time = "2025-07-14T20:13:28.243Z" },
+    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318, upload-time = "2025-07-14T20:13:30.348Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
+    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
 ]
 
 [[package]]
@@ -3629,6 +3684,15 @@ wheels = [
 ]
 
 [[package]]
+name = "tabulate"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/58/8c37dea7bbf769b20d58e7ace7e5edfe65b849442b00ffcdd56be88697c6/tabulate-0.10.0.tar.gz", hash = "sha256:e2cfde8f79420f6deeffdeda9aaec3b6bc5abce947655d17ac662b126e48a60d", size = 91754, upload-time = "2026-03-04T18:55:34.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl", hash = "sha256:f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3", size = 39814, upload-time = "2026-03-04T18:55:31.284Z" },
+]
+
+[[package]]
 name = "tacoreader"
 version = "0.5.6"
 source = { registry = "https://pypi.org/simple" }
@@ -3891,6 +3955,7 @@ dependencies = [
 all = [
     { name = "cleanlab" },
     { name = "faissknn" },
+    { name = "fvcore" },
     { name = "imagehash" },
     { name = "linkify-it-py" },
     { name = "matplotlib" },
@@ -3941,6 +4006,9 @@ id = [
 olmoearth = [
     { name = "olmoearth-pretrain-minimal" },
 ]
+perf = [
+    { name = "fvcore" },
+]
 sam3 = [
     { name = "transformers" },
 ]
@@ -3957,6 +4025,7 @@ requires-dist = [
     { name = "cleanlab", marker = "extra == 'cleanlab'", specifier = ">=2.7" },
     { name = "faiss-cpu", specifier = ">=1.7" },
     { name = "faissknn", marker = "extra == 'cuda'", specifier = ">=0.0.3" },
+    { name = "fvcore", marker = "extra == 'perf'", specifier = ">=0.1.5" },
     { name = "geobenchv2", specifier = ">=0.9" },
     { name = "h5py", specifier = ">=3.8" },
     { name = "huggingface-hub", specifier = ">=0.20" },
@@ -3992,6 +4061,7 @@ requires-dist = [
     { name = "torchgeo-bench", extras = ["dev"], marker = "extra == 'all'" },
     { name = "torchgeo-bench", extras = ["docs"], marker = "extra == 'all'" },
     { name = "torchgeo-bench", extras = ["id"], marker = "extra == 'all'" },
+    { name = "torchgeo-bench", extras = ["perf"], marker = "extra == 'all'" },
     { name = "torchgeo-bench", extras = ["sam3"], marker = "extra == 'all'" },
     { name = "torchgeo-bench", extras = ["terratorch"], marker = "extra == 'all'" },
     { name = "torchgeo-bench", extras = ["viz"], marker = "extra == 'all'" },
@@ -4000,7 +4070,7 @@ requires-dist = [
     { name = "tqdm", specifier = ">=4.65" },
     { name = "transformers", marker = "extra == 'sam3'", specifier = ">=4.50" },
 ]
-provides-extras = ["all", "cleanlab", "cuda", "dev", "docs", "id", "olmoearth", "sam3", "terratorch", "viz"]
+provides-extras = ["all", "cleanlab", "cuda", "dev", "docs", "id", "olmoearth", "perf", "sam3", "terratorch", "viz"]
 
 [[package]]
 name = "torchid"
@@ -4248,6 +4318,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/4b/a6/6fe936a798a3a38a79c7422d1a31afd2e9a14690fcb0ccff96bc01f04bf2/xarray-2026.4.0.tar.gz", hash = "sha256:c4ac9a01a945d90d5b1628e2af045099a9d4943536d4f2ee3ae963c3b222d15b", size = 3132311, upload-time = "2026-04-13T19:45:36.688Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/83/6d810a8a9ebc9c307989b418840c20e46907c74d707beb67ab566773e6fc/xarray-2026.4.0-py3-none-any.whl", hash = "sha256:d43751d9fb4a90f9249c30431684f00c41bc874f1edccd862631a40cbc0edf08", size = 1414326, upload-time = "2026-04-13T19:45:34.659Z" },
+]
+
+[[package]]
+name = "yacs"
+version = "0.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/44/3e/4a45cb0738da6565f134c01d82ba291c746551b5bc82e781ec876eb20909/yacs-0.1.8.tar.gz", hash = "sha256:efc4c732942b3103bea904ee89af98bcd27d01f0ac12d8d4d369f1e7a2914384", size = 11100, upload-time = "2020-08-10T16:37:47.755Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/4f/fe9a4d472aa867878ce3bb7efb16654c5d63672b86dc0e6e953a67018433/yacs-0.1.8-py3-none-any.whl", hash = "sha256:99f893e30497a4b66842821bac316386f7bd5c4f47ad35c9073ef089aa33af32", size = 14747, upload-time = "2020-08-10T16:37:46.4Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- New `model_perf.py`: `measure_model_perf()` runs `n_warmup + n_measure` forward passes on a fixed batch to record throughput (samples/s), p50 latency (ms/batch), peak CUDA memory (GB); params via `numel()`; GMACs via `fvcore` if installed.
- `evaluate_model_perf()` in `main.py` mirrors `evaluate_intrinsic_dim` — one CSV row per metric with `method=\"model_perf\"`. Gated by `cfg.eval.model_perf.enabled` and resume-aware.
- New `[perf]` extra (`fvcore>=0.1.5`); added to `[all]`. GMACs is skipped with an info-log when fvcore is missing — other four metrics still record.
- `scripts/slurm/probe_sweep.sh` now passes `eval.model_perf.enabled=true`, so all existing job manifests collect perf alongside KNN/linear/ID without changes.

## Usage
\`\`\`bash
uv pip install 'torchgeo-bench[perf]'   # for GMACs
torchgeo-bench run model=... dataset.names=[m-eurosat] \  eval.model_perf.enabled=true \  eval.intrinsic_dim.enabled=true
\`\`\`

## Test plan
- [x] `ruff check` + `ruff format` clean
- [x] `pre-commit run` (incl. uv-lock) green locally
- [x] Smoke: `measure_model_perf` on a toy CPU net returns sensible throughput/latency/params
- [x] `pytest tests/test_logistic_regression_parity.py tests/test_multilabel.py tests/test_bench_model.py tests/test_intrinsic_dim.py` — 40/40 pass
- [ ] Full CI green