### PR TITLE
feat(olmoearth): re-enable wrapper + add nano/tiny variant configs

### DIFF
--- a/scripts/slurm/build_probe_jobs.py
+++ b/scripts/slurm/build_probe_jobs.py
@@ -43,6 +43,8 @@ SINGLE_BAND_MODE_MODELS: dict[str, str] = {
     "sam3_encoder": "rgb",
     # OlmoEarth wrapper accepts 3-ch RGB or 12-ch S2 (no B10).  m-eurosat
     # all is 13-ch including cirrus; just sweep RGB for now.
+    "olmoearth_nano": "rgb",
+    "olmoearth_tiny": "rgb",
     "olmoearth_base": "rgb",
     "olmoearth_large": "rgb",
     # 3-channel pretrained backbones (DOFA hardcodes S2-RGB wavelengths;
@@ -84,10 +86,14 @@ DEFAULT_MODELS: list[str] = [
     "timm/vit/vit_large_patch16_dinov3sat",
     # DINOv3 ViT-Large web-pretrained (natural-image baseline, RGB-only)
     "timm/vit/vit_large_patch16_dinov3",
-    # OlmoEarth (direct olmoearth-pretrain-minimal path) — disabled: HF
-    # weight download hangs on the cluster; re-enable after caching weights
-    # locally.
-    # "olmoearth_base",
+    # OlmoEarth (AI2 GeoFM) — all four variants.  Requires the
+    # `[olmoearth]` extra (olmoearth-pretrain-minimal).  The original
+    # disable note was about a transient HF download hang + the extra
+    # not being installed in the cluster venv; both resolved.
+    "olmoearth_nano",
+    "olmoearth_tiny",
+    "olmoearth_base",
+    "olmoearth_large",
     # baselines
     "rcf",
     "imagestats",

--- a/src/torchgeo_bench/conf/model/olmoearth_base.yaml
+++ b/src/torchgeo_bench/conf/model/olmoearth_base.yaml
@@ -1,7 +1,8 @@
 # OlmoEarth-v1-Base (AI2 geospatial foundation model)
 # Feature dimension: 768
-# Default: RGB mode (3 channels). For full S2, set num_channels=12 and dataset.bands=all
-# Run with: dataset.normalization=none
+# Default: RGB mode (3 channels). For full S2, set dataset.bands=all
+# The wrapper applies OlmoEarth's internal Normalizer regardless of the
+# dataset.normalization setting (normalize_inputs is overridden to identity).
 
 _target_: torchgeo_bench.models.OlmoEarthBenchModel
 model_size: base

--- a/src/torchgeo_bench/conf/model/olmoearth_large.yaml
+++ b/src/torchgeo_bench/conf/model/olmoearth_large.yaml
@@ -1,7 +1,8 @@
 # OlmoEarth-v1-Large (AI2 geospatial foundation model)
 # Feature dimension: 1024
-# Default: RGB mode (3 channels). For full S2, set num_channels=12 and dataset.bands=all
-# Run with: dataset.normalization=none
+# Default: RGB mode (3 channels). For full S2, set dataset.bands=all
+# The wrapper applies OlmoEarth's internal Normalizer regardless of the
+# dataset.normalization setting (normalize_inputs is overridden to identity).
 
 _target_: torchgeo_bench.models.OlmoEarthBenchModel
 model_size: large

--- a/src/torchgeo_bench/conf/model/olmoearth_nano.yaml
+++ b/src/torchgeo_bench/conf/model/olmoearth_nano.yaml
@@ -1,0 +1,13 @@
+# OlmoEarth-v1-Nano (AI2 geospatial foundation model)
+# Feature dimension: 128
+# Default: RGB mode (3 channels). For full S2, set dataset.bands=all
+# Run with: dataset.normalization=identity (the wrapper applies OlmoEarth's own normalizer)
+
+_target_: torchgeo_bench.models.OlmoEarthBenchModel
+model_size: nano
+patch_size: 8
+input_res: 10
+time_steps: 3
+std_multiplier: 2.0
+normalize: false
+name: olmoearth_v1_nano

--- a/src/torchgeo_bench/conf/model/olmoearth_tiny.yaml
+++ b/src/torchgeo_bench/conf/model/olmoearth_tiny.yaml
@@ -1,0 +1,13 @@
+# OlmoEarth-v1-Tiny (AI2 geospatial foundation model)
+# Feature dimension: 192
+# Default: RGB mode (3 channels). For full S2, set dataset.bands=all
+# Run with: dataset.normalization=identity (the wrapper applies OlmoEarth's own normalizer)
+
+_target_: torchgeo_bench.models.OlmoEarthBenchModel
+model_size: tiny
+patch_size: 8
+input_res: 10
+time_steps: 3
+std_multiplier: 2.0
+normalize: false
+name: olmoearth_v1_tiny

--- a/src/torchgeo_bench/models/olmoearth.py
+++ b/src/torchgeo_bench/models/olmoearth.py
@@ -5,11 +5,13 @@ BenchModel interface. Supports both RGB (3-channel) and full multispectral
 (12-channel Sentinel-2) input.
 
 When given RGB input, the 3 channels are mapped to B02/B03/B04 in OlmoEarth's
-expected band order, the remaining 9 bands are zero-filled, and the
-corresponding band sets are marked as MISSING in the mask so the model
-treats them as absent data rather than real zero-valued observations.
+expected band order; the remaining 9 bands are zero-filled.  All band sets
+remain marked visible in the mask — the encoder learns to attend through
+zero-valued bands but the docstring's earlier claim of MISSING masking was
+never actually implemented (and breaks ``pool_spatially`` when applied).
 
-Reference implementation:
+Reference implementations (canonical first):
+    https://github.com/allenai/olmoearth_pretrain/blob/main/docs/Inference-Quickstart.md
     https://github.com/isaaccorley/geopool/blob/main/scripts/embed_olmoearth.py
 """
 
@@ -156,7 +158,9 @@ class OlmoEarthBenchModel(BenchModel):
         out of bounds.  ``ONLINE_ENCODER`` has value 0, so all-zeros == all
         visible.
         """
-        return torch.zeros(B, H, W, self.time_steps, _NUM_BAND_SETS, dtype=torch.float32, device=device)
+        return torch.zeros(
+            B, H, W, self.time_steps, _NUM_BAND_SETS, dtype=torch.float32, device=device
+        )
 
     @torch.no_grad()
     def _forward_patch_features(

--- a/src/torchgeo_bench/models/olmoearth.py
+++ b/src/torchgeo_bench/models/olmoearth.py
@@ -45,9 +45,9 @@ OLMOEARTH_S2_BANDS = (
     "B09",
 )
 
-# Number of channels per band set
+# Number of channels per band set (B02/B03/B04/B08 — B05-B12 — B01/B09).
 _BAND_SET_SIZES = (4, 6, 2)
-_NUM_BAND_SETS = len(_BAND_SET_SIZES)
+_NUM_BAND_SETS = len(_BAND_SET_SIZES)  # 3
 _TOTAL_S2_CHANNELS = sum(_BAND_SET_SIZES)  # 12
 
 
@@ -72,9 +72,14 @@ class OlmoEarthBenchModel(BenchModel):
     Args:
         bands: Either a 3-band RGB list or a 12-band Sentinel-2 list.
         model_size: One of ``"nano"``, ``"tiny"``, ``"base"``, ``"large"``.
-        patch_size: Patch size for the encoder (default 8).
+        patch_size: Patch size for the encoder (default 4 per the AI2 quickstart;
+            smaller patch sizes generally perform better but use more GPU memory).
         input_res: Input resolution in meters (default 10 for Sentinel-2).
-        time_steps: Temporal repeats for single-timestep input (default 3).
+        time_steps: Number of temporal slots in the input.  Default 1, matching the
+            official ``olmoearth_pretrain`` quickstart for single-image inference.
+            Replicating a single image across T>1 timesteps was historically used
+            here to satisfy a buggy 4-D mask shape, but the correct fix is a 5-D
+            mask and T=1 (see ``_build_mask`` below).
         std_multiplier: Standard deviation multiplier for normalization.
         normalize: If True, L2-normalize output embeddings.
     """
@@ -84,9 +89,9 @@ class OlmoEarthBenchModel(BenchModel):
         bands: list[BandSpec],
         *,
         model_size: Literal["nano", "tiny", "base", "large"] = "base",
-        patch_size: int = 8,
+        patch_size: int = 4,
         input_res: int = 10,
-        time_steps: int = 3,
+        time_steps: int = 1,
         std_multiplier: float = 2.0,
         normalize: bool = False,
         **_kwargs,
@@ -139,8 +144,19 @@ class OlmoEarthBenchModel(BenchModel):
         return s2
 
     def _build_mask(self, B: int, H: int, W: int, device: torch.device) -> torch.Tensor:
-        """Build the mask tensor (B, H, W, T) — all visible."""
-        return torch.zeros(B, H, W, self.time_steps, dtype=torch.long, device=device)
+        """Build the per-band-set mask tensor — all visible.
+
+        Shape is ``(B, H, W, T, num_band_sets)`` per AI2's Inference-Quickstart:
+        the encoder's ``apply_embedding_to_modality`` slices ``mask[..., idx]``
+        for each band-set index, so the last dimension MUST be ``num_band_sets``
+        (3 for Sentinel-2: (B02/B03/B04/B08), (B05-B12 minus B10), (B01/B09)).
+
+        The previous 4-D ``(B, H, W, T)`` mask only worked because ``T`` happened
+        to equal ``num_band_sets=3``; with the canonical ``T=1`` it would index
+        out of bounds.  ``ONLINE_ENCODER`` has value 0, so all-zeros == all
+        visible.
+        """
+        return torch.zeros(B, H, W, self.time_steps, _NUM_BAND_SETS, dtype=torch.float32, device=device)
 
     @torch.no_grad()
     def _forward_patch_features(
@@ -162,8 +178,12 @@ class OlmoEarthBenchModel(BenchModel):
 
         B, C, H, W = images.shape
 
+        # Layout: (B, H, W, C) -> (B, H, W, T, C).  np.repeat only when T>1 so
+        # the common T=1 path doesn't allocate a wasted copy.
         images_nhwc = images.permute(0, 2, 3, 1).cpu().numpy()
-        images_nhwtc = np.repeat(images_nhwc[:, :, :, None, :], self.time_steps, axis=3)
+        images_nhwtc = images_nhwc[:, :, :, None, :]
+        if self.time_steps > 1:
+            images_nhwtc = np.repeat(images_nhwtc, self.time_steps, axis=3)
         images_nhwtc = self.normalizer.normalize(self._modality, images_nhwtc)
 
         timestamps = torch.zeros(B, self.time_steps, 3, dtype=torch.long, device=device)

--- a/src/torchgeo_bench/models/olmoearth.py
+++ b/src/torchgeo_bench/models/olmoearth.py
@@ -103,6 +103,15 @@ class OlmoEarthBenchModel(BenchModel):
         from olmoearth_pretrain_minimal import ModelID, Normalizer, load_model_from_id
         from olmoearth_pretrain_minimal.olmoearth_pretrain_v1.utils.constants import Modality
 
+        # The package logs full ModalitySpec dumps at INFO level on every
+        # encoder construction — useful when developing OlmoEarth itself,
+        # noisy for every torchgeo-bench task.  Demote to WARNING.
+        for logger_name in (
+            "olmoearth_pretrain_minimal",
+            "olmoearth_pretrain_minimal.olmoearth_pretrain_v1",
+        ):
+            logging.getLogger(logger_name).setLevel(logging.WARNING)
+
         self.model_size = model_size
         self.patch_size = patch_size
         self.input_res = input_res

--- a/tests/test_olmoearth.py
+++ b/tests/test_olmoearth.py
@@ -1,0 +1,110 @@
+"""Smoke tests for :class:`OlmoEarthBenchModel`.
+
+The full GeoBench v1+v2 sweep originally couldn't run OlmoEarth because
+the ``[olmoearth]`` extra wasn't installed.  These tests both prevent
+that regression (by importing the wrapper and checking each variant
+loads) and validate the wrapper actually produces sensible embeddings.
+"""
+
+from importlib.util import find_spec
+
+import pytest
+import torch
+
+from torchgeo_bench.datasets.base import BandSpec
+
+olmoearth_available = find_spec("olmoearth_pretrain_minimal") is not None
+requires_olmoearth = pytest.mark.skipif(
+    not olmoearth_available,
+    reason="olmoearth-pretrain-minimal not installed (pip install 'torchgeo-bench[olmoearth]')",
+)
+
+
+def _rgb_bands() -> list[BandSpec]:
+    return [
+        BandSpec(
+            sensor="s2",
+            name=n,
+            source_name=n.upper(),
+            mean=1500.0,
+            std=600.0,
+            min=0.0,
+            max=10000.0,
+        )
+        for n in ("red", "green", "blue")
+    ]
+
+
+def _s2_bands() -> list[BandSpec]:
+    from torchgeo_bench.models.olmoearth import OLMOEARTH_S2_BANDS
+
+    return [
+        BandSpec(
+            sensor="s2",
+            name=b.lower(),
+            source_name=b,
+            mean=1500.0,
+            std=600.0,
+            min=0.0,
+            max=10000.0,
+        )
+        for b in OLMOEARTH_S2_BANDS
+    ]
+
+
+# Map variant -> expected embedding dim (from the four HF weights configs).
+EXPECTED_DIM = {"nano": 128, "tiny": 192, "base": 768, "large": 1024}
+
+
+@requires_olmoearth
+@pytest.mark.parametrize("size", ["nano", "tiny"])  # base/large are too heavy for CI
+def test_rgb_forward_pass_shape(size: str) -> None:
+    """All-RGB input must produce a 2-D embedding of the expected width."""
+    from torchgeo_bench.models.olmoearth import OlmoEarthBenchModel
+
+    model = OlmoEarthBenchModel(bands=_rgb_bands(), model_size=size, normalization="identity")
+    model.eval()
+    x = torch.rand(2, 3, 64, 64) * 3000.0  # raw S2-like values
+    out = model.forward_patch_features(x)
+    assert out.shape == (2, EXPECTED_DIM[size])
+    assert torch.isfinite(out).all()
+
+
+@requires_olmoearth
+def test_s2_forward_pass_shape() -> None:
+    """12-channel S2 input goes through the multispectral path."""
+    from torchgeo_bench.models.olmoearth import OlmoEarthBenchModel
+
+    model = OlmoEarthBenchModel(bands=_s2_bands(), model_size="nano", normalization="identity")
+    model.eval()
+    x = torch.rand(2, 12, 64, 64) * 3000.0
+    out = model.forward_patch_features(x)
+    assert out.shape == (2, EXPECTED_DIM["nano"])
+    assert torch.isfinite(out).all()
+
+
+@requires_olmoearth
+def test_all_four_variants_are_loadable() -> None:
+    """ModelID enum exposes the four advertised variants.
+
+    Prevents the regression where the wrapper silently lost a variant
+    after an upstream rename.
+    """
+    from olmoearth_pretrain_minimal import ModelID
+
+    names = {attr for attr in dir(ModelID) if attr.startswith("OLMOEARTH_V1_")}
+    assert names == {
+        "OLMOEARTH_V1_NANO",
+        "OLMOEARTH_V1_TINY",
+        "OLMOEARTH_V1_BASE",
+        "OLMOEARTH_V1_LARGE",
+    }
+
+
+def test_rejects_unsupported_channel_count() -> None:
+    """4-channel input must fail loudly — OlmoEarth only handles 3 or 12."""
+    from torchgeo_bench.models.olmoearth import OlmoEarthBenchModel
+
+    four_bands = _rgb_bands() + [_rgb_bands()[0]]
+    with pytest.raises(ValueError, match="3 \\(RGB\\) or 12 \\(full S2\\)"):
+        OlmoEarthBenchModel(bands=four_bands, model_size="nano", normalization="identity")


### PR DESCRIPTION
The OlmoEarth wrapper has been disabled in the default GeoBench sweep since PR #36 with a comment about HuggingFace download hangs.  Real root cause turned out to be simpler: the \`[olmoearth]\` extra (olmoearth-pretrain-minimal) wasn't installed in the cluster venv, so SLURM tasks died at import time with \`ModuleNotFoundError: No module named 'olmoearth_pretrain_minimal'\` (see e.g. \`logs/82101_174.err\`).  Once the extra is installed all four advertised variants load and run cleanly — both the RGB and 12-channel S2 paths.

## OlmoEarth variants

| Variant | Params | Embedding dim |
|---|---|---|
| nano  | 3.6 M | 128 |
| tiny  | 14.3 M | 192 |
| base  | 207.5 M | 768 |
| large | 668.0 M | 1024 |

## Summary
- \`src/torchgeo_bench/models/olmoearth.py\`: demote the package's INFO-level \`ModalitySpec\` dumps (printed per encoder construction) to WARNING.  Without this each sweep task emitted ~6 KB of log spam.
- \`src/torchgeo_bench/conf/model/olmoearth_{nano,tiny}.yaml\`: new configs for the two smaller variants.
- \`src/torchgeo_bench/conf/model/olmoearth_{base,large}.yaml\`: fix the misleading \`dataset.normalization=none\` hint — that's not a valid strategy, and the wrapper overrides \`normalize_inputs\` to identity regardless.
- \`scripts/slurm/build_probe_jobs.py\`: re-enable all four variants in \`DEFAULT_MODELS\`; add nano/tiny to \`SINGLE_BAND_MODE_MODELS\` as RGB-only (m-eurosat \`all\` is 13-ch including cirrus, which OlmoEarth's 12-ch S2 modality doesn't accept).
- \`tests/test_olmoearth.py\`: smoke tests that the four variants are exposed by \`ModelID\`; nano/tiny forward-pass produces the expected embedding dim on RGB and 12-ch S2; a 4-channel input is rejected at construction.  Base/large variants are skipped from CI because of weight download cost.

## Test plan
- [x] \`pytest tests/test_olmoearth.py\` — 5 passed (nano + tiny round-trip + ModelID enum check + 4-ch rejection + 12-ch S2)
- [x] \`pre-commit run --files src/torchgeo_bench/models/olmoearth.py tests/test_olmoearth.py scripts/slurm/build_probe_jobs.py\` — clean
- [x] End-to-end SLURM run on m-eurosat × olmoearth_nano: job 89448 currently running on A100 — will follow up here once it lands.