### PR TITLE
fix: real fixes for TwoNN nan and Panopticon GFLOPs (sweep 88205 surfaced bugs)

### DIFF
--- a/src/torchgeo_bench/intrinsic_dim.py
+++ b/src/torchgeo_bench/intrinsic_dim.py
@@ -67,17 +67,27 @@ def _subsample(X: np.ndarray, max_samples: int | None, seed: int) -> np.ndarray:
 
 
 def _two_nearest_distances(X: torch.Tensor) -> torch.Tensor:
-    """Pairwise (d1, d2) for each row, computed via ``torch.cdist``.
+    """Pairwise (d1, d2) for each row, matching torchid's knn precision.
 
-    Same shape and meaning as ``torchid.primitives.knn(X, k=2)[0]`` but
-    has no torchid dependency, so the dedup runs in environments where
-    we haven't installed the ``[id]`` extra (e.g. CI without
-    Python 3.13).  We don't need indices, just the smallest two
-    distances per row.
+    We deliberately replicate torchid's exact squared-distance formula
+    (``x_sq + y_sq − 2·x·y.T`` then ``clamp_(min=0)``) instead of using
+    ``torch.cdist``.  ``cdist`` is more numerically stable on CUDA, so
+    its distances disagree with torchid's at the underflow boundary —
+    that mismatch was hiding a TwoNN nan we just debugged (sweep 88205,
+    Prithvi v1_100): the dedup said ``d1.min = 9.96e-3, zeros = 0`` but
+    torchid's internal knn produced ``d1 == 0`` for the same rows
+    because its squared-distance formula cancels to a tiny negative,
+    gets clamped to 0, and underflows to 0 in fp32 after ``.sqrt()``.
+
+    Replicating the formula keeps dedup and the estimator agreeing on
+    which rows are degenerate.
     """
-    dist = torch.cdist(X, X)
-    dist.fill_diagonal_(float("inf"))
-    return dist.topk(k=2, largest=False).values
+    x_sq = (X * X).sum(dim=1, keepdim=True)
+    y_sq = x_sq.squeeze(1)
+    d_sq = (x_sq + y_sq.unsqueeze(0) - 2.0 * (X @ X.T)).clamp_(min=0.0)
+    d_sq.fill_diagonal_(float("inf"))
+    top2_sq = d_sq.topk(k=2, largest=False).values
+    return top2_sq.sqrt()
 
 
 def _drop_zero_distance_rows(X_tensor: torch.Tensor) -> torch.Tensor:

--- a/src/torchgeo_bench/model_profile.py
+++ b/src/torchgeo_bench/model_profile.py
@@ -37,42 +37,72 @@ def _count_params(model: nn.Module) -> float:
     return total / 1e6
 
 
-def _count_gflops(model: nn.Module, sample: torch.Tensor) -> float | None:
+def _count_gflops(model: nn.Module, sample: torch.Tensor) -> float:
     """Run one forward pass under torch's FlopCounterMode for a single sample.
 
-    Uses ``torch.utils.flop_counter`` (stdlib torch since 2.0). The counter
-    relies on ``__torch_dispatch__`` and is incompatible with some custom
-    forwards (e.g. ``Panopticon`` raises
-    ``'NoneType' object has no attribute 'next_functions'`` because one of
-    its hooks returns ``None`` where dispatch expects a tensor).
+    Uses ``torch.utils.flop_counter`` (stdlib torch since 2.0).  The
+    counter's ``module_tracker`` wants to call
+    ``register_multi_grad_hook`` on the activations, which requires every
+    intermediate tensor to have a ``grad_fn`` (i.e. autograd must be
+    enabled).  Three different contexts have to be tried in order from
+    cheapest to most permissive:
 
-    On dispatch errors we fall back to ``no_grad`` instead of
-    ``inference_mode`` — the latter disables version-counting which some
-    custom modules rely on.  If that also fails we surface the error so
-    callers can decide whether to skip a metric or fail loudly; we no
-    longer swallow it and write ``None`` to the CSV.
+    1. ``torch.inference_mode``: cheapest.  Works for most timm /
+       torchgeo backbones because their forwards don't trigger the
+       module-tracker code paths that need grad_fn.
+    2. ``torch.no_grad``: keeps the version counter that
+       ``inference_mode`` disables.  Catches forwards that rely on
+       ``inference_tensor`` returning a regular tensor.
+    3. ``torch.enable_grad`` with ``requires_grad=True`` on the input:
+       only path that gives every activation a grad_fn.  Required by
+       ``torchgeo.models.Panopticon``, which inside ``MultiheadAttention``
+       triggers ``register_multi_grad_hook`` on a non-leaf tensor and
+       raises ``AssertionError: Expected gradient function to be set``
+       otherwise.  More expensive (autograd graph is built and then
+       discarded) but still a single forward pass.
+
+    Each fallback only triggers on the *specific* exception that earlier
+    fallback can't handle, so genuine bugs in the counter surface
+    instead of being papered over.
     """
     from torch.utils.flop_counter import FlopCounterMode
 
-    one = sample[:1]
+    base = sample[:1]
 
-    def _measure(ctx: "torch.utils._contextlib.ContextDecorator") -> float:
-        with FlopCounterMode(display=False) as counter, ctx:
-            model(one)
+    def _measure_no_autograd(ctx_factory) -> float:
+        with FlopCounterMode(display=False) as counter, ctx_factory():
+            model(base)
+        return float(counter.get_total_flops()) / 1e9
+
+    def _measure_with_autograd() -> float:
+        inp = base.detach().clone().requires_grad_(True)
+        with FlopCounterMode(display=False) as counter, torch.enable_grad():
+            model(inp)
         return float(counter.get_total_flops()) / 1e9
 
     try:
-        return _measure(torch.inference_mode())
+        return _measure_no_autograd(torch.inference_mode)
     except AttributeError as exc:
-        # Specifically the "NoneType .. next_functions" path; retry under
-        # no_grad which keeps version counters enabled.
+        # 'NoneType' object has no attribute 'next_functions' — only
+        # the dispatch-vs-inference-tensor mismatch.
         if "next_functions" not in str(exc):
             raise
         logger.info(
             f"FlopCounterMode inference_mode rejected by {type(model).__name__}: "
             f"{exc}; retrying under no_grad."
         )
-        return _measure(torch.no_grad())
+    try:
+        return _measure_no_autograd(torch.no_grad)
+    except AssertionError as exc:
+        # 'Expected gradient function to be set' — the module_tracker
+        # needs activations to have grad_fn; only enable_grad provides that.
+        if "Expected gradient function" not in str(exc):
+            raise
+        logger.info(
+            f"FlopCounterMode no_grad rejected by {type(model).__name__}: "
+            f"{exc}; retrying under enable_grad with requires_grad input."
+        )
+    return _measure_with_autograd()
 
 
 class _NvmlSampler:


### PR DESCRIPTION
After the silent-skip audit in #78, sweep 88205 exposed two real bugs:

## TwoNN still nan on Prithvi v1_100, v2_600
- Diagnostic from the now-loud failure: `d1[min=9.96e-03 zeros=0]` per my cdist dedup, yet torchid's TwoNN still produced nan.
- Root cause: `torch.cdist` and torchid's internal `(x_sq + y_sq − 2·x·y.T).clamp_(min=0).sqrt()` disagree at the fp32 cancellation boundary. cdist sees nonzero distance; torchid's formula cancels to negative, clamps to 0, sqrt to 0.
- Fix: replicate torchid's exact formula in `_two_nearest_distances` so the dedup catches the same degenerate rows TwoNN will.

## Panopticon FlopCounterMode failed under no_grad
- Inner error: `AssertionError: Expected gradient function to be set` in `module_tracker → register_multi_grad_hook`. The tracker needs activations to have grad_fn.
- Fix: a third fallback under `torch.enable_grad()` with `requires_grad=True` on the input. Single forward pass; builds and discards the graph. Triggers only on the specific assertion message.

Both fallbacks raise on any *other* exception so genuine bugs still surface.

## Verification
Submitted sweep 88239 (5 affected combos) with this branch's code. Expecting 5/5 to land — will update once it returns.