### PR TITLE
feat(models): pool=cls|mean|both kwarg for terratorch + ScaleMAE wrappers

### DIFF
--- a/src/torchgeo_bench/models/_pooling.py
+++ b/src/torchgeo_bench/models/_pooling.py
@@ -1,0 +1,62 @@
+"""Token pooling strategies for ViT-style frozen backbones.
+
+The choice between CLS-token and mean-pooled patch tokens is not innocent.
+Different pretraining objectives leave the [CLS] token with different
+quality of information:
+
+- MAE / SSL reconstruction (Prithvi, Clay): [CLS] is not directly
+  supervised; the encoder ends up routing whatever it likes through it.
+  Mean-pooled patch tokens tend to be richer for downstream probing.
+- DINO / DINOv3: explicit [CLS] supervision via self-distillation; the
+  CLS token is the canonical feature.
+- ImageNet-supervised ViT (most timm baselines): [CLS] is read by the
+  classifier; both CLS and pooled patches are reasonable.
+
+This module hosts a single helper so every wrapper picks pooling the
+same way and the choice is easy to ablate from configs.
+"""
+
+import torch
+
+PoolMode = str  # "cls" | "mean" | "both"
+VALID_MODES = ("cls", "mean", "both")
+
+
+def pool_tokens(tokens: torch.Tensor, mode: PoolMode = "mean") -> torch.Tensor:
+    """Pool ``(B, N, D)`` ViT tokens to a single ``(B, D)`` (or ``(B, 2D)``) vector.
+
+    Args:
+        tokens: ``(B, N, D)`` token sequence. If ``N`` is a perfect square plus
+            one, the first token is treated as ``[CLS]``; otherwise the whole
+            sequence is treated as patch tokens.
+        mode: ``"cls"`` returns the CLS token, ``"mean"`` mean-pools the patch
+            tokens (dropping CLS if present), ``"both"`` concatenates them.
+
+    Returns:
+        ``(B, D)`` (cls or mean) or ``(B, 2D)`` (both).
+    """
+    if tokens.ndim != 3:
+        raise ValueError(f"expected (B, N, D), got shape {tuple(tokens.shape)}")
+    if mode not in VALID_MODES:
+        raise ValueError(f"pool mode {mode!r} not in {VALID_MODES}")
+
+    n = tokens.shape[1]
+    side = int(round(n**0.5))
+    has_cls = side * side == n - 1
+
+    if mode == "cls":
+        if not has_cls:
+            raise ValueError(
+                f"pool='cls' requested but tokens shape {tuple(tokens.shape)} has "
+                f"no detectable CLS slot (N={n} is not square+1)."
+            )
+        return tokens[:, 0, :]
+
+    patches = tokens[:, 1:, :] if has_cls else tokens
+    mean = patches.mean(dim=1)
+    if mode == "mean":
+        return mean
+
+    # both — concat cls and mean_patches; falls back to mean+mean when no CLS
+    cls = tokens[:, 0, :] if has_cls else mean
+    return torch.cat([cls, mean], dim=-1)

--- a/src/torchgeo_bench/models/terratorch_models.py
+++ b/src/torchgeo_bench/models/terratorch_models.py
@@ -11,6 +11,7 @@ from torchgeo_bench.datasets.base import BandSpec
 
 from ._band_mapping import map_to_model_bands
 from ._input_units import InputUnit
+from ._pooling import VALID_MODES, pool_tokens
 from .interface import BenchModel
 
 logger = logging.getLogger(__name__)
@@ -37,24 +38,19 @@ def _maybe_resize(images: torch.Tensor, size: int | None) -> torch.Tensor:
     return F.interpolate(images, size=(size, size), mode="bicubic", align_corners=False)
 
 
-def _pool_tokens(tokens: torch.Tensor) -> torch.Tensor:
-    """Mean-pool ``(B, N, D)`` tokens, dropping a CLS token if N is square+1."""
-    if tokens.ndim != 3:
-        return tokens
-    n = tokens.shape[1]
-    side = int(round(n**0.5))
-    if side * side == n - 1:
-        return tokens[:, 1:, :].mean(dim=1)
-    return tokens.mean(dim=1)
-
-
-def _reduce_to_vec(out: torch.Tensor | list | tuple) -> torch.Tensor:
+def _reduce_to_vec(out: torch.Tensor | list | tuple, pool: str) -> torch.Tensor:
     if isinstance(out, list | tuple):
         out = out[-1]
     if out.ndim == 4:
-        return out.mean(dim=(-2, -1))
+        # Spatial feature maps: mean / cls both reduce to a GAP; "both" doubles
+        # the feature dim by concatenating GAP + max-pooled features.
+        gap = out.mean(dim=(-2, -1))
+        if pool == "both":
+            mp = out.amax(dim=(-2, -1))
+            return torch.cat([gap, mp], dim=-1)
+        return gap
     if out.ndim == 3:
-        return _pool_tokens(out)
+        return pool_tokens(out, mode=pool)
     return out
 
 
@@ -69,10 +65,14 @@ class _TerraTorchBench(BenchModel):
         *,
         target_size: int | None = 224,
         backbone_kwargs: dict[str, Any] | None = None,
+        pool: str = "mean",
         **kwargs: Any,
     ) -> None:
         super().__init__(bands=bands, **kwargs)
+        if pool not in VALID_MODES:
+            raise ValueError(f"pool={pool!r} not in {VALID_MODES}")
         self.target_size = target_size
+        self.pool = pool
         self.backbone = _build_backbone(self.backbone_name, **(backbone_kwargs or {}))
         self.backbone.eval()
         for p in self.backbone.parameters():
@@ -87,7 +87,7 @@ class _TerraTorchBench(BenchModel):
     ) -> torch.Tensor:
         del bboxes
         x = _maybe_resize(self._prepare_input(images), self.target_size)
-        return _reduce_to_vec(self.backbone(x))
+        return _reduce_to_vec(self.backbone(x), pool=self.pool)
 
 
 PRITHVI_BANDS: list[str] = ["blue", "green", "red", "nir_narrow", "swir1", "swir2"]

--- a/src/torchgeo_bench/models/torchgeo_models.py
+++ b/src/torchgeo_bench/models/torchgeo_models.py
@@ -33,6 +33,7 @@ from torchvision.transforms.v2 import Normalize as NormalizeV2
 from torchgeo_bench.datasets.base import BandSpec
 
 from ._input_units import InputUnit, detect_input_unit
+from ._pooling import VALID_MODES, pool_tokens
 from .interface import BenchModel
 
 logger = logging.getLogger(__name__)
@@ -354,8 +355,8 @@ class TorchGeoSwinBench(_TorchGeoBackboneBench):
 class TorchGeoScaleMAEBench(_TorchGeoBackboneBench):
     """Wrapper for torchgeo ScaleMAE-Large.
 
-    ``forward_features()`` returns ``(B, N+1, D)`` tokens; we average spatial
-    tokens (dropping CLS at index 0) to produce ``(B, D)``.
+    ``forward_features()`` returns ``(B, N+1, D)`` tokens; ``pool`` selects
+    between CLS, mean-pooled patch tokens, or their concatenation.
     """
 
     weights_input_unit = "uint8_div255"
@@ -370,6 +371,7 @@ class TorchGeoScaleMAEBench(_TorchGeoBackboneBench):
         auto_resize: bool = True,
         target_size: int | None = 224,
         input_unit_check: str = "warn",
+        pool: str = "mean",
         **_kwargs: Any,
     ) -> None:
         super().__init__(
@@ -381,6 +383,9 @@ class TorchGeoScaleMAEBench(_TorchGeoBackboneBench):
             target_size=target_size,
             input_unit_check=input_unit_check,
         )
+        if pool not in VALID_MODES:
+            raise ValueError(f"pool={pool!r} not in {VALID_MODES}")
+        self.pool = pool
 
     @torch.no_grad()
     def _forward_patch_features(
@@ -390,7 +395,7 @@ class TorchGeoScaleMAEBench(_TorchGeoBackboneBench):
         if self.auto_resize and self.target_size:
             images = _auto_resize(images, self.target_size)
         tokens = self.backbone.forward_features(images)  # (B, N+1, D)
-        return tokens[:, 1:, :].mean(dim=1)
+        return pool_tokens(tokens, mode=self.pool)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pooling.py
+++ b/tests/test_pooling.py
@@ -1,0 +1,57 @@
+"""Tests for torchgeo_bench.models._pooling."""
+
+import pytest
+import torch
+
+from torchgeo_bench.models._pooling import pool_tokens
+
+
+@pytest.fixture
+def cls_tokens() -> torch.Tensor:
+    # 14x14 patches + CLS = 197
+    return torch.randn(2, 197, 8)
+
+
+@pytest.fixture
+def patch_only() -> torch.Tensor:
+    # 14x14 patches, no CLS
+    return torch.randn(2, 196, 8)
+
+
+def test_cls_picks_first_token(cls_tokens: torch.Tensor) -> None:
+    out = pool_tokens(cls_tokens, mode="cls")
+    assert out.shape == (2, 8)
+    assert torch.allclose(out, cls_tokens[:, 0, :])
+
+
+def test_mean_drops_cls_when_present(cls_tokens: torch.Tensor) -> None:
+    out = pool_tokens(cls_tokens, mode="mean")
+    assert out.shape == (2, 8)
+    assert torch.allclose(out, cls_tokens[:, 1:, :].mean(dim=1))
+
+
+def test_mean_uses_all_patches_when_no_cls(patch_only: torch.Tensor) -> None:
+    out = pool_tokens(patch_only, mode="mean")
+    assert torch.allclose(out, patch_only.mean(dim=1))
+
+
+def test_both_concats_cls_and_mean(cls_tokens: torch.Tensor) -> None:
+    out = pool_tokens(cls_tokens, mode="both")
+    assert out.shape == (2, 16)
+    assert torch.allclose(out[:, :8], cls_tokens[:, 0, :])
+    assert torch.allclose(out[:, 8:], cls_tokens[:, 1:, :].mean(dim=1))
+
+
+def test_cls_requires_cls_slot(patch_only: torch.Tensor) -> None:
+    with pytest.raises(ValueError, match="no detectable CLS slot"):
+        pool_tokens(patch_only, mode="cls")
+
+
+def test_unknown_mode_rejected(cls_tokens: torch.Tensor) -> None:
+    with pytest.raises(ValueError, match="not in"):
+        pool_tokens(cls_tokens, mode="median")
+
+
+def test_rejects_non_3d_input() -> None:
+    with pytest.raises(ValueError, match=r"expected \(B, N, D\)"):
+        pool_tokens(torch.randn(2, 8), mode="mean")


### PR DESCRIPTION
## Why
Different pretraining objectives reward different ViT readout strategies:
- **MAE-style (Prithvi, Clay):** the CLS token is essentially unsupervised; patch tokens carry the reconstruction signal.
- **DINO / DINOv3:** explicit CLS supervision via self-distillation.
- **CLIP-style:** pooled patches are the canonical output.

Today the terratorch `_pool_tokens` and ScaleMAE wrapper hard-code mean-pool-drop-CLS, making the CLS-vs-mean ablation impossible to express in configs. The Prithvi/Clay TwoNN nan we just fixed (#71) is partly downstream of this choice — see `docs/interesting-findings.md`.

## What changed
- `src/torchgeo_bench/models/_pooling.py` — single `pool_tokens()` helper with modes `cls` / `mean` / `both` (concat). Detects the CLS slot via `N = side**2 + 1`.
- `_TerraTorchBench` (Prithvi / Clay / Terramind) gets `pool: str = "mean"` kwarg. Default keeps current behavior.
- `TorchGeoScaleMAEBench` same kwarg + uses the helper.
- 7 unit tests in `tests/test_pooling.py` cover each mode + validation paths.

## What's not in this PR
- timm wrapper already has `use_cls_token`; left untouched to keep the change focused. Unifying the API is a tidy-up follow-up.
- Other torchgeo backbones (DOFA, Panopticon, CROMA, OlmoEarth, SAM3) do their own pooling deeper in the model and would need bespoke wiring — also follow-up.
- No new sweep / configs yet. Generating `*_cls.yaml` / `*_mean.yaml` variants and running the actual ablation is the next PR.

## Test plan
- [x] `pytest tests/test_pooling.py` — 7/7 pass
- [x] Existing `tests/test_bench_model.py` + `tests/test_band_mapping.py` still pass (14/14)
- [x] `ruff check` / `ruff format` clean
- [ ] CI green