### PR TITLE
feat: sweep speed knobs — HF cache, batch=256, --preempt flag

### DIFF
--- a/scripts/slurm/build_probe_jobs.py
+++ b/scripts/slurm/build_probe_jobs.py
@@ -83,8 +83,10 @@ DEFAULT_MODELS: list[str] = [
     "timm/vit/vit_large_patch16_dinov3sat",
     # DINOv3 ViT-Large web-pretrained (natural-image baseline, RGB-only)
     "timm/vit/vit_large_patch16_dinov3",
-    # OlmoEarth (direct olmoearth-pretrain-minimal path)
-    "olmoearth_base",
+    # OlmoEarth (direct olmoearth-pretrain-minimal path) — disabled: HF
+    # weight download hangs on the cluster; re-enable after caching weights
+    # locally.
+    # "olmoearth_base",
     # baselines
     "rcf",
     "imagestats",

--- a/scripts/slurm/eurosat_spatial_geofm.sh
+++ b/scripts/slurm/eurosat_spatial_geofm.sh
@@ -8,10 +8,24 @@
 # for method in {knn5, linear, intrinsic_dim, profile}.
 #
 # Usage:
-#   bash scripts/slurm/eurosat_spatial_geofm.sh            # submit array
-#   DRY_RUN=1 bash scripts/slurm/eurosat_spatial_geofm.sh  # print sbatch cmd, don't submit
+#   bash scripts/slurm/eurosat_spatial_geofm.sh                # gpu_a100
+#   bash scripts/slurm/eurosat_spatial_geofm.sh --preempt      # preempt partition
+#   DRY_RUN=1 bash scripts/slurm/eurosat_spatial_geofm.sh ...  # print sbatch cmd, don't submit
+#
+# --preempt: submit to the preempt partition with --requeue, so jobs
+# killed by higher-priority work are re-queued automatically.  Combined
+# with resume=true in probe_sweep.sh, killed tasks pick up cleanly on the
+# next slot; many more concurrent slots cuts wall time substantially.
 
 set -euo pipefail
+
+PREEMPT=0
+for arg in "$@"; do
+  case "$arg" in
+    --preempt) PREEMPT=1 ;;
+    *) echo "unknown arg: $arg" >&2; exit 2 ;;
+  esac
+done
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$REPO_ROOT"
@@ -32,8 +46,11 @@ SBATCH_CMD=(
   sbatch
   --array="0-${ARRAY_MAX}"
   --export=ALL,JOBS_FILE="$JOBS_FILE"
-  scripts/slurm/probe_sweep.sh
 )
+if [[ "$PREEMPT" -eq 1 ]]; then
+  SBATCH_CMD+=(--partition=preempt --requeue)
+fi
+SBATCH_CMD+=(scripts/slurm/probe_sweep.sh)
 
 echo "[3/3] ${SBATCH_CMD[*]}"
 if [[ "${DRY_RUN:-0}" == "1" ]]; then

--- a/scripts/slurm/probe_sweep.sh
+++ b/scripts/slurm/probe_sweep.sh
@@ -57,10 +57,17 @@ done
 export MODEL_WEIGHTS_DIR=${MODEL_WEIGHTS_DIR:-/projects/bgtj/isaaccorley/cache/geobreeze_weights}
 mkdir -p "$MODEL_WEIGHTS_DIR"
 
+# Shared HuggingFace cache so big terratorch/torchgeo backbones don't
+# re-download per task.  HF_HOME is the umbrella var (covers hub, datasets,
+# transformers) and overrides the per-job $HOME/.cache/huggingface default.
+export HF_HOME=${HF_HOME:-/projects/bgtj/isaaccorley/cache/hf}
+mkdir -p "$HF_HOME"
+
 torchgeo-bench run \
   model="${MODEL}" \
   dataset.names="[${DATASET}]" \
   dataset.bands="${BANDS}" \
+  dataset.batch_size="${TGB_BATCH_SIZE:-256}" \
   dataset.num_workers="${TGB_NUM_WORKERS:-4}" \
   dataset.normalization="${NORM}" \
   resume=true \


### PR DESCRIPTION
Speedup batch for the probe sweep.

- `probe_sweep.sh`: export `HF_HOME=/projects/bgtj/isaaccorley/cache/hf` so terratorch / torchgeo backbones don't re-download per array task.
- `probe_sweep.sh`: bump `dataset.batch_size` default 64 → 256 (overridable via `TGB_BATCH_SIZE`). 4× fewer forwards on A100-80GB for small-image datasets.
- `eurosat_spatial_geofm.sh`: `--preempt` flag appends `--partition=preempt --requeue`. Combined with `resume=true` in the runner, preempted tasks are auto-re-queued and skip already-completed combos when they restart.
- `build_probe_jobs.py`: temporarily drop `olmoearth_base` from DEFAULT_MODELS — its HF weight download hung indefinitely on the cluster during sweep 87713. Re-enable once weights are mirrored to `MODEL_WEIGHTS_DIR`.

## Test plan
- [x] Dry-run wrapper with and without `--preempt` prints expected sbatch invocation
- [x] In-flight job 87753 unaffected (submission snapshot pre-dates these changes)
- [ ] Next sweep validates the speedup empirically