### PR TITLE
feat: add DINOv3-sat ViT-Large to GeoFM sweep lineup

### DIFF
--- a/scripts/slurm/build_probe_jobs.py
+++ b/scripts/slurm/build_probe_jobs.py
@@ -52,6 +52,8 @@ SINGLE_BAND_MODE_MODELS: dict[str, str] = {
     "torchgeo/dofa_large": "rgb",
     "torchgeo/scalemae_large_fmow": "rgb",
     "torchgeo/earthloc_s2_resnet50": "rgb",
+    # DINOv3 ViT-Large pretrained on sat493m (RGB satellite imagery).
+    "timm/vit/vit_large_patch16_dinov3sat": "rgb",
 }
 
 
@@ -75,6 +77,8 @@ DEFAULT_MODELS: list[str] = [
     "torchgeo/resnet50_s2rgb_moco",
     "torchgeo/resnet50_s2_all_moco",
     "torchgeo/earthloc_s2_resnet50",
+    # DINOv3 ViT-Large pretrained on satellite imagery (sat493m, RGB-only)
+    "timm/vit/vit_large_patch16_dinov3sat",
     # OlmoEarth (direct olmoearth-pretrain-minimal path)
     "olmoearth_base",
     # baselines


### PR DESCRIPTION
## Summary
Add `timm/vit/vit_large_patch16_dinov3sat` (DINOv3 ViT-Large pretrained on sat493m, RGB) to `DEFAULT_MODELS` in `build_probe_jobs.py`, alongside the other GeoFM entries.

Also locked to `rgb` in `SINGLE_BAND_MODE_MODELS` so the band cross-product doesn't try to feed 13-channel inputs through a 3-channel pretrained conv.

## Test plan
- [x] `python scripts/slurm/build_probe_jobs.py --dry-run` emits 6 dinov3sat lines (one per default V1 dataset), all `rgb` only, no `all` variant.