### PR TITLE
feat(configs): _cls variants + eurosat-spatial pool ablation sweep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ scripts/slurm/*
 !scripts/slurm/cleanlab_audit.sh
 !scripts/slurm/cleanlab_audit.jobs
 !scripts/slurm/eurosat_spatial_geofm.sh
+!scripts/slurm/eurosat_spatial_pool_ablation.sh
 figures/
 
 # Python

--- a/scripts/slurm/eurosat_spatial_pool_ablation.sh
+++ b/scripts/slurm/eurosat_spatial_pool_ablation.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# CLS-vs-mean pool ablation on eurosat-spatial.
+#
+# For each (backbone, bands) combo we already have a mean-pool row from
+# the main sweep; this submits the matching cls-pool runs.  resume=true
+# in probe_sweep.sh keeps each task to feature extraction + KNN/linear/
+# intrinsic_dim/profile for the new (model_config, name) — no duplicate
+# work against the mean rows.
+#
+# Usage:
+#   bash scripts/slurm/eurosat_spatial_pool_ablation.sh             # gpu_a100
+#   DRY_RUN=1 bash scripts/slurm/eurosat_spatial_pool_ablation.sh   # print and exit
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+JOBS_FILE="scripts/slurm/eurosat_spatial_pool_ablation.jobs"
+
+cat > "$JOBS_FILE" <<'EOF'
+terratorch/prithvi_eo_v1_100_cls eurosat-spatial rgb bandspec_zscore
+terratorch/prithvi_eo_v1_100_cls eurosat-spatial all bandspec_zscore
+terratorch/prithvi_eo_v2_100_tl_cls eurosat-spatial rgb bandspec_zscore
+terratorch/prithvi_eo_v2_100_tl_cls eurosat-spatial all bandspec_zscore
+terratorch/prithvi_eo_v2_300_cls eurosat-spatial rgb bandspec_zscore
+terratorch/prithvi_eo_v2_300_cls eurosat-spatial all bandspec_zscore
+terratorch/prithvi_eo_v2_300_tl_cls eurosat-spatial rgb bandspec_zscore
+terratorch/prithvi_eo_v2_300_tl_cls eurosat-spatial all bandspec_zscore
+terratorch/prithvi_eo_v2_600_cls eurosat-spatial rgb bandspec_zscore
+terratorch/prithvi_eo_v2_600_cls eurosat-spatial all bandspec_zscore
+terratorch/clay_v1_5_cls eurosat-spatial rgb bandspec_zscore
+terratorch/clay_v1_5_cls eurosat-spatial all bandspec_zscore
+terratorch/terramind_v1_base_cls eurosat-spatial rgb bandspec_zscore
+terratorch/terramind_v1_base_cls eurosat-spatial all bandspec_zscore
+terratorch/terramind_v1_large_cls eurosat-spatial rgb bandspec_zscore
+terratorch/terramind_v1_large_cls eurosat-spatial all bandspec_zscore
+torchgeo/scalemae_large_fmow_cls eurosat-spatial rgb bandspec_zscore
+EOF
+
+NUM_JOBS=$(wc -l < "$JOBS_FILE")
+ARRAY_MAX=$((NUM_JOBS - 1))
+echo "[1/2] $NUM_JOBS cls-pool jobs -> --array=0-$ARRAY_MAX"
+
+SBATCH_CMD=(
+  sbatch
+  --array="0-${ARRAY_MAX}"
+  --export=ALL,JOBS_FILE="$JOBS_FILE"
+  scripts/slurm/probe_sweep.sh
+)
+
+echo "[2/2] ${SBATCH_CMD[*]}"
+if [[ "${DRY_RUN:-0}" == "1" ]]; then
+  echo "DRY_RUN=1 set; not submitting."
+  exit 0
+fi
+"${SBATCH_CMD[@]}"

--- a/src/torchgeo_bench/conf/model/terratorch/clay_v1_5_cls.yaml
+++ b/src/torchgeo_bench/conf/model/terratorch/clay_v1_5_cls.yaml
@@ -1,0 +1,7 @@
+_target_: torchgeo_bench.models.TerraTorchClayBench
+backbone_name: timm_clay_v1_base
+pretrained: true
+target_size: 256  # Clay's pretrained pos_embed is fixed to 32x32 patches @ patch_size=8
+modality: sentinel-2-l2a
+name: tt_clay_v1_5_base_cls
+pool: cls

--- a/src/torchgeo_bench/conf/model/terratorch/prithvi_eo_v1_100_cls.yaml
+++ b/src/torchgeo_bench/conf/model/terratorch/prithvi_eo_v1_100_cls.yaml
@@ -1,0 +1,6 @@
+_target_: torchgeo_bench.models.TerraTorchPrithviBench
+backbone_name: prithvi_eo_v1_100
+pretrained: true
+target_size: 224
+name: tt_prithvi_eo_v1_100_cls
+pool: cls

--- a/src/torchgeo_bench/conf/model/terratorch/prithvi_eo_v2_100_tl_cls.yaml
+++ b/src/torchgeo_bench/conf/model/terratorch/prithvi_eo_v2_100_tl_cls.yaml
@@ -1,0 +1,6 @@
+_target_: torchgeo_bench.models.TerraTorchPrithviBench
+backbone_name: prithvi_eo_v2_100_tl
+pretrained: true
+target_size: 224
+name: tt_prithvi_eo_v2_100_tl_cls
+pool: cls

--- a/src/torchgeo_bench/conf/model/terratorch/prithvi_eo_v2_300_cls.yaml
+++ b/src/torchgeo_bench/conf/model/terratorch/prithvi_eo_v2_300_cls.yaml
@@ -1,0 +1,8 @@
+_target_: torchgeo_bench.models.TerraTorchPrithviBench
+backbone_name: prithvi_eo_v2_300
+pretrained: true
+target_size: 224
+name: tt_prithvi_eo_v2_300_cls
+eval:
+  c_range: [-6, 5, 60]
+pool: cls

--- a/src/torchgeo_bench/conf/model/terratorch/prithvi_eo_v2_300_tl_cls.yaml
+++ b/src/torchgeo_bench/conf/model/terratorch/prithvi_eo_v2_300_tl_cls.yaml
@@ -1,0 +1,8 @@
+_target_: torchgeo_bench.models.TerraTorchPrithviBench
+backbone_name: prithvi_eo_v2_300_tl
+pretrained: true
+target_size: 224
+name: tt_prithvi_eo_v2_300_tl_cls
+eval:
+  c_range: [-6, 5, 60]
+pool: cls

--- a/src/torchgeo_bench/conf/model/terratorch/prithvi_eo_v2_600_cls.yaml
+++ b/src/torchgeo_bench/conf/model/terratorch/prithvi_eo_v2_600_cls.yaml
@@ -1,0 +1,8 @@
+_target_: torchgeo_bench.models.TerraTorchPrithviBench
+backbone_name: prithvi_eo_v2_600
+pretrained: true
+target_size: 224
+name: tt_prithvi_eo_v2_600_cls
+eval:
+  c_range: [-6, 5, 60]
+pool: cls

--- a/src/torchgeo_bench/conf/model/terratorch/terramind_v1_base_cls.yaml
+++ b/src/torchgeo_bench/conf/model/terratorch/terramind_v1_base_cls.yaml
@@ -1,0 +1,7 @@
+_target_: torchgeo_bench.models.TerraTorchTerraMindBench
+backbone_name: terramind_v1_base
+pretrained: true
+target_size: 224
+modality: S2L2A
+name: tt_terramind_v1_base_cls
+pool: cls

--- a/src/torchgeo_bench/conf/model/terratorch/terramind_v1_large_cls.yaml
+++ b/src/torchgeo_bench/conf/model/terratorch/terramind_v1_large_cls.yaml
@@ -1,0 +1,9 @@
+_target_: torchgeo_bench.models.TerraTorchTerraMindBench
+backbone_name: terramind_v1_large
+pretrained: true
+target_size: 224
+modality: S2L2A
+name: tt_terramind_v1_large_cls
+eval:
+  c_range: [-6, 5, 60]
+pool: cls

--- a/src/torchgeo_bench/conf/model/torchgeo/scalemae_large_fmow_cls.yaml
+++ b/src/torchgeo_bench/conf/model/torchgeo/scalemae_large_fmow_cls.yaml
@@ -1,0 +1,16 @@
+# torchgeo ScaleMAE-Large — fMoW RGB
+# Feature dimension: 1024
+
+_target_: torchgeo_bench.models.TorchGeoScaleMAEBench
+factory: scalemae_large_patch16
+weights_class: ScaleMAELarge16_Weights
+weights_member: FMOW_RGB
+auto_resize: true
+target_size: 224
+name: tgeo_scalemae_large_fmow_cls
+pool: cls
+eval:
+  segmentation:
+    # ViT-Large (24 blocks, 1024ch). Coarse-to-fine: deepest block first.
+    # backbone.* prefix is stripped by SegmentationProbe automatically.
+    layers: ["blocks.23", "blocks.17", "blocks.11", "blocks.5"]


### PR DESCRIPTION
Companion to #73 (pool kwarg in wrappers).  Adds the actual `_cls.yaml` configs and a sweep wrapper so the ablation can land in the explorer.

## Configs (9 new, all `pool: cls` + `_cls` name suffix)
- `terratorch/{prithvi_eo_v1_100, prithvi_eo_v2_100_tl, prithvi_eo_v2_300, prithvi_eo_v2_300_tl, prithvi_eo_v2_600, clay_v1_5, terramind_v1_base, terramind_v1_large}_cls`
- `torchgeo/scalemae_large_fmow_cls`

Each variant differs from its mean-pool sibling only by `pool: cls` and the `_cls` suffix on `name` — CSV rows from cls and mean coexist as distinct keys, no resume collisions.

## Sweep wrapper
`scripts/slurm/eurosat_spatial_pool_ablation.sh` submits the 17-task array (8 backbones × rgb/all + ScaleMAE rgb-only). Re-uses `probe_sweep.sh` so the new rows pick up knn5 / linear / intrinsic_dim / profile automatically.

## Test plan
- [x] Dry-run shows 17 jobs, correct sbatch command
- [ ] Submit on cluster (next step)
- [ ] Explorer Figure 7 (ID vs accuracy) renders cls vs mean side-by-side after sweep