### PR TITLE
feat: extrapolate $/inference & gCO2/inference from profile metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,11 @@ scripts/*
 !scripts/eurosat_family_dedup.py
 !scripts/cleanlab_per_class_multilabel.py
 !scripts/cleanlab_per_class_singlelabel.py
+!scripts/analyze_compute_cost.py
+!scripts/cost/
+scripts/cost/*
+!scripts/cost/gpu_prices.yaml
+!scripts/cost/carbon_intensity.yaml
 !scripts/slurm/
 scripts/slurm/*
 !scripts/slurm/build_probe_jobs.py

--- a/scripts/analyze_compute_cost.py
+++ b/scripts/analyze_compute_cost.py
@@ -1,0 +1,155 @@
+"""Extrapolate $/inference and gCO2/inference from measured profile metrics.
+
+Joins the ``method="profile"`` rows of an ``all_results.csv`` against the
+GPU price and carbon-intensity tables in ``scripts/cost/``, then computes
+per-cloud and per-region cost/emissions for an arbitrary inference
+budget (defaults to 1M samples).
+
+Assumes the throughput and energy in ``all_results.csv`` were measured
+on the same GPU SKU that is being priced (passed via ``--measured-gpu``).
+Extrapolating across GPU families is out of scope -- run the profile
+sweep on the target GPU and re-join.
+
+Usage:
+    python scripts/analyze_compute_cost.py \\
+        --results results/all_results.csv \\
+        --measured-gpu "NVIDIA A100-SXM4-80GB" \\
+        --samples 1000000 \\
+        --top 20
+
+    # All GPU types in the price table, only AWS, sorted by emissions
+    python scripts/analyze_compute_cost.py --provider aws --sort kg_co2
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+import pandas as pd
+import yaml
+
+COST_DIR = Path(__file__).parent / "cost"
+PROFILE_METRICS = (
+    "throughput_samples_per_sec",
+    "energy_wh_per_1k_samples",
+    "gpu_power_w_avg",
+    "params_m",
+    "gmacs",
+    "latency_ms_per_batch_p50",
+    "peak_gpu_mem_gb",
+)
+
+
+def load_profile_rows(path: Path) -> pd.DataFrame:
+    df = pd.read_csv(path)
+    df = df[df["method"] == "profile"]
+    if df.empty:
+        sys.exit(f"No method=profile rows in {path}. Run with eval.profile.enabled=true.")
+    wide = df.pivot_table(
+        index=["model", "name", "dataset", "bands"],
+        columns="metric_name",
+        values="metric_value",
+        aggfunc="first",
+    ).reset_index()
+    wide.columns.name = None
+    return wide
+
+
+def load_table(name: str, key: str) -> pd.DataFrame:
+    with (COST_DIR / name).open() as f:
+        return pd.DataFrame(yaml.safe_load(f)[key])
+
+
+def compute_costs(
+    profile: pd.DataFrame,
+    prices: pd.DataFrame,
+    carbon: pd.DataFrame,
+    measured_gpu: str,
+    n_samples: int,
+) -> pd.DataFrame:
+    prices = prices[prices["gpu_model"] == measured_gpu].copy()
+    if prices.empty:
+        sys.exit(
+            f"No price entries for gpu_model={measured_gpu!r}. "
+            f"Available: {sorted(set(prices['gpu_model']))}"
+        )
+
+    joined = profile.merge(prices, how="cross")
+    joined = joined.merge(carbon, on="provider", how="left")
+
+    # Throughput is per *single* GPU; instance price covers num_gpus, so
+    # amortise to a per-GPU $/hr.
+    joined["usd_per_hr_per_gpu"] = joined["usd_per_hr"] / joined["num_gpus"]
+
+    seconds = n_samples / joined["throughput_samples_per_sec"]
+    hours = seconds / 3600.0
+    kwh = joined["energy_wh_per_1k_samples"] * (n_samples / 1000.0) / 1000.0
+
+    joined["wall_seconds"] = seconds
+    joined["kwh"] = kwh
+    joined["usd"] = hours * joined["usd_per_hr_per_gpu"]
+    joined["kg_co2"] = kwh * joined["gco2_per_kwh"] / 1000.0
+    return joined
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawTextHelpFormatter
+    )
+    parser.add_argument("--results", type=Path, default=Path("results/all_results.csv"))
+    parser.add_argument(
+        "--measured-gpu",
+        default="NVIDIA A100-SXM4-80GB",
+        help="GPU model string the profile rows were measured on (matches NVML name).",
+    )
+    parser.add_argument("--samples", type=int, default=1_000_000, help="Inferences to extrapolate.")
+    parser.add_argument(
+        "--provider", choices=("aws", "gcp", "azure"), help="Filter cloud provider."
+    )
+    parser.add_argument("--region", help="Filter region (exact match).")
+    parser.add_argument("--top", type=int, default=20, help="Top-N rows to print.")
+    parser.add_argument(
+        "--sort",
+        default="usd",
+        choices=("usd", "kg_co2", "wall_seconds", "throughput_samples_per_sec"),
+        help="Sort column (ascending).",
+    )
+    parser.add_argument("--out", type=Path, help="Write full joined table to CSV.")
+    args = parser.parse_args()
+
+    profile = load_profile_rows(args.results)
+    prices = load_table("gpu_prices.yaml", "instances")
+    carbon = load_table("carbon_intensity.yaml", "regions")
+
+    df = compute_costs(profile, prices, carbon, args.measured_gpu, args.samples)
+    if args.provider:
+        df = df[df["provider"] == args.provider]
+    if args.region:
+        df = df[df["region"] == args.region]
+    if df.empty:
+        sys.exit("No rows match the requested filters.")
+
+    df = df.sort_values(args.sort).reset_index(drop=True)
+
+    show_cols = [
+        "model",
+        "dataset",
+        "bands",
+        "provider",
+        "instance_type",
+        "region",
+        "throughput_samples_per_sec",
+        "wall_seconds",
+        "kwh",
+        "usd",
+        "kg_co2",
+    ]
+    print(df[show_cols].head(args.top).to_string(index=False, float_format=lambda v: f"{v:,.4f}"))
+
+    if args.out:
+        df.to_csv(args.out, index=False)
+        print(f"\nwrote {len(df)} rows to {args.out}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/cost/carbon_intensity.yaml
+++ b/scripts/cost/carbon_intensity.yaml
@@ -1,0 +1,66 @@
+# Grid carbon intensity (gCO2eq/kWh) by cloud region.
+#
+# Sources (snapshot 2026-05-15):
+#   - codecarbon's bundled global_grid_intensity table (electricityMaps + EIA)
+#   - Cloud provider sustainability dashboards (where published)
+#
+# Numbers are averaged annual; instantaneous intensity varies 2-4x by hour
+# (electricityMaps API gives live values).  Replace with live lookup if you
+# need anything more precise than order-of-magnitude.
+#
+# `provider` matches the entries in gpu_prices.yaml.
+
+regions:
+  # ---------- AWS ----------
+  - provider: aws
+    region: us-east-1            # Virginia
+    gco2_per_kwh: 367
+  - provider: aws
+    region: us-east-2            # Ohio
+    gco2_per_kwh: 526
+  - provider: aws
+    region: us-west-2            # Oregon
+    gco2_per_kwh: 124
+  - provider: aws
+    region: eu-west-1            # Ireland
+    gco2_per_kwh: 290
+  - provider: aws
+    region: eu-north-1           # Stockholm
+    gco2_per_kwh: 22
+  - provider: aws
+    region: ap-northeast-1       # Tokyo
+    gco2_per_kwh: 484
+  - provider: aws
+    region: ap-south-1           # Mumbai
+    gco2_per_kwh: 708
+
+  # ---------- GCP ----------
+  - provider: gcp
+    region: us-central1          # Iowa
+    gco2_per_kwh: 481
+  - provider: gcp
+    region: us-west1             # Oregon
+    gco2_per_kwh: 78
+  - provider: gcp
+    region: europe-west1         # Belgium
+    gco2_per_kwh: 165
+  - provider: gcp
+    region: europe-north1        # Finland
+    gco2_per_kwh: 86
+  - provider: gcp
+    region: asia-southeast1      # Singapore
+    gco2_per_kwh: 408
+
+  # ---------- Azure ----------
+  - provider: azure
+    region: eastus
+    gco2_per_kwh: 367
+  - provider: azure
+    region: westus2
+    gco2_per_kwh: 124
+  - provider: azure
+    region: northeurope          # Ireland
+    gco2_per_kwh: 290
+  - provider: azure
+    region: swedencentral
+    gco2_per_kwh: 22

--- a/scripts/cost/gpu_prices.yaml
+++ b/scripts/cost/gpu_prices.yaml
@@ -1,0 +1,99 @@
+# Cloud GPU on-demand list prices ($/hr) by (provider, instance_type, gpu_model).
+#
+# Sources (last refreshed 2026-05-15):
+#   - AWS:    https://aws.amazon.com/ec2/instance-types/  (us-east-1 on-demand)
+#   - Azure:  https://azure.microsoft.com/pricing/details/virtual-machines/  (East US pay-as-you-go)
+#   - GCP:    https://cloud.google.com/compute/all-pricing  (us-central1 on-demand)
+#
+# Notes:
+#   - Prices listed are for a *single instance* (which may host multiple GPUs);
+#     divide by `num_gpus` to amortise per-GPU.
+#   - List price is generous; spot/savings-plans/CUDs run 30–70% cheaper.
+#   - The `gpu_model` field must match the NVML name string captured by
+#     model_profile.measure_profile (use `nvidia-smi -L` to verify).
+
+instances:
+  # ---------- NVIDIA A100 40 GB ----------
+  - provider: aws
+    instance_type: p4d.24xlarge
+    gpu_model: NVIDIA A100-SXM4-40GB
+    num_gpus: 8
+    usd_per_hr: 32.7726
+  - provider: gcp
+    instance_type: a2-highgpu-1g
+    gpu_model: NVIDIA A100-SXM4-40GB
+    num_gpus: 1
+    usd_per_hr: 3.6730
+  - provider: azure
+    instance_type: Standard_ND96asr_v4
+    gpu_model: NVIDIA A100-SXM4-40GB
+    num_gpus: 8
+    usd_per_hr: 27.197
+
+  # ---------- NVIDIA A100 80 GB ----------
+  - provider: aws
+    instance_type: p4de.24xlarge
+    gpu_model: NVIDIA A100-SXM4-80GB
+    num_gpus: 8
+    usd_per_hr: 40.9656
+  - provider: gcp
+    instance_type: a2-ultragpu-1g
+    gpu_model: NVIDIA A100-SXM4-80GB
+    num_gpus: 1
+    usd_per_hr: 5.07
+  - provider: azure
+    instance_type: Standard_ND96amsr_A100_v4
+    gpu_model: NVIDIA A100-SXM4-80GB
+    num_gpus: 8
+    usd_per_hr: 32.77
+
+  # ---------- NVIDIA H100 80 GB ----------
+  - provider: aws
+    instance_type: p5.48xlarge
+    gpu_model: NVIDIA H100 80GB HBM3
+    num_gpus: 8
+    usd_per_hr: 98.32
+  - provider: gcp
+    instance_type: a3-highgpu-1g
+    gpu_model: NVIDIA H100 80GB HBM3
+    num_gpus: 1
+    usd_per_hr: 11.06
+  - provider: azure
+    instance_type: Standard_ND96isr_H100_v5
+    gpu_model: NVIDIA H100 80GB HBM3
+    num_gpus: 8
+    usd_per_hr: 98.32
+
+  # ---------- NVIDIA L4 / L40S (inference-class) ----------
+  - provider: aws
+    instance_type: g6.xlarge
+    gpu_model: NVIDIA L4
+    num_gpus: 1
+    usd_per_hr: 0.8048
+  - provider: gcp
+    instance_type: g2-standard-4
+    gpu_model: NVIDIA L4
+    num_gpus: 1
+    usd_per_hr: 0.7050
+  - provider: aws
+    instance_type: g6e.xlarge
+    gpu_model: NVIDIA L40S
+    num_gpus: 1
+    usd_per_hr: 1.8610
+
+  # ---------- NVIDIA T4 (legacy inference) ----------
+  - provider: aws
+    instance_type: g4dn.xlarge
+    gpu_model: Tesla T4
+    num_gpus: 1
+    usd_per_hr: 0.526
+  - provider: gcp
+    instance_type: n1-standard-4 + 1x T4
+    gpu_model: Tesla T4
+    num_gpus: 1
+    usd_per_hr: 0.35
+  - provider: azure
+    instance_type: Standard_NC4as_T4_v3
+    gpu_model: Tesla T4
+    num_gpus: 1
+    usd_per_hr: 0.526


### PR DESCRIPTION
## Summary
Follow-up to #60/#62. Joins `method=\"profile\"` rows of `all_results.csv` with two curated YAML tables and prints/writes per-cloud, per-region cost & emissions for an arbitrary inference budget — e.g. \"how much to inference Prithvi-300 over 1M tiles on AWS Stockholm vs Mumbai?\"

- `scripts/cost/gpu_prices.yaml` — AWS/GCP/Azure on-demand \$/hr for A100 40/80 GB, H100, L4/L40S, T4. Sources cited inline (last refreshed 2026-05-15).
- `scripts/cost/carbon_intensity.yaml` — gCO2/kWh per region; codecarbon-sourced. Annual averages; live intensity swings 2-4× by hour.
- `scripts/analyze_compute_cost.py` — pivots profile rows wide, cross-joins with the price table filtered to `--measured-gpu`, joins the carbon table on provider, derives `wall_seconds`/`kwh`/`usd`/`kg_co2` for `--samples`. Supports `--provider`/`--region`/`--sort`/`--out`.

**Smoke output** (fake Prithvi-EO-v2-300 profile row, 1M samples on A100-80GB, sorted by \$):
\`\`\`
provider  instance_type              region          wall_seconds   kwh    usd    kg_co2
azure     Standard_ND96amsr_A100_v4  swedencentral   1951.6        0.92   2.22   0.020
azure     Standard_ND96amsr_A100_v4  westus2         1951.6        0.92   2.22   0.114
gcp       a2-ultragpu-1g             us-west1        1951.6        0.92   2.75   0.072
aws       p4de.24xlarge              ap-south-1      1951.6        0.92   2.78   0.651
\`\`\`
Cleanest grids (Sweden/Oregon/Finland) cut emissions ~30×.

## Out of scope
- Extrapolating throughput/energy across GPU families. Run the sweep on the target GPU and re-join.
- Live carbon-intensity API lookup. Annual averages are fine for ballparking; replace with electricityMaps if you need hour-of-day precision.

## Test plan
- [x] Smoke run on a synthetic profile CSV produces sensible numbers
- [x] `ruff check`/`ruff format` clean
- [x] `pre-commit run` (check-yaml etc.) clean
- [ ] Full CI green