### PR TITLE
fix(terratorch): pass pool kwarg through Clay + Terramind _forward_patch_features

### DIFF
--- a/src/torchgeo_bench/models/terratorch_models.py
+++ b/src/torchgeo_bench/models/terratorch_models.py
@@ -169,7 +169,10 @@ class TerraTorchClayBench(_TerraTorchBench):
     ) -> torch.Tensor:
         del bboxes
         x = _maybe_resize(self._prepare_input(images), self.target_size)
-        return _reduce_to_vec(self.backbone(x, waves=self._clay_waves.to(x.device), gsd=self.gsd))
+        return _reduce_to_vec(
+            self.backbone(x, waves=self._clay_waves.to(x.device), gsd=self.gsd),
+            pool=self.pool,
+        )
 
 
 TERRAMIND_S2L2A_BANDS: list[str] = [
@@ -219,4 +222,4 @@ class TerraTorchTerraMindBench(_TerraTorchBench):
         del bboxes
         x, _ = map_to_model_bands(images, self.bands, TERRAMIND_S2L2A_BANDS)
         x = _maybe_resize(x, self.target_size)
-        return _reduce_to_vec(self.backbone({self.modality: x}))
+        return _reduce_to_vec(self.backbone({self.modality: x}), pool=self.pool)


### PR DESCRIPTION
Follow-up to #73/#74.  The pool refactor updated `_reduce_to_vec`'s signature to take a positional `pool` arg, but Clay and Terramind override `_forward_patch_features` with their own custom backbone calls — those two call sites were missed.

Surfaced as `TypeError: _reduce_to_vec() missing 1 required positional argument: 'pool'` on tasks 10-15 of sweep 88174 (cls pool ablation).  Resubmitted those 6 combos as job 88191 with the fix in place.

## Test plan
- [x] Sweep 88191 (6 fixed combos) submitted; awaiting results
- [ ] CI green