### PR TITLE
fix(timm): populate model_native stats from pretrained_cfg

### DIFF
--- a/src/torchgeo_bench/models/timm.py
+++ b/src/torchgeo_bench/models/timm.py
@@ -8,6 +8,7 @@ import torch.nn.functional as F
 
 from torchgeo_bench.datasets.base import BandSpec
 
+from ._normalization import InputUnit
 from .interface import BenchModel
 
 logger = logging.getLogger(__name__)
@@ -55,6 +56,34 @@ class TimmPatchBenchModel(BenchModel):
         input_normalization: str = "bands_zscore",
         **_kwargs,
     ) -> None:
+        # Populate the BenchModel-level pretrain stats from timm's pretrained
+        # cfg *before* super().__init__ so the ``model_native`` normalisation
+        # strategy has mean/std to work with.  Without this, model_native
+        # raises ``requires expected_input_unit`` because timm wrappers don't
+        # subclass-declare those attrs (unlike terratorch / torchgeo
+        # wrappers that hard-code them).
+        #
+        # Only meaningful when num_channels == 3 — timm cfgs ship RGB stats.
+        # For multispectral inputs we leave the attrs at the class-level
+        # ``None`` defaults so build_normalizer raises a clear error if the
+        # caller asked for model_native (we have no per-channel stats).
+        if len(bands) == 3:
+            # timm.get_pretrained_cfg returns None for unknown model names.
+            # A typo should fail loudly at construction, not silently lose
+            # model_native — but only insist on a cfg existing when the
+            # caller is actually 3-band (the multispectral branch below
+            # already has no path to use it).
+            cfg = timm.get_pretrained_cfg(model_name)
+            if cfg is None:
+                raise RuntimeError(
+                    f"timm has no pretrained cfg for {model_name!r}; check the "
+                    f"model name (was the wrapper called with a fake/scratch model?)."
+                )
+            if cfg.mean is not None and cfg.std is not None:
+                self.expected_input_unit = InputUnit.REFLECTANCE_0_1
+                self.pretrain_mean = list(cfg.mean)
+                self.pretrain_std = list(cfg.std)
+
         super().__init__(bands=bands, **_kwargs)
 
         if input_normalization not in _VALID_INPUT_NORMALIZATIONS:

--- a/tests/test_timm_normalization.py
+++ b/tests/test_timm_normalization.py
@@ -153,3 +153,61 @@ def test_none_normalization_is_identity():
     raw = torch.tensor([[[[1234.0]], [[5678.0]], [[9012.0]]]])
     out = model.normalize_inputs(raw)
     assert torch.equal(out, raw)
+
+
+def test_model_native_uses_timm_pretrained_stats():
+    """``normalization=model_native`` on a timm wrapper pulls mean/std from
+    timm's pretrained_cfg (previously raised ``requires expected_input_unit``
+    because TimmPatchBenchModel didn't populate the BenchModel-level stats).
+    """
+    import timm
+
+    from torchgeo_bench.models.timm import TimmPatchBenchModel
+
+    cfg = timm.get_pretrained_cfg("resnet18")
+    bands = _rgb_bands(mins=(0.0, 0.0, 0.0), maxs=(1.0, 1.0, 1.0))  # already in [0, 1]
+    model = TimmPatchBenchModel(
+        bands=bands,
+        model_name="resnet18",
+        pretrained=False,
+        normalization="model_native",
+    )
+    raw = torch.zeros(1, 3, 2, 2)  # zero reflectance -> -mean/std after normalize
+    out = model.normalize_inputs(raw)
+    expected = -torch.tensor(cfg.mean).view(1, 3, 1, 1) / torch.tensor(cfg.std).view(1, 3, 1, 1)
+    assert torch.allclose(out, expected.expand_as(out), atol=1e-5)
+
+
+def test_model_native_picks_up_variant_stats():
+    """A timm variant (e.g. dinov3.sat493m) ships its own pretrained stats —
+    the wrapper must use those, not the generic ImageNet defaults."""
+    import timm
+
+    from torchgeo_bench.models.timm import TimmPatchBenchModel
+
+    name = "vit_large_patch16_dinov3.sat493m"
+    cfg = timm.get_pretrained_cfg(name)
+    assert tuple(cfg.mean) != (0.485, 0.456, 0.406), "stats should differ from ImageNet"
+
+    bands = _rgb_bands(mins=(0.0, 0.0, 0.0), maxs=(1.0, 1.0, 1.0))
+    model = TimmPatchBenchModel(
+        bands=bands,
+        model_name=name,
+        pretrained=False,
+        normalization="model_native",
+    )
+    assert model.pretrain_mean == list(cfg.mean)
+    assert model.pretrain_std == list(cfg.std)
+
+
+def test_unknown_timm_model_name_raises_clearly():
+    """A typo in ``model_name`` must fail loudly at construction (we don't
+    silently swallow the missing pretrained_cfg)."""
+    from torchgeo_bench.models.timm import TimmPatchBenchModel
+
+    with pytest.raises(RuntimeError, match="no pretrained cfg"):
+        TimmPatchBenchModel(
+            bands=_rgb_bands(),
+            model_name="this_model_definitely_does_not_exist_xyz",
+            pretrained=False,
+        )


### PR DESCRIPTION
## Summary
- `TimmPatchBenchModel` now pulls `mean`/`std` from `timm.get_pretrained_cfg(model_name)` before `super().__init__`, so `dataset.normalization=model_native` works for any timm backbone.
- Previously `model_native` raised `ValueError('model_native normalisation requires expected_input_unit')` because the wrapper didn't populate the `BenchModel`-level stats (unlike the terratorch / torchgeo wrappers which subclass-declare them).
- Real signal recovered: `vit_large_patch16_dinov3.sat493m` ships satellite-tuned stats `(0.43, 0.411, 0.296)` distinct from ImageNet's `(0.485, 0.456, 0.406)`. The web variant `.lvd1689m` happens to use ImageNet stats, which is still correct.
- Unknown model names now raise loudly at construction (`timm.get_pretrained_cfg` returns None for those; we re-raise with a clear message instead of silently skipping the population).

## Test plan
- [x] `pytest tests/test_timm_normalization.py` — 3 new tests + all 6 existing pass
  - `test_model_native_uses_timm_pretrained_stats` — confirms resnet18 normalisation matches `(x - cfg.mean) / cfg.std`
  - `test_model_native_picks_up_variant_stats` — confirms `dinov3.sat493m` picks up its variant-specific stats
  - `test_unknown_timm_model_name_raises_clearly` — confirms typo path raises `RuntimeError`
- [x] `pre-commit run --files src/torchgeo_bench/models/timm.py tests/test_timm_normalization.py` — clean

## Follow-up
After this merges, re-queue the timm × `model_native` slices from the in-flight GeoBench sweep to backfill the rows that previously crashed.