### PR TITLE
chore: drop Terramind _cls configs (no CLS token in architecture)

### DIFF
--- a/scripts/slurm/eurosat_spatial_pool_ablation.sh
+++ b/scripts/slurm/eurosat_spatial_pool_ablation.sh
@@ -31,10 +31,6 @@ terratorch/prithvi_eo_v2_600_cls eurosat-spatial rgb bandspec_zscore
 terratorch/prithvi_eo_v2_600_cls eurosat-spatial all bandspec_zscore
 terratorch/clay_v1_5_cls eurosat-spatial rgb bandspec_zscore
 terratorch/clay_v1_5_cls eurosat-spatial all bandspec_zscore
-terratorch/terramind_v1_base_cls eurosat-spatial rgb bandspec_zscore
-terratorch/terramind_v1_base_cls eurosat-spatial all bandspec_zscore
-terratorch/terramind_v1_large_cls eurosat-spatial rgb bandspec_zscore
-terratorch/terramind_v1_large_cls eurosat-spatial all bandspec_zscore
 torchgeo/scalemae_large_fmow_cls eurosat-spatial rgb bandspec_zscore
 EOF
 

--- a/src/torchgeo_bench/conf/model/terratorch/terramind_v1_base_cls.yaml
+++ b/src/torchgeo_bench/conf/model/terratorch/terramind_v1_base_cls.yaml
@@ -1,7 +1,0 @@
-_target_: torchgeo_bench.models.TerraTorchTerraMindBench
-backbone_name: terramind_v1_base
-pretrained: true
-target_size: 224
-modality: S2L2A
-name: tt_terramind_v1_base_cls
-pool: cls

--- a/src/torchgeo_bench/conf/model/terratorch/terramind_v1_large_cls.yaml
+++ b/src/torchgeo_bench/conf/model/terratorch/terramind_v1_large_cls.yaml
@@ -1,9 +1,0 @@
-_target_: torchgeo_bench.models.TerraTorchTerraMindBench
-backbone_name: terramind_v1_large
-pretrained: true
-target_size: 224
-modality: S2L2A
-name: tt_terramind_v1_large_cls
-eval:
-  c_range: [-6, 5, 60]
-pool: cls


### PR DESCRIPTION
Terramind v1 base/large produce N=196 patch tokens with no CLS slot — `pool=cls` raised ValueError on sweep 88197.  The ablation isn't meaningful for Terramind: there's nothing to compare mean-pool against.

Removes the two configs and the matching jobs-manifest entries from the ablation wrapper. The other 7 cls variants (5 Prithvi + Clay + ScaleMAE) landed cleanly.