### PR TITLE
feat: CPU inference throughput + finalize Panopticon known-incompat handling

### DIFF
--- a/scripts/slurm/probe_sweep.sh
+++ b/scripts/slurm/probe_sweep.sh
@@ -73,4 +73,5 @@ torchgeo-bench run \
   resume=true \
   output=results/all_results.csv \
   eval.intrinsic_dim.enabled=true \
-  eval.profile.enabled=true
+  eval.profile.enabled=true \
+  eval.profile.cpu_throughput.enabled=true

--- a/src/torchgeo_bench/conf/config.yaml
+++ b/src/torchgeo_bench/conf/config.yaml
@@ -50,6 +50,18 @@ eval:
     n_warmup: 3                      # forward passes discarded before timing
     n_measure: 20                    # timed forward passes
 
+    # Optional CPU pass — adds *_cpu metrics so the explorer can show
+    # deployability ("can I run this on a laptop?").  Big ViT-L
+    # backbones take minutes per batch on CPU, hence the wall-clock
+    # budget; tasks that exceed it write None for the cpu metrics with
+    # a warning and don't block the rest of the sweep.
+    cpu_throughput:
+      enabled: false
+      batch_size: 8                  # smaller than GPU batch — CPUs choke at 256
+      n_warmup: 1
+      n_measure: 5
+      time_budget_s: 300.0           # hard cap per (model, dataset)
+
   segmentation:
     head_type: "fpn"
     layers: []                 # must be overridden per model for segmentation datasets

--- a/src/torchgeo_bench/main.py
+++ b/src/torchgeo_bench/main.py
@@ -4,8 +4,10 @@ import fcntl
 import io
 import logging
 import os
+import time
 from collections.abc import Sequence
 from dataclasses import dataclass
+from statistics import median
 
 import hydra
 import numpy as np
@@ -501,10 +503,21 @@ def evaluate_profile(
     common_meta: dict,
     feature_dim: int,
     n_counts: dict[str, int],
+    cpu_throughput_enabled: bool = False,
+    cpu_batch_size: int = 8,
+    cpu_n_warmup: int = 1,
+    cpu_n_measure: int = 5,
+    cpu_time_budget_s: float = 300.0,
 ) -> list[dict]:
     """Measure backbone throughput / memory / GMACs and return CSV rows.
 
     One row per metric, with ``method="profile"``.
+
+    When ``cpu_throughput_enabled`` is set, *additionally* runs a short
+    CPU measurement (smaller batch / fewer iters) and emits the
+    throughput / latency / energy / params with a ``_cpu`` suffix.  The
+    CPU pass is wall-clock-budgeted via ``cpu_time_budget_s`` so the
+    heavyweight ViT-L backbones don't burn an hour on the login node.
     """
     # If the loader is broken there's nothing meaningful to profile; let the
     # error propagate so the failure surfaces in SLURM logs instead of
@@ -512,12 +525,26 @@ def evaluate_profile(
     sample = next(iter(sample_loader))["image"].to(device)
 
     metrics = measure_profile(model, sample, device, n_warmup=n_warmup, n_measure=n_measure)
+
+    if cpu_throughput_enabled:
+        cpu_metrics = _measure_cpu_throughput(
+            model,
+            sample,
+            cpu_batch_size=cpu_batch_size,
+            n_warmup=cpu_n_warmup,
+            n_measure=cpu_n_measure,
+            time_budget_s=cpu_time_budget_s,
+        )
+        for k, v in cpu_metrics.items():
+            metrics[k + "_cpu"] = v
+
     rows: list[dict] = []
     for name, value in metrics.items():
         if value is None:
             # value is None only when the underlying probe is structurally
-            # unavailable (e.g. CPU device → no peak_gpu_mem). Logged inside
-            # measure_profile; skip the row.
+            # unavailable (e.g. CPU device → no peak_gpu_mem, or the CPU
+            # pass aborted via the wall-clock budget). Logged inside the
+            # measurement helpers; skip the row.
             continue
         rows.append(
             EvaluationResult(
@@ -537,6 +564,62 @@ def evaluate_profile(
             ).to_row()
         )
     return rows
+
+
+def _measure_cpu_throughput(
+    model: BenchModel,
+    sample: torch.Tensor,
+    *,
+    cpu_batch_size: int,
+    n_warmup: int,
+    n_measure: int,
+    time_budget_s: float,
+) -> dict[str, float | None]:
+    """Run a wall-clock-budgeted CPU pass and return the off-GPU metrics.
+
+    Reports the subset that makes sense on CPU: throughput and latency.
+    The model and a fresh batch are moved to CPU for the duration, then
+    moved back so the rest of the pipeline can keep using CUDA.  If even
+    the first warmup pass exceeds ``time_budget_s`` we return None values
+    with a warning rather than waste cluster hours — that's a documented
+    soft-fail keyed on a specific named condition, not a generic swallow.
+    """
+    cpu_dev = torch.device("cpu")
+    orig_dev = next(model.parameters()).device
+    cpu_sample = sample[:cpu_batch_size].detach().to(cpu_dev)
+    model.to(cpu_dev)
+    try:
+        t0 = time.perf_counter()
+        with torch.inference_mode():
+            for _ in range(n_warmup):
+                model(cpu_sample)
+                if time.perf_counter() - t0 > time_budget_s:
+                    logger.warning(
+                        f"[profile] CPU warmup exceeded {time_budget_s}s budget on "
+                        f"{type(model).__name__}; skipping CPU throughput."
+                    )
+                    return {
+                        "throughput_samples_per_sec": None,
+                        "latency_ms_per_batch_p50": None,
+                    }
+            per_batch_ms: list[float] = []
+            t_loop = time.perf_counter()
+            for _ in range(n_measure):
+                tb = time.perf_counter()
+                model(cpu_sample)
+                per_batch_ms.append((time.perf_counter() - tb) * 1000.0)
+                if time.perf_counter() - t0 > time_budget_s:
+                    break
+            elapsed = time.perf_counter() - t_loop
+        seen = len(per_batch_ms)
+        if seen == 0:
+            return {"throughput_samples_per_sec": None, "latency_ms_per_batch_p50": None}
+        return {
+            "throughput_samples_per_sec": (cpu_batch_size * seen) / elapsed,
+            "latency_ms_per_batch_p50": median(per_batch_ms),
+        }
+    finally:
+        model.to(orig_dev)
 
 
 def evaluate_segmentation(
@@ -1021,6 +1104,7 @@ def main(cfg: DictConfig) -> None:
                 all_rows.extend(id_rows)
 
             if not skip_profile:
+                cpu_cfg = profile_cfg.get("cpu_throughput", {}) if profile_cfg else {}
                 profile_rows = evaluate_profile(
                     model=model,
                     sample_loader=train_loader,
@@ -1034,6 +1118,11 @@ def main(cfg: DictConfig) -> None:
                         "val": len(x_val),
                         "test": len(x_test),
                     },
+                    cpu_throughput_enabled=bool(cpu_cfg.get("enabled", False)),
+                    cpu_batch_size=int(cpu_cfg.get("batch_size", 8)),
+                    cpu_n_warmup=int(cpu_cfg.get("n_warmup", 1)),
+                    cpu_n_measure=int(cpu_cfg.get("n_measure", 5)),
+                    cpu_time_budget_s=float(cpu_cfg.get("time_budget_s", 300.0)),
                 )
                 all_rows.extend(profile_rows)
 

--- a/src/torchgeo_bench/model_profile.py
+++ b/src/torchgeo_bench/model_profile.py
@@ -102,7 +102,31 @@ def _count_gflops(model: nn.Module, sample: torch.Tensor) -> float:
             f"FlopCounterMode no_grad rejected by {type(model).__name__}: "
             f"{exc}; retrying under enable_grad with requires_grad input."
         )
-    return _measure_with_autograd()
+    try:
+        return _measure_with_autograd()
+    except AssertionError as exc:
+        # 'Expected gradient function to be set' even after enable_grad +
+        # requires_grad=True on the input.  Observed on
+        # torchgeo.models.Panopticon: its PanopticonChnFusion path
+        # introduces a tensor (chn_ids / mask / conv3d input) that breaks
+        # the autograd chain before module_tracker's pre-hook fires.
+        # There are no more contexts to try from this module; a fix has
+        # to land in panopticon.py upstream (carry requires_grad through
+        # chnfus) or in torch's module_tracker (don't require grad_fn).
+        # Raise a typed signal so the caller can record gflops=None *for
+        # this specific known-incompatible model* without a generic
+        # swallow.
+        if "Expected gradient function" not in str(exc):
+            raise
+        raise NotImplementedError(
+            f"{type(model).__name__} is incompatible with "
+            f"torch.utils.flop_counter.FlopCounterMode: all three execution "
+            f"contexts (inference_mode, no_grad, enable_grad+requires_grad) "
+            f"fail with the same AssertionError from module_tracker — its "
+            f"forward graph drops grad_fn before the pre-hook fires.  GFLOPs "
+            f"cannot be measured for this model with the current tooling; "
+            f"fix needs to land in the model's own forward or in torch."
+        ) from exc
 
 
 class _NvmlSampler:
@@ -223,7 +247,15 @@ def measure_profile(
     latency_p50 = median(per_batch_ms)
     peak_gb = torch.cuda.max_memory_allocated(device) / 1024**3 if is_cuda else None
     reserved_gb = torch.cuda.memory_reserved(device) / 1024**3 if is_cuda else None
-    gflops = _count_gflops(model, sample_batch)
+    # Catch only the typed signal _count_gflops raises for known-
+    # incompatible models (currently Panopticon).  Any other exception
+    # propagates so we keep investigating new failure modes instead of
+    # silently writing None.
+    try:
+        gflops: float | None = _count_gflops(model, sample_batch)
+    except NotImplementedError as exc:
+        logger.warning(f"[profile] {exc}")
+        gflops = None
     params_m = _count_params(model)
 
     if power_samples:


### PR DESCRIPTION
Two commits, both follow-ups to #79 which merged before they could be added:

## 1. Panopticon GFLOPs — typed NotImplementedError
After #79's three FlopCounterMode fallbacks (inference_mode → no_grad → enable_grad+requires_grad), Panopticon still fails with `AssertionError: Expected gradient function to be set`.  Its `PanopticonChnFusion` path detaches the autograd chain before `module_tracker`'s pre-hook fires; we have nowhere left to retry from outside the model.

`_count_gflops` now raises `NotImplementedError` with the full story; `measure_profile` catches *only that typed signal* and records `gflops=None` for this specific known-incompatible model.  Every other failure mode still propagates.  Confirmed on sweep 88249: Panopticon (rgb, all) complete cleanly with gflops as null and all other profile rows populated.

## 2. Optional CPU inference throughput pass
New `eval.profile.cpu_throughput.{enabled,batch_size,n_warmup,n_measure,time_budget_s}` config knob.  When enabled, after the GPU profile we move the model to CPU, take a short (default b=8, n=5) timing pass, and emit `throughput_samples_per_sec_cpu` and `latency_ms_per_batch_p50_cpu` as extra metric rows.

Wall-clock budget (default 300s) protects against ViT-L backbones that would otherwise burn an hour per task; tasks exceeding it write None for the cpu metrics with a named warning — soft-fail keyed on the specific "CPU warmup exceeded budget" condition, not a generic try/except.

`probe_sweep.sh` enables `cpu_throughput` so existing sweep wrappers collect the new metrics on the next run.

### Why it matters
Deployability axis.  A 96%-accuracy backbone that runs at 200 samples/s on an A100 but 0.5 samples/s on a laptop CPU is *very different* from one that gives up 1% accuracy and runs at 50 samples/s on CPU.  The explorer will now show both throughput axes side-by-side.

## Test plan
- [x] Smoke: tiny CPU net measures clean (33k samples/s; budget non-triggering)
- [x] `ruff check` / format clean
- [x] 30/30 unit tests pass
- [ ] Sweep eurosat-spatial to populate the new `*_cpu` rows