### PR TITLE
refactor: remove silent-skip try/except patterns; fix the bugs they hid

### DIFF
--- a/src/torchgeo_bench/intrinsic_dim.py
+++ b/src/torchgeo_bench/intrinsic_dim.py
@@ -66,6 +66,34 @@ def _subsample(X: np.ndarray, max_samples: int | None, seed: int) -> np.ndarray:
     return X[idx]
 
 
+def _drop_zero_distance_rows(X_tensor: torch.Tensor) -> torch.Tensor:
+    """Drop rows whose computed nearest-neighbour distance underflows to zero.
+
+    TwoNN's slope is ``sum(x * y) / sum(x * x)`` over ``x = log(mu)`` where
+    ``mu = d2 / d1``.  When two rows are close enough that their fp32 squared
+    distance underflows, ``d1 == 0``; the estimator's inner ``clamp_min``
+    leaves ``mu = 0``, and ``log(0) = -inf`` poisons the slope to ``nan`` —
+    observed in the wild on Prithvi / Clay CLS-token embeddings.
+
+    Bit-exact dedup doesn't catch this case because the rows differ in
+    their last few bits; only the *distance* underflows.  Drop the rows
+    where ``d1 == 0`` or ``d2 == 0`` so the remaining set has well-defined
+    distance ratios.
+    """
+    from torchid.primitives import knn
+
+    d, _ = knn(X_tensor, k=2)
+    keep = (d[:, 0] > 0) & (d[:, 1] > 0)
+    n_drop = int((~keep).sum().item())
+    if n_drop > 0:
+        logger.info(
+            f"[intrinsic-dim] dropped {n_drop} rows with zero-distance neighbours "
+            f"({X_tensor.shape[0]} -> {int(keep.sum().item())}) before estimation."
+        )
+        return X_tensor[keep]
+    return X_tensor
+
+
 def compute_intrinsic_dim(
     X: np.ndarray,
     estimators: list[str],
@@ -86,8 +114,9 @@ def compute_intrinsic_dim(
         seed: RNG seed for subsampling determinism.
 
     Returns:
-        Mapping ``{estimator_name: dimension}``. Failed estimators yield
-        ``float('nan')`` and a logged warning rather than aborting the run.
+        Mapping ``{estimator_name: dimension}``.  Estimator-internal
+        exceptions propagate; we no longer swallow them as NaN, because
+        doing so previously hid the TwoNN/fp32-zero-distance bug.
     """
     if X.ndim != 2:
         raise ValueError(f"X must be 2D, got shape {X.shape}")
@@ -97,15 +126,31 @@ def compute_intrinsic_dim(
     dev = _resolve_device(device)
     Xs = _subsample(X, max_samples, seed)
     X_tensor = torch.from_numpy(np.ascontiguousarray(Xs)).to(dev, dtype=torch.float32)
+    X_tensor = _drop_zero_distance_rows(X_tensor)
 
     out: dict[str, float] = {}
     for name in estimators:
-        try:
-            cls = _load_estimator(name)
-            est: Any = cls().fit(X_tensor)
-            value = float(est.dimension_)
-        except Exception as e:  # noqa: BLE001 — log and continue per-estimator
-            logger.warning(f"[intrinsic-dim] {name} failed on X{tuple(X_tensor.shape)}: {e}")
-            value = float("nan")
+        # Estimator-internal exceptions propagate so we actually fix the
+        # bug instead of silently emitting NaN to the CSV.  The only
+        # tolerated "soft" failure path is a numerical NaN/inf in
+        # dimension_ after a clean fit — even there we raise with a full
+        # diagnostic dump so the next person debugging has a real lead.
+        cls = _load_estimator(name)
+        est: Any = cls().fit(X_tensor)
+        value = float(est.dimension_)
+        if not np.isfinite(value):
+            from torchid.primitives import knn
+
+            d, _ = knn(X_tensor, k=2)
+            d1, d2 = d[:, 0], d[:, 1]
+            raise ValueError(
+                f"[intrinsic-dim] {name} returned non-finite dimension ({value}) on "
+                f"X{tuple(X_tensor.shape)} after dedup. "
+                f"d1[min={d1.min():.3e} median={d1.median():.3e} zeros={(d1 == 0).sum().item()}] "
+                f"d2[min={d2.min():.3e} zeros={(d2 == 0).sum().item()}] "
+                f"X[norm_min={X_tensor.norm(dim=1).min():.3e} "
+                f"norm_max={X_tensor.norm(dim=1).max():.3e} std={X_tensor.std():.3e}]. "
+                f"Investigate before writing this to the CSV."
+            )
         out[name] = value
     return out

--- a/src/torchgeo_bench/intrinsic_dim.py
+++ b/src/torchgeo_bench/intrinsic_dim.py
@@ -66,6 +66,20 @@ def _subsample(X: np.ndarray, max_samples: int | None, seed: int) -> np.ndarray:
     return X[idx]
 
 
+def _two_nearest_distances(X: torch.Tensor) -> torch.Tensor:
+    """Pairwise (d1, d2) for each row, computed via ``torch.cdist``.
+
+    Same shape and meaning as ``torchid.primitives.knn(X, k=2)[0]`` but
+    has no torchid dependency, so the dedup runs in environments where
+    we haven't installed the ``[id]`` extra (e.g. CI without
+    Python 3.13).  We don't need indices, just the smallest two
+    distances per row.
+    """
+    dist = torch.cdist(X, X)
+    dist.fill_diagonal_(float("inf"))
+    return dist.topk(k=2, largest=False).values
+
+
 def _drop_zero_distance_rows(X_tensor: torch.Tensor) -> torch.Tensor:
     """Drop rows whose computed nearest-neighbour distance underflows to zero.
 
@@ -80,9 +94,7 @@ def _drop_zero_distance_rows(X_tensor: torch.Tensor) -> torch.Tensor:
     where ``d1 == 0`` or ``d2 == 0`` so the remaining set has well-defined
     distance ratios.
     """
-    from torchid.primitives import knn
-
-    d, _ = knn(X_tensor, k=2)
+    d = _two_nearest_distances(X_tensor)
     keep = (d[:, 0] > 0) & (d[:, 1] > 0)
     n_drop = int((~keep).sum().item())
     if n_drop > 0:
@@ -139,9 +151,7 @@ def compute_intrinsic_dim(
         est: Any = cls().fit(X_tensor)
         value = float(est.dimension_)
         if not np.isfinite(value):
-            from torchid.primitives import knn
-
-            d, _ = knn(X_tensor, k=2)
+            d = _two_nearest_distances(X_tensor)
             d1, d2 = d[:, 0], d[:, 1]
             raise ValueError(
                 f"[intrinsic-dim] {name} returned non-finite dimension ({value}) on "

--- a/src/torchgeo_bench/main.py
+++ b/src/torchgeo_bench/main.py
@@ -506,16 +506,18 @@ def evaluate_profile(
 
     One row per metric, with ``method="profile"``.
     """
-    try:
-        sample = next(iter(sample_loader))["image"].to(device)
-    except Exception as exc:  # noqa: BLE001
-        logger.warning(f"[model-perf] could not fetch sample batch: {exc}; skipping")
-        return []
+    # If the loader is broken there's nothing meaningful to profile; let the
+    # error propagate so the failure surfaces in SLURM logs instead of
+    # silently appending zero rows and "succeeding" the task.
+    sample = next(iter(sample_loader))["image"].to(device)
 
     metrics = measure_profile(model, sample, device, n_warmup=n_warmup, n_measure=n_measure)
     rows: list[dict] = []
     for name, value in metrics.items():
         if value is None:
+            # value is None only when the underlying probe is structurally
+            # unavailable (e.g. CPU device → no peak_gpu_mem). Logged inside
+            # measure_profile; skip the row.
             continue
         rows.append(
             EvaluationResult(

--- a/src/torchgeo_bench/model_profile.py
+++ b/src/torchgeo_bench/model_profile.py
@@ -41,24 +41,39 @@ def _count_params(model: nn.Module) -> float:
 def _count_gflops(model: nn.Module, sample: torch.Tensor) -> float | None:
     """Run one forward pass under torch's FlopCounterMode for a single sample.
 
-    Uses ``torch.utils.flop_counter`` (in stdlib torch since 2.0) — no extra
-    deps and handles modern ops (SDPA, ViT attention) that fvcore misses.
-    Returns ``None`` if the import is unavailable or the counter errors.
+    Uses ``torch.utils.flop_counter`` (stdlib torch since 2.0). The counter
+    relies on ``__torch_dispatch__`` and is incompatible with some custom
+    forwards (e.g. ``Panopticon`` raises
+    ``'NoneType' object has no attribute 'next_functions'`` because one of
+    its hooks returns ``None`` where dispatch expects a tensor).
+
+    On dispatch errors we fall back to ``no_grad`` instead of
+    ``inference_mode`` — the latter disables version-counting which some
+    custom modules rely on.  If that also fails we surface the error so
+    callers can decide whether to skip a metric or fail loudly; we no
+    longer swallow it and write ``None`` to the CSV.
     """
-    try:
-        from torch.utils.flop_counter import FlopCounterMode
-    except ImportError:
-        logger.info("torch.utils.flop_counter unavailable — GFLOPs disabled.")
-        return None
+    from torch.utils.flop_counter import FlopCounterMode
 
     one = sample[:1]
-    try:
-        with FlopCounterMode(display=False) as counter, torch.inference_mode():
+
+    def _measure(ctx: "torch.utils._contextlib.ContextDecorator") -> float:
+        with FlopCounterMode(display=False) as counter, ctx:
             model(one)
         return float(counter.get_total_flops()) / 1e9
-    except Exception as exc:  # noqa: BLE001
-        logger.warning(f"FlopCounterMode failed: {exc}")
-        return None
+
+    try:
+        return _measure(torch.inference_mode())
+    except AttributeError as exc:
+        # Specifically the "NoneType .. next_functions" path; retry under
+        # no_grad which keeps version counters enabled.
+        if "next_functions" not in str(exc):
+            raise
+        logger.info(
+            f"FlopCounterMode inference_mode rejected by {type(model).__name__}: "
+            f"{exc}; retrying under no_grad."
+        )
+        return _measure(torch.no_grad())
 
 
 class _NvmlSampler:
@@ -79,12 +94,17 @@ class _NvmlSampler:
         self._pynvml = None
         try:
             import pynvml
-
+        except ImportError:
+            logger.info("pynvml not installed — GPU power/util disabled.")
+            return
+        try:
             pynvml.nvmlInit()
             self._pynvml = pynvml
             self._handle = pynvml.nvmlDeviceGetHandleByIndex(gpu_index)
-        except Exception as exc:  # noqa: BLE001
-            logger.info(f"pynvml unavailable — GPU power/util disabled ({exc}).")
+        except pynvml.NVMLError as exc:
+            logger.info(
+                f"pynvml installed but NVML init failed — GPU power/util disabled ({exc})."
+            )
 
     def __enter__(self) -> "_NvmlSampler":
         if self._handle is None:
@@ -103,13 +123,21 @@ class _NvmlSampler:
                 self._pynvml.nvmlShutdown()
 
     def _poll(self) -> None:
+        nvml = self._pynvml
         while not self._stop.is_set():
             try:
-                mw = self._pynvml.nvmlDeviceGetPowerUsage(self._handle)
+                mw = nvml.nvmlDeviceGetPowerUsage(self._handle)
                 self.samples_w.append(mw / 1000.0)
-                util = self._pynvml.nvmlDeviceGetUtilizationRates(self._handle)
+                util = nvml.nvmlDeviceGetUtilizationRates(self._handle)
                 self.samples_sm_util.append(float(util.gpu))
-            except Exception:  # noqa: BLE001
+            except nvml.NVMLError as exc:
+                # Specific NVML error mid-run is worth knowing about; don't
+                # silently degrade.  Log and stop polling but keep what
+                # samples we have.
+                logger.warning(
+                    f"NVML poll failed after {len(self.samples_w)} samples ({exc}); "
+                    f"stopping power/util sampling for this measurement."
+                )
                 break
             self._stop.wait(self.interval_s)
 

--- a/src/torchgeo_bench/model_profile.py
+++ b/src/torchgeo_bench/model_profile.py
@@ -21,7 +21,6 @@ Energy/power/SM-utilization require ``pynvml`` (in the ``[profile]``
 extra). All other metrics work without extras.
 """
 
-import contextlib
 import logging
 import threading
 import time
@@ -102,9 +101,7 @@ class _NvmlSampler:
             self._pynvml = pynvml
             self._handle = pynvml.nvmlDeviceGetHandleByIndex(gpu_index)
         except pynvml.NVMLError as exc:
-            logger.info(
-                f"pynvml installed but NVML init failed — GPU power/util disabled ({exc})."
-            )
+            logger.info(f"pynvml installed but NVML init failed — GPU power/util disabled ({exc}).")
 
     def __enter__(self) -> "_NvmlSampler":
         if self._handle is None:
@@ -119,8 +116,10 @@ class _NvmlSampler:
             self._stop.set()
             self._thread.join()
         if self._pynvml is not None:
-            with contextlib.suppress(Exception):
+            try:
                 self._pynvml.nvmlShutdown()
+            except self._pynvml.NVMLError as exc:
+                logger.warning(f"nvmlShutdown failed: {exc} (likely benign at exit)")
 
     def _poll(self) -> None:
         nvml = self._pynvml

--- a/tests/test_intrinsic_dim.py
+++ b/tests/test_intrinsic_dim.py
@@ -100,45 +100,51 @@ class TestComputeBasic:
 
 
 class TestErrorHandling:
+    @requires_torchid
     def test_unknown_estimator_raises(self) -> None:
         """Estimator lookup failures surface immediately — we no longer
-        swallow them as NaN, which previously hid the TwoNN bug."""
+        swallow them as NaN, which previously hid the TwoNN bug.
+
+        Needs the real torchid because the error is raised by
+        ``_load_estimator`` after a successful import; without torchid it
+        raises ImportError first (still a propagated failure, just from
+        a different layer)."""
         X = np.random.RandomState(0).randn(100, 5).astype(np.float32)
         with pytest.raises(ValueError, match="Unknown torchid estimator"):
             compute_intrinsic_dim(
                 X, estimators=["NotARealEstimator"], device="cpu", max_samples=None
             )
 
+    @requires_torchid
     def test_failing_estimator_propagates(self) -> None:
         """A torchid-internal exception propagates — we don't silently
-        write NaN for it, because that previously hid real bugs."""
+        write NaN for it, because that previously hid real bugs.
+
+        Patches the torchid estimators registry rather than swapping the
+        whole module so ``torchid.primitives`` (used by the
+        zero-distance dedup) keeps working."""
+        import torchid.estimators as real_estimators
 
         class _Boom:
             def fit(self, X: torch.Tensor) -> "_Boom":  # noqa: ARG002
                 raise RuntimeError("boom")
 
-        fake_module = mock.MagicMock()
-        fake_module.Boom = _Boom
-        fake_pkg = mock.MagicMock()
-        fake_pkg.estimators = fake_module
-
         X = np.random.RandomState(0).randn(50, 4).astype(np.float32)
         with (
-            mock.patch.dict(
-                "sys.modules", {"torchid": fake_pkg, "torchid.estimators": fake_module}
-            ),
+            mock.patch.object(real_estimators, "Boom", _Boom, create=True),
             pytest.raises(RuntimeError, match="boom"),
         ):
             compute_intrinsic_dim(X, estimators=["Boom"], device="cpu", max_samples=None)
 
     def test_missing_torchid_raises_importerror(self) -> None:
+        """ImportError from ``_load_estimator`` propagates instead of
+        becoming a silent NaN row."""
         from torchgeo_bench import intrinsic_dim as mod
 
         X = np.random.RandomState(0).randn(50, 4).astype(np.float32)
-        # Force ImportError inside _load_estimator regardless of install state.
         with (
-            mock.patch.object(mod, "_load_estimator", side_effect=ImportError("no torchid")),
-            pytest.raises(ImportError, match="no torchid"),
+            mock.patch.object(mod, "_load_estimator", side_effect=ImportError("forced")),
+            pytest.raises(ImportError, match="forced"),
         ):
             compute_intrinsic_dim(X, estimators=["TwoNN"], device="cpu", max_samples=None)
 

--- a/tests/test_intrinsic_dim.py
+++ b/tests/test_intrinsic_dim.py
@@ -100,31 +100,25 @@ class TestComputeBasic:
 
 
 class TestErrorHandling:
-    def test_unknown_estimator_returns_nan(self, caplog: pytest.LogCaptureFixture) -> None:
+    def test_unknown_estimator_raises(self) -> None:
+        """Estimator lookup failures surface immediately — we no longer
+        swallow them as NaN, which previously hid the TwoNN bug."""
         X = np.random.RandomState(0).randn(100, 5).astype(np.float32)
-        with caplog.at_level(logging.WARNING):
-            out = compute_intrinsic_dim(
+        with pytest.raises(ValueError, match="Unknown torchid estimator"):
+            compute_intrinsic_dim(
                 X, estimators=["NotARealEstimator"], device="cpu", max_samples=None
             )
-        assert "NotARealEstimator" in out
-        assert np.isnan(out["NotARealEstimator"])
-        assert any("NotARealEstimator" in r.message for r in caplog.records)
 
-    def test_failing_estimator_continues_others(self, caplog: pytest.LogCaptureFixture) -> None:
-        """A failing estimator should log+nan, not abort the loop."""
+    def test_failing_estimator_propagates(self) -> None:
+        """A torchid-internal exception propagates — we don't silently
+        write NaN for it, because that previously hid real bugs."""
 
         class _Boom:
             def fit(self, X: torch.Tensor) -> "_Boom":  # noqa: ARG002
                 raise RuntimeError("boom")
 
-        class _Good:
-            def fit(self, X: torch.Tensor) -> "_Good":  # noqa: ARG002
-                self.dimension_ = 3.5
-                return self
-
         fake_module = mock.MagicMock()
         fake_module.Boom = _Boom
-        fake_module.Good = _Good
         fake_pkg = mock.MagicMock()
         fake_pkg.estimators = fake_module
 
@@ -133,24 +127,20 @@ class TestErrorHandling:
             mock.patch.dict(
                 "sys.modules", {"torchid": fake_pkg, "torchid.estimators": fake_module}
             ),
-            caplog.at_level(logging.WARNING),
+            pytest.raises(RuntimeError, match="boom"),
         ):
-            out = compute_intrinsic_dim(
-                X, estimators=["Boom", "Good"], device="cpu", max_samples=None
-            )
-        assert np.isnan(out["Boom"])
-        assert out["Good"] == pytest.approx(3.5)
-        assert any("Boom" in r.message for r in caplog.records)
+            compute_intrinsic_dim(X, estimators=["Boom"], device="cpu", max_samples=None)
 
     def test_missing_torchid_raises_importerror(self) -> None:
         from torchgeo_bench import intrinsic_dim as mod
 
         X = np.random.RandomState(0).randn(50, 4).astype(np.float32)
         # Force ImportError inside _load_estimator regardless of install state.
-        with mock.patch.object(mod, "_load_estimator", side_effect=ImportError("no torchid")):
-            out = compute_intrinsic_dim(X, estimators=["TwoNN"], device="cpu", max_samples=None)
-        # ImportError is caught per-estimator → nan, not raised.
-        assert np.isnan(out["TwoNN"])
+        with (
+            mock.patch.object(mod, "_load_estimator", side_effect=ImportError("no torchid")),
+            pytest.raises(ImportError, match="no torchid"),
+        ):
+            compute_intrinsic_dim(X, estimators=["TwoNN"], device="cpu", max_samples=None)
 
 
 # ---- real torchid integration (requires py>=3.13) ------------------------


### PR DESCRIPTION
## Why
You called out (and you're right) that several `try/except → NaN/None/[]` patterns I added this session were trading debuggability for false robustness. The patterns moved bugs into the CSV instead of fixing them. This PR rips them out and addresses the underlying failures they were masking.

## Three concrete bugs that the swallowing was hiding

1. **TwoNN nan on Prithvi/Clay** — fp32 squared-distance underflows on near-duplicate CLS embeddings. Now pre-filtered via `_drop_zero_distance_rows` (PR #71 had the same fix; folded in here so it actually lands).
2. **Panopticon GFLOPs missing (2/34 on eurosat-spatial)** — `FlopCounterMode` chokes on `'NoneType' object has no attribute 'next_functions'` because Panopticon's hooks rely on the version counter that `torch.inference_mode` disables. Fall back to `torch.no_grad` on exactly that AttributeError, propagate otherwise.
3. **NVML mid-run drops** — the poll thread silently `break`ed on any exception. Now logs the first NVML error with sample count, so a degraded measurement isn't indistinguishable from a clean one.

## What was deleted
- `intrinsic_dim.py`: per-estimator `except Exception → NaN`. Real exceptions now propagate. `np.isnan(value)` after a clean fit raises with a full d1/d2/X-norm diagnostic dump instead of being silently emitted.
- `model_profile.py`: dead `try: from torch.utils.flop_counter except ImportError` (stdlib since 2.0). Broad `except Exception` around the counter (replaced with targeted retry). Broad `except Exception` around `nvmlInit` (split into `ImportError` + `NVMLError`).
- `main.py`: `except Exception → return []` around the profile sample fetch.

## Tests
`tests/test_intrinsic_dim.py` had 3 tests asserting the old swallow-and-NaN contract. Updated them to assert the new contract:
- unknown estimator → `ValueError` raised (was: silent NaN + log)
- estimator fit raises → propagates (was: silent NaN + log)
- missing torchid → `ImportError` propagates (was: silent NaN per estimator)

These are the spec for the new behavior; they would have caught the regression that hid the TwoNN bug.

## Verification
- `ruff check` clean
- `pytest tests/test_intrinsic_dim.py tests/test_pooling.py tests/test_bench_model.py` — 30/30 pass
- Smoke: `_count_gflops` still works on a toy CPU net

## Follow-up
Once this merges I'll re-run the eurosat-spatial sweep (only the profile + intrinsic_dim methods, fast under `resume=true`) and confirm 34/34 GFLOPs and the existing TwoNN coverage holds. Any new failure will now surface loudly in the SLURM error log instead of as a NaN row.