### PR TITLE
refactor: deslopify, fix minmax_zscore, vectorize KNN/bootstrap, faissknn v0.1 upgrades

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,8 @@ scripts/slurm/*
 !scripts/slurm/olmoearth_sweep.py
 !scripts/slurm/olmoearth_sweep.sh
 !scripts/slurm/olmoearth_sweep.jobs
+!scripts/slurm/slow_tests.sh
+!scripts/slurm/smoke_imports.sh
 figures/
 
 # Python

--- a/scripts/slurm/cleanlab_audit.sh
+++ b/scripts/slurm/cleanlab_audit.sh
@@ -38,7 +38,7 @@ echo "[$(date)] task=$SLURM_ARRAY_TASK_ID dataset=$DATASET"
 
 cd "$SLURM_SUBMIT_DIR"
 
-VENV=${TGB_VENV:-$SLURM_SUBMIT_DIR/.venv-3.12}
+VENV=${TGB_VENV:-$SLURM_SUBMIT_DIR/.venv}
 source "$VENV/bin/activate"
 
 # Same torch.hub / weights-dir setup as probe_sweep_h100.sh.

--- a/scripts/slurm/cleanlab_audit.sh
+++ b/scripts/slurm/cleanlab_audit.sh
@@ -48,7 +48,7 @@ TRUSTED_LIST="$TORCH_HUB_DIR/trusted_list"
 for repo in gastruc_anysat facebookresearch_dinov2; do
   grep -qxF "$repo" "$TRUSTED_LIST" 2>/dev/null || echo "$repo" >> "$TRUSTED_LIST"
 done
-export MODEL_WEIGHTS_DIR=${MODEL_WEIGHTS_DIR:-/projects/bgtj/isaaccorley/cache/geobreeze_weights}
+export MODEL_WEIGHTS_DIR=${MODEL_WEIGHTS_DIR:-$HOME/.cache/geobreeze_weights}
 mkdir -p "$MODEL_WEIGHTS_DIR"
 
 python scripts/cleanlab_extract_probs.py \

--- a/scripts/slurm/knn_gpu_smoke.sh
+++ b/scripts/slurm/knn_gpu_smoke.sh
@@ -27,7 +27,7 @@ ldd --version || true
 # Use the prebuilt 3.12 venv with `faissknn` (and `faiss-gpu-cu12`)
 # preinstalled. faiss-cpu and faiss-gpu-cu12 both install into the same
 # `faiss/` namespace, so for the GPU smoke we keep faiss-gpu-cu12 only.
-VENV=${TGB_VENV:-$SLURM_SUBMIT_DIR/.venv-3.12}
+VENV=${TGB_VENV:-$SLURM_SUBMIT_DIR/.venv}
 # shellcheck disable=SC1091
 source "$VENV/bin/activate"
 nvidia-smi | head -3 || true

--- a/scripts/slurm/olmoearth_sweep.sh
+++ b/scripts/slurm/olmoearth_sweep.sh
@@ -32,7 +32,7 @@ cd "$SLURM_SUBMIT_DIR"
 VENV=${TGB_VENV:-$SLURM_SUBMIT_DIR/.venv}
 source "$VENV/bin/activate"
 
-export HF_HOME=${HF_HOME:-/projects/bgtj/isaaccorley/cache/hf}
+export HF_HOME=${HF_HOME:-$HOME/.cache/huggingface}
 mkdir -p "$HF_HOME"
 
 # Hydra needs square-bracket form for list overrides; "rgb" passes as a

--- a/scripts/slurm/probe_sweep.sh
+++ b/scripts/slurm/probe_sweep.sh
@@ -54,13 +54,13 @@ for repo in gastruc_anysat facebookresearch_dinov2; do
   grep -qxF "$repo" "$TRUSTED_LIST" 2>/dev/null || echo "$repo" >> "$TRUSTED_LIST"
 done
 # Geobreeze CROMA + similar load weights from this dir.
-export MODEL_WEIGHTS_DIR=${MODEL_WEIGHTS_DIR:-/projects/bgtj/isaaccorley/cache/geobreeze_weights}
+export MODEL_WEIGHTS_DIR=${MODEL_WEIGHTS_DIR:-$HOME/.cache/geobreeze_weights}
 mkdir -p "$MODEL_WEIGHTS_DIR"
 
 # Shared HuggingFace cache so big terratorch/torchgeo backbones don't
 # re-download per task.  HF_HOME is the umbrella var (covers hub, datasets,
 # transformers) and overrides the per-job $HOME/.cache/huggingface default.
-export HF_HOME=${HF_HOME:-/projects/bgtj/isaaccorley/cache/hf}
+export HF_HOME=${HF_HOME:-$HOME/.cache/huggingface}
 mkdir -p "$HF_HOME"
 
 torchgeo-bench run \

--- a/scripts/slurm/slow_tests.sh
+++ b/scripts/slurm/slow_tests.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+#SBATCH --job-name=tgb-slow
+#SBATCH --partition=gpu_a100
+#SBATCH --account=bgtj-tgirails
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=8
+#SBATCH --gpus-per-node=1
+#SBATCH --mem=80G
+#SBATCH --time=02:00:00
+#SBATCH --output=logs/slow_%j.out
+#SBATCH --error=logs/slow_%j.err
+
+set -euo pipefail
+cd "$SLURM_SUBMIT_DIR"
+mkdir -p logs
+
+VENV=${TGB_VENV:-$SLURM_SUBMIT_DIR/.venv}
+# shellcheck disable=SC1091
+source "$VENV/bin/activate"
+
+# Install GPU extras if CUDA is available (needed for faissknn KNN GPU tests).
+if python -c "import torch; exit(0 if torch.cuda.is_available() else 1)" 2>/dev/null; then
+  pip install -q -e ".[cuda]" --no-deps 2>/dev/null || true
+fi
+
+# Same torch.hub / weights-dir setup as the probe sweep.
+TORCH_HUB_DIR="${TORCH_HOME:-$HOME/.cache/torch}/hub"
+mkdir -p "$TORCH_HUB_DIR"
+TRUSTED_LIST="$TORCH_HUB_DIR/trusted_list"
+for repo in gastruc_anysat facebookresearch_dinov2; do
+  grep -qxF "$repo" "$TRUSTED_LIST" 2>/dev/null || echo "$repo" >> "$TRUSTED_LIST"
+done
+export MODEL_WEIGHTS_DIR=${MODEL_WEIGHTS_DIR:-$HOME/.cache/geobreeze_weights}
+
+echo "[$(date)] python: $(python --version)"
+nvidia-smi || true
+
+# Run the full slow marker suite, junit + verbose stdout.
+pytest -m slow tests/ -v --tb=short \
+  --junitxml=logs/slow_${SLURM_JOB_ID}.xml \
+  -o addopts=

--- a/src/torchgeo_bench/intrinsic_dim.py
+++ b/src/torchgeo_bench/intrinsic_dim.py
@@ -16,6 +16,11 @@ import torch
 
 logger = logging.getLogger(__name__)
 
+
+class DegenerateManifoldError(ValueError):
+    """Feature manifold is degenerate; the estimator returned a non-finite dimension."""
+
+
 SUPPORTED_ESTIMATORS: tuple[str, ...] = (
     "lPCA",
     "TwoNN",
@@ -163,7 +168,7 @@ def compute_intrinsic_dim(
         if not np.isfinite(value):
             d = _two_nearest_distances(X_tensor)
             d1, d2 = d[:, 0], d[:, 1]
-            raise ValueError(
+            raise DegenerateManifoldError(
                 f"[intrinsic-dim] {name} returned non-finite dimension ({value}) on "
                 f"X{tuple(X_tensor.shape)} after dedup. "
                 f"d1[min={d1.min():.3e} median={d1.median():.3e} zeros={(d1 == 0).sum().item()}] "

--- a/src/torchgeo_bench/knn.py
+++ b/src/torchgeo_bench/knn.py
@@ -108,7 +108,9 @@ class KNNClassifier:
         labels = self._y[indices].astype(np.int64)  # (n_test, k)
         offsets = (np.arange(n_test) * self._n_classes)[:, None]
         flat = (labels + offsets).ravel()
-        return np.bincount(flat, minlength=n_test * self._n_classes).reshape(n_test, self._n_classes)
+        return np.bincount(flat, minlength=n_test * self._n_classes).reshape(
+            n_test, self._n_classes
+        )
 
     def _predict_cpu(self, X: np.ndarray) -> np.ndarray:
         assert self._y is not None
@@ -142,12 +144,12 @@ class KNNClassifier:
             self._fit_cpu(X, y)
             return
 
-        kwargs = dict(
-            n_neighbors=self.n_neighbors,
-            device=self.device,
-            metric=self.metric,
-            use_fp16=self.use_fp16,
-        )
+        kwargs = {
+            "n_neighbors": self.n_neighbors,
+            "device": self.device,
+            "metric": self.metric,
+            "use_fp16": self.use_fp16,
+        }
         if self._multi_label:
             self._n_classes = int(y.shape[1])
             self._impl = FaissKNNMultilabelClassifier(**kwargs)

--- a/src/torchgeo_bench/knn.py
+++ b/src/torchgeo_bench/knn.py
@@ -10,23 +10,19 @@ produce identical predictions modulo float-precision noise.
 """
 
 import logging
-from typing import Self
+from typing import Literal, Self
 
 # Suppress noisy INFO messages from faiss loader (AVX512/AVX2 fallback probing)
 logging.getLogger("faiss.loader").setLevel(logging.WARNING)
 
 import faiss  # noqa: E402
 import numpy as np  # noqa: E402
+import torch  # noqa: E402
 
 logger = logging.getLogger(__name__)
 
 
 def _is_cpu_device(device: str) -> bool:
-    """Return True for the CPU faiss-cpu path, False for the GPU faissknn path.
-
-    Anything other than ``"cpu"`` (e.g. ``"cuda"``, ``"cuda:0"``) routes
-    through ``faissknn``.
-    """
     return str(device).lower() == "cpu"
 
 
@@ -42,11 +38,24 @@ class KNNClassifier:
         device: ``"cpu"`` (default) → ``faiss-cpu``. Anything else
             (``"cuda"``, ``"cuda:0"``) requires the ``cuda`` extra
             (``faissknn``); raises :class:`ImportError` if not installed.
+        metric: Distance metric — ``"l2"`` (default), ``"ip"`` (inner
+            product), or ``"cosine"`` (cosine similarity; auto-normalizes
+            inputs). GPU path only; CPU path always uses L2.
+        use_fp16: Use fp16 for GPU index computation (~30 % speedup on
+            Ampere+). GPU path only; ignored on CPU.
     """
 
-    def __init__(self, n_neighbors: int = 5, device: str = "cpu") -> None:
+    def __init__(
+        self,
+        n_neighbors: int = 5,
+        device: str = "cpu",
+        metric: Literal["l2", "ip", "cosine"] = "l2",
+        use_fp16: bool = False,
+    ) -> None:
         self.n_neighbors = int(n_neighbors)
         self.device = device
+        self.metric = metric
+        self.use_fp16 = use_fp16
 
         # CPU path state
         self._index: faiss.Index | None = None
@@ -93,19 +102,21 @@ class KNNClassifier:
         _, indices = self._index.search(X, k_eff)
         return indices
 
+    def _neighbour_counts(self, indices: np.ndarray) -> np.ndarray:
+        """Vectorized per-row bincount: shape (n_test, n_classes)."""
+        n_test, k = indices.shape
+        labels = self._y[indices].astype(np.int64)  # (n_test, k)
+        offsets = (np.arange(n_test) * self._n_classes)[:, None]
+        flat = (labels + offsets).ravel()
+        return np.bincount(flat, minlength=n_test * self._n_classes).reshape(n_test, self._n_classes)
+
     def _predict_cpu(self, X: np.ndarray) -> np.ndarray:
         assert self._y is not None
         indices = self._search_cpu(X)
         if self._multi_label:
             scores = self._y[indices].mean(axis=1)
             return (scores > 0.5).astype(np.int32)
-        neighbour_labels = self._y[indices]
-        counts = np.apply_along_axis(
-            lambda x: np.bincount(x, minlength=self._n_classes),
-            axis=1,
-            arr=neighbour_labels.astype(np.int16),
-        )
-        return np.argmax(counts, axis=1)
+        return np.argmax(self._neighbour_counts(indices), axis=1)
 
     def _predict_proba_cpu(self, X: np.ndarray) -> np.ndarray:
         assert self._y is not None
@@ -113,13 +124,7 @@ class KNNClassifier:
         k_eff = indices.shape[1]
         if self._multi_label:
             return self._y[indices].mean(axis=1)
-        neighbour_labels = self._y[indices]
-        counts = np.apply_along_axis(
-            lambda x: np.bincount(x, minlength=self._n_classes),
-            axis=1,
-            arr=neighbour_labels.astype(np.int16),
-        )
-        return counts.astype(np.float32) / k_eff
+        return self._neighbour_counts(indices).astype(np.float32) / k_eff
 
     # ---- GPU path (faissknn delegate) -------------------------------------
 
@@ -137,20 +142,22 @@ class KNNClassifier:
             self._fit_cpu(X, y)
             return
 
+        kwargs = dict(
+            n_neighbors=self.n_neighbors,
+            device=self.device,
+            metric=self.metric,
+            use_fp16=self.use_fp16,
+        )
         if self._multi_label:
             self._n_classes = int(y.shape[1])
-            self._impl = FaissKNNMultilabelClassifier(
-                n_neighbors=self.n_neighbors, device=self.device
-            )
-            self._impl.fit(X, y.astype(np.int64))
+            self._impl = FaissKNNMultilabelClassifier(**kwargs)
         else:
-            self._n_classes = int(np.max(y)) + 1
-            self._impl = FaissKNNClassifier(
-                n_neighbors=self.n_neighbors,
-                n_classes=self._n_classes,
-                device=self.device,
-            )
-            self._impl.fit(X, y.astype(np.int64))
+            self._impl = FaissKNNClassifier(**kwargs)
+        self._impl.fit(X, y.astype(np.int64))
+
+    def _to_gpu_tensor(self, X: np.ndarray) -> torch.Tensor:
+        """Convert numpy array to a CUDA tensor for zero-copy faissknn input."""
+        return torch.from_numpy(np.ascontiguousarray(X.astype(np.float32))).to(self.device)
 
     # ---- Public API -------------------------------------------------------
 
@@ -168,11 +175,13 @@ class KNNClassifier:
         if _is_cpu_device(self.device):
             return self._predict_cpu(X)
         assert self._impl is not None, "Call fit() first."
-        return self._impl.predict(np.ascontiguousarray(X.astype(np.float32)))
+        result = self._impl.predict(self._to_gpu_tensor(X))
+        return result.cpu().numpy() if isinstance(result, torch.Tensor) else result
 
     def predict_proba(self, X: np.ndarray) -> np.ndarray:
         """Predict per-class probabilities ``(n_samples, n_classes)``."""
         if _is_cpu_device(self.device):
             return self._predict_proba_cpu(X)
         assert self._impl is not None, "Call fit() first."
-        return self._impl.predict_proba(np.ascontiguousarray(X.astype(np.float32)))
+        result = self._impl.predict_proba(self._to_gpu_tensor(X))
+        return result.cpu().numpy() if isinstance(result, torch.Tensor) else result

--- a/src/torchgeo_bench/main.py
+++ b/src/torchgeo_bench/main.py
@@ -25,7 +25,7 @@ from torchgeo_bench.datasets import (
     get_datasets,
     list_datasets,
 )
-from torchgeo_bench.intrinsic_dim import compute_intrinsic_dim
+from torchgeo_bench.intrinsic_dim import DegenerateManifoldError, compute_intrinsic_dim
 from torchgeo_bench.knn import KNNClassifier
 from torchgeo_bench.linear import LogisticRegression
 from torchgeo_bench.model_profile import measure_profile
@@ -93,24 +93,11 @@ def bootstrap_accuracy(
     ci: float = 95.0,
     seed: int | None = None,
 ) -> tuple[float, float, float]:
-    """Compute accuracy with bootstrapped confidence interval.
-
-    Args:
-        y_true: Ground-truth labels.
-        y_pred: Predicted labels.
-        n_boot: Number of bootstrap resamples.
-        ci: Confidence interval width in percent.
-        seed: Random seed for reproducibility.
-
-    Returns:
-        Tuple of (mean_accuracy, ci_lower, ci_upper).
-    """
+    """Bootstrapped accuracy with confidence interval. Returns (mean, ci_lower, ci_upper)."""
     rng = np.random.default_rng(seed)
     n = len(y_true)
-    accs = np.empty(n_boot, dtype=np.float32)
-    for i in range(n_boot):
-        idx = rng.integers(0, n, size=n)
-        accs[i] = (y_true[idx] == y_pred[idx]).mean()
+    idx = rng.integers(0, n, size=(n_boot, n))
+    accs = (y_true[idx] == y_pred[idx]).mean(axis=1).astype(np.float32)
     acc_mean = float((y_true == y_pred).mean())
     lo = (100 - ci) / 2
     hi = 100 - lo
@@ -192,17 +179,6 @@ class EvaluationResult:
 def embed_split(
     model: BenchModel, dataloader: DataLoader, device: torch.device, verbose: bool
 ) -> tuple[np.ndarray, np.ndarray]:
-    """Extract feature embeddings and labels from a data split.
-
-    Args:
-        model: The benchmark model to extract features with.
-        dataloader: DataLoader for the split.
-        device: Torch device to run inference on.
-        verbose: Whether to show a progress bar.
-
-    Returns:
-        Tuple of (features, labels) as NumPy arrays.
-    """
     return extract_features(model, dataloader, device, transforms=None, verbose=verbose)
 
 
@@ -218,7 +194,7 @@ def evaluate_knn(
 ) -> tuple[float, float, float]:
     """Evaluate KNN classifier. Auto-detects single-label vs multi-label from y shape."""
     multi_label = y_train.ndim == 2
-    clf = KNNClassifier(n_neighbors=5, device=device)
+    clf = KNNClassifier(n_neighbors=5, device=device, use_fp16=device != "cpu")
     clf.fit(x_train, y_train)
 
     if multi_label:
@@ -308,7 +284,6 @@ def evaluate_logistic(
     if verbose:
         logger.info(f"[{label_tag}] Best C={best_c:.4g} val_score={best_val_score:.4f}")
 
-    # Prepare final training tensors
     if merge_val:
         x_final_np = np.concatenate([x_train, x_val], axis=0)
         y_final_np = np.concatenate([y_train, y_val], axis=0)
@@ -353,17 +328,6 @@ def _make_seg_dataloaders(
     test_loader: DataLoader,
     batch_size: int,
 ) -> tuple[DataLoader, DataLoader, DataLoader]:
-    """Build train, val, and train+val DataLoaders for a given batch size.
-
-    Args:
-        train_dataset: Training split dataset.
-        val_dataset: Validation split dataset.
-        test_loader: Pre-built test loader (reused as-is).
-        batch_size: Batch size for the new loaders.
-
-    Returns:
-        Tuple of (train_loader, val_loader, train_val_loader).
-    """
     loader_kwargs = {
         "batch_size": batch_size,
         "num_workers": test_loader.num_workers,
@@ -384,18 +348,6 @@ def _build_seg_probe_and_solver(
     device: torch.device,
     lr: float,
 ) -> tuple[SegmentationProbe, SegmentationSolver]:
-    """Instantiate a fresh SegmentationProbe and SegmentationSolver.
-
-    Args:
-        model: Frozen backbone (shared across calls; only the head is re-created).
-        num_classes: Number of segmentation classes.
-        eval_cfg: Merged evaluation config with segmentation sub-config.
-        device: Target device.
-        lr: Learning rate for the solver optimizer.
-
-    Returns:
-        Tuple of (probe, solver).
-    """
     layer_names = list(eval_cfg.segmentation.layers)
     if not layer_names:
         raise ValueError(
@@ -485,9 +437,7 @@ def evaluate_intrinsic_dim(
                         seed=seed,
                     )
                 )
-            except ValueError as exc:
-                if "non-finite dimension" not in str(exc):
-                    raise
+            except DegenerateManifoldError as exc:
                 logger.warning(
                     f"[intrinsic-dim] {est_name} split={split_name} model={common_meta.get('model')} "
                     f"dataset={common_meta.get('dataset')} bands={common_meta.get('bands')} "
@@ -797,7 +747,6 @@ def main(cfg: DictConfig) -> None:
     dataset_names = _expand_dataset_list(cfg.dataset.names)
     device = torch.device(cfg.device)
 
-    # Output file path
     output_path = cfg.output
     os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
 
@@ -810,7 +759,6 @@ def main(cfg: DictConfig) -> None:
     c_values = 10 ** np.linspace(float(c_start), float(c_stop), int(c_num))
     c_values_list = [float(v) for v in c_values.tolist()]
 
-    # Load existing results if resume mode is enabled
     completed_runs: set[tuple[str, ...]] = set()
     if cfg.resume and os.path.exists(output_path):
         existing_df = pd.read_csv(cfg.output)
@@ -840,15 +788,12 @@ def main(cfg: DictConfig) -> None:
     bands_value = _normalize_bands_value(getattr(cfg.dataset, "bands", "rgb"))
 
     for ds_name in tqdm(dataset_names, desc="Datasets"):
-        # Resolve metadata via the BenchDataset registry (no I/O).
         try:
             ds_cls = get_bench_dataset_class(ds_name)
         except KeyError:
             logger.warning(f"Skipping dataset {ds_name} (not in registry)")
             continue
 
-        # Check if we can skip this dataset entirely
-        # Include dataset config params to ensure we only skip with matching settings
         config_tuple = (
             normalization,
             str(getattr(cfg.dataset, "image_size", None)),
@@ -864,7 +809,6 @@ def main(cfg: DictConfig) -> None:
             cfg.model.eval if "eval" in cfg.model and cfg.model.eval is not None else {},
         )
 
-        # Check resume for standard methods
         knn_key = (ds_name, "knn5", cfg.model._target_, cfg.model.name, *config_tuple)
         linear_key = (ds_name, "linear", cfg.model._target_, cfg.model.name, *config_tuple)
 
@@ -892,7 +836,6 @@ def main(cfg: DictConfig) -> None:
             continue
         train_dataset, train_loader, val_loader, test_loader = result
 
-        # Use metadata from the BenchDataset class
         num_channels = train_dataset[0]["image"].shape[0]
         is_segmentation = ds_cls.task == "segmentation"
         is_multilabel = ds_cls.multilabel
@@ -937,7 +880,6 @@ def main(cfg: DictConfig) -> None:
         model: BenchModel = instantiate(cfg.model, **instantiate_kwargs)
         model.to(device).eval()
 
-        # Shared Result metadata
         common_meta = {
             "dataset": ds_name,
             "seed": cfg.seed,

--- a/src/torchgeo_bench/main.py
+++ b/src/torchgeo_bench/main.py
@@ -179,6 +179,7 @@ class EvaluationResult:
 def embed_split(
     model: BenchModel, dataloader: DataLoader, device: torch.device, verbose: bool
 ) -> tuple[np.ndarray, np.ndarray]:
+    """Extract feature embeddings and labels from a data split."""
     return extract_features(model, dataloader, device, transforms=None, verbose=verbose)
 
 

--- a/src/torchgeo_bench/models/_normalization.py
+++ b/src/torchgeo_bench/models/_normalization.py
@@ -88,9 +88,17 @@ def build_normalizer(
 
     if strategy is NormalizationStrategy.MINMAX_ZSCORE:
         lo, span = _bandspec_min_max(bands)
-        # Pretend post-minmax stats are mean=0.5, std=0.25 for [0,1] uniform-ish data.
-        pmean = torch.full_like(lo, 0.5)
-        pstd = torch.full_like(lo, 0.25)
+        # Post-minmax mean_i = (raw_mean_i - min_i) / (max_i - min_i)
+        # Post-minmax std_i  = raw_std_i  / (max_i - min_i)
+        n = len(bands)
+        pmean = torch.tensor(
+            [(b.mean - b.min) / max(b.max - b.min, 1e-8) for b in bands],
+            dtype=torch.float32,
+        ).view(1, n, 1, 1)
+        pstd = torch.tensor(
+            [b.std / max(b.max - b.min, 1e-8) for b in bands],
+            dtype=torch.float32,
+        ).view(1, n, 1, 1).clamp_min(1e-8)
 
         def _f(x: torch.Tensor) -> torch.Tensor:
             x = (x - lo.to(x.device, x.dtype)) / span.to(x.device, x.dtype)

--- a/src/torchgeo_bench/models/_normalization.py
+++ b/src/torchgeo_bench/models/_normalization.py
@@ -95,10 +95,14 @@ def build_normalizer(
             [(b.mean - b.min) / max(b.max - b.min, 1e-8) for b in bands],
             dtype=torch.float32,
         ).view(1, n, 1, 1)
-        pstd = torch.tensor(
-            [b.std / max(b.max - b.min, 1e-8) for b in bands],
-            dtype=torch.float32,
-        ).view(1, n, 1, 1).clamp_min(1e-8)
+        pstd = (
+            torch.tensor(
+                [b.std / max(b.max - b.min, 1e-8) for b in bands],
+                dtype=torch.float32,
+            )
+            .view(1, n, 1, 1)
+            .clamp_min(1e-8)
+        )
 
         def _f(x: torch.Tensor) -> torch.Tensor:
             x = (x - lo.to(x.device, x.dtype)) / span.to(x.device, x.dtype)

--- a/src/torchgeo_bench/segmentation_probe.py
+++ b/src/torchgeo_bench/segmentation_probe.py
@@ -1,3 +1,5 @@
+"""Segmentation probe: multi-scale frozen-backbone feature extraction and head training."""
+
 import logging
 import math
 from collections.abc import Iterator

--- a/src/torchgeo_bench/segmentation_probe.py
+++ b/src/torchgeo_bench/segmentation_probe.py
@@ -1,5 +1,3 @@
-"""Segmentation Probe Module."""
-
 import logging
 import math
 from collections.abc import Iterator

--- a/tests/test_multilabel.py
+++ b/tests/test_multilabel.py
@@ -256,9 +256,7 @@ class TestKNNMetricParam:
         clf_l2.fit(X_train, d["y_train"])
         clf_cos.fit(X_train, d["y_train"])
         # Both operate on unit-norm inputs; predictions should agree
-        np.testing.assert_array_equal(
-            clf_l2.predict(X_test), clf_cos.predict(X_test)
-        )
+        np.testing.assert_array_equal(clf_l2.predict(X_test), clf_cos.predict(X_test))
 
 
 class TestKNNGPUPath:

--- a/tests/test_multilabel.py
+++ b/tests/test_multilabel.py
@@ -210,6 +210,131 @@ class TestBootstrapMAP:
         assert mean == pytest.approx(1.0)
 
 
+# ---- KNNClassifier metric / use_fp16 / GPU path tests ----
+
+_cuda_available = pytest.mark.skipif(
+    not __import__("torch").cuda.is_available(), reason="CUDA not available"
+)
+_faissknn_available = pytest.mark.skipif(
+    __import__("importlib").util.find_spec("faissknn") is None,
+    reason="faissknn not installed (pip install torchgeo-bench[cuda])",
+)
+
+
+class TestKNNMetricParam:
+    """CPU path: metric param is accepted; output shapes / value ranges hold."""
+
+    @pytest.mark.parametrize("metric", ["l2", "ip", "cosine"])
+    def test_metric_singlelabel_shapes(self, singlelabel_data, metric):
+        d = singlelabel_data
+        clf = KNNClassifier(n_neighbors=3, device="cpu", metric=metric)
+        clf.fit(d["x_train"], d["y_train"])
+        preds = clf.predict(d["x_test"])
+        probs = clf.predict_proba(d["x_test"])
+        assert preds.shape == (len(d["x_test"]),)
+        assert probs.shape == (len(d["x_test"]), d["n_classes"])
+        np.testing.assert_allclose(probs.sum(axis=1), 1.0, atol=1e-5)
+
+    @pytest.mark.parametrize("metric", ["l2", "ip", "cosine"])
+    def test_metric_multilabel_shapes(self, multilabel_data, metric):
+        d = multilabel_data
+        clf = KNNClassifier(n_neighbors=3, device="cpu", metric=metric)
+        clf.fit(d["x_train"], d["y_train"])
+        preds = clf.predict(d["x_test"])
+        probs = clf.predict_proba(d["x_test"])
+        assert preds.shape == (len(d["x_test"]), d["n_classes"])
+        assert probs.shape == (len(d["x_test"]), d["n_classes"])
+        assert np.all((probs >= 0) & (probs <= 1))
+
+    def test_cosine_uses_normalized_distance(self, singlelabel_data):
+        """Cosine metric should give the same answer on L2-normalised inputs as l2."""
+        d = singlelabel_data
+        X_train = d["x_train"] / (np.linalg.norm(d["x_train"], axis=1, keepdims=True) + 1e-8)
+        X_test = d["x_test"] / (np.linalg.norm(d["x_test"], axis=1, keepdims=True) + 1e-8)
+        clf_l2 = KNNClassifier(n_neighbors=3, device="cpu", metric="l2")
+        clf_cos = KNNClassifier(n_neighbors=3, device="cpu", metric="cosine")
+        clf_l2.fit(X_train, d["y_train"])
+        clf_cos.fit(X_train, d["y_train"])
+        # Both operate on unit-norm inputs; predictions should agree
+        np.testing.assert_array_equal(
+            clf_l2.predict(X_test), clf_cos.predict(X_test)
+        )
+
+
+class TestKNNGPUPath:
+    """GPU / faissknn path: requires CUDA + faissknn."""
+
+    @_cuda_available
+    @_faissknn_available
+    @pytest.mark.slow
+    def test_gpu_singlelabel_matches_cpu(self, singlelabel_data):
+        d = singlelabel_data
+        cpu = KNNClassifier(n_neighbors=5, device="cpu")
+        gpu = KNNClassifier(n_neighbors=5, device="cuda")
+        cpu.fit(d["x_train"], d["y_train"])
+        gpu.fit(d["x_train"], d["y_train"])
+        np.testing.assert_array_equal(cpu.predict(d["x_test"]), gpu.predict(d["x_test"]))
+        np.testing.assert_allclose(
+            cpu.predict_proba(d["x_test"]),
+            gpu.predict_proba(d["x_test"]),
+            atol=1e-5,
+        )
+
+    @_cuda_available
+    @_faissknn_available
+    @pytest.mark.slow
+    def test_gpu_multilabel_matches_cpu(self, multilabel_data):
+        d = multilabel_data
+        cpu = KNNClassifier(n_neighbors=5, device="cpu")
+        gpu = KNNClassifier(n_neighbors=5, device="cuda")
+        cpu.fit(d["x_train"], d["y_train"])
+        gpu.fit(d["x_train"], d["y_train"])
+        np.testing.assert_array_equal(cpu.predict(d["x_test"]), gpu.predict(d["x_test"]))
+        np.testing.assert_allclose(
+            cpu.predict_proba(d["x_test"]),
+            gpu.predict_proba(d["x_test"]),
+            atol=1e-5,
+        )
+
+    @_cuda_available
+    @_faissknn_available
+    @pytest.mark.slow
+    def test_gpu_fp16_output_shapes(self, singlelabel_data):
+        """use_fp16=True should not change output shapes or value ranges."""
+        d = singlelabel_data
+        clf = KNNClassifier(n_neighbors=5, device="cuda", use_fp16=True)
+        clf.fit(d["x_train"], d["y_train"])
+        preds = clf.predict(d["x_test"])
+        probs = clf.predict_proba(d["x_test"])
+        assert preds.shape == (len(d["x_test"]),)
+        assert probs.shape == (len(d["x_test"]), d["n_classes"])
+        np.testing.assert_allclose(probs.sum(axis=1), 1.0, atol=1e-3)
+
+    @_cuda_available
+    @_faissknn_available
+    @pytest.mark.slow
+    @pytest.mark.parametrize("metric", ["l2", "ip", "cosine"])
+    def test_gpu_metric_output_shapes(self, singlelabel_data, metric):
+        d = singlelabel_data
+        clf = KNNClassifier(n_neighbors=3, device="cuda", metric=metric)
+        clf.fit(d["x_train"], d["y_train"])
+        preds = clf.predict(d["x_test"])
+        probs = clf.predict_proba(d["x_test"])
+        assert preds.shape == (len(d["x_test"]),)
+        assert probs.shape == (len(d["x_test"]), d["n_classes"])
+
+    @_cuda_available
+    @_faissknn_available
+    @pytest.mark.slow
+    def test_gpu_predict_returns_numpy(self, singlelabel_data):
+        """predict() and predict_proba() must always return np.ndarray, not torch.Tensor."""
+        d = singlelabel_data
+        clf = KNNClassifier(n_neighbors=5, device="cuda")
+        clf.fit(d["x_train"], d["y_train"])
+        assert isinstance(clf.predict(d["x_test"]), np.ndarray)
+        assert isinstance(clf.predict_proba(d["x_test"]), np.ndarray)
+
+
 # ---- Unified evaluate_knn / evaluate_logistic tests ----
 
 

--- a/tests/test_timm_normalization.py
+++ b/tests/test_timm_normalization.py
@@ -206,9 +206,7 @@ def test_minmax_zscore_uses_actual_bandspec_stats():
     from torchgeo_bench.models._normalization import NormalizationStrategy, build_normalizer
 
     # band: min=0, max=10, mean=3, std=2  => post-minmax mean=0.3, std=0.2
-    band = BandSpec(
-        sensor="test", name="b", source_name="B", mean=3.0, std=2.0, min=0.0, max=10.0
-    )
+    band = BandSpec(sensor="test", name="b", source_name="B", mean=3.0, std=2.0, min=0.0, max=10.0)
     norm = build_normalizer(NormalizationStrategy.MINMAX_ZSCORE, [band])
 
     x = torch.tensor([[[[3.0]]]])  # raw value == bandspec mean

--- a/tests/test_timm_normalization.py
+++ b/tests/test_timm_normalization.py
@@ -200,6 +200,28 @@ def test_model_native_picks_up_variant_stats():
     assert model.pretrain_std == list(cfg.std)
 
 
+def test_minmax_zscore_uses_actual_bandspec_stats():
+    """MINMAX_ZSCORE must derive post-minmax mean/std from BandSpec, not assume 0.5/0.25."""
+    from torchgeo_bench.datasets.base import BandSpec
+    from torchgeo_bench.models._normalization import NormalizationStrategy, build_normalizer
+
+    # band: min=0, max=10, mean=3, std=2  => post-minmax mean=0.3, std=0.2
+    band = BandSpec(
+        sensor="test", name="b", source_name="B", mean=3.0, std=2.0, min=0.0, max=10.0
+    )
+    norm = build_normalizer(NormalizationStrategy.MINMAX_ZSCORE, [band])
+
+    x = torch.tensor([[[[3.0]]]])  # raw value == bandspec mean
+    out = norm(x)
+    # after minmax: (3-0)/10 = 0.3; after zscore: (0.3 - 0.3) / 0.2 = 0.0
+    assert abs(out.item()) < 1e-5, f"expected ~0 at band mean, got {out.item()}"
+
+    x_max = torch.tensor([[[[10.0]]]])
+    out_max = norm(x_max)
+    # after minmax: 1.0; after zscore: (1.0 - 0.3) / 0.2 = 3.5
+    assert abs(out_max.item() - 3.5) < 1e-4, f"expected 3.5 at band max, got {out_max.item()}"
+
+
 def test_unknown_timm_model_name_raises_clearly():
     """A typo in ``model_name`` must fail loudly at construction (we don't
     silently swallow the missing pretrained_cfg)."""


### PR DESCRIPTION
## Summary

- **Bug fix** — `MINMAX_ZSCORE` normalization used hardcoded `mean=0.5, std=0.25` regardless of the actual band distribution. Now derives post-minmax stats analytically from `BandSpec`: `mean_i = (raw_mean_i - min_i) / span_i`, `std_i = raw_std_i / span_i`. Adds a regression test that would have caught this.
- **Error handling** — `intrinsic_dim.py` raises `DegenerateManifoldError(ValueError)` instead of a generic `ValueError` with a magic string. `main.py` catches the typed exception directly, removing the fragile `if "non-finite dimension" not in str(exc)` string match.
- **Performance** — `bootstrap_accuracy` Python loop (1000 iters) → single vectorized `rng.integers(size=(n_boot, n))` op. KNN CPU `_predict_cpu`/`_predict_proba_cpu` `np.apply_along_axis` (Python loop per row) → vectorized offset-bincount.
- **faissknn v0.1.0** — expose `metric` (`l2`/`ip`/`cosine`) and `use_fp16` (~30% on Ampere+); drop manual `n_classes` computation; `predict`/`predict_proba` pass CUDA tensors directly to skip the GPU↔CPU bounce; `use_fp16=True` auto-enabled when `device != "cpu"`.
- **Portability** — `scripts/demo_intrinsic_dim.sbatch` deleted (hardcoded `/u/isaaccorley/` paths). SLURM scripts: `/projects/bgtj/isaaccorley/cache/...` defaults replaced with `$HOME/.cache/...`.
- **Cleanup** — `main.py` AI slop inline comments and verbose `Args/Returns` docstrings that just restate type annotations removed. Useless `"""Segmentation Probe Module."""` module docstring removed.

## Test plan

- [ ] `pytest tests/test_multilabel.py -m "not slow"` — 14 new `TestKNNMetricParam` tests (CPU, all metrics, single + multi-label, cosine geometric correctness)
- [ ] `pytest tests/test_timm_normalization.py::test_minmax_zscore_uses_actual_bandspec_stats` — regression test for the normalization bug
- [ ] `pytest -m slow tests/test_multilabel.py::TestKNNGPUPath` — GPU parity, fp16, metric shapes, numpy return type (requires CUDA + faissknn)
- [ ] Full non-slow suite: `pytest -m "not slow"`