### PR TITLE
feat(cli): replace argparse+tqdm with typer+rich

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,8 @@ dependencies = [
   "torch>=2",
   "torchgeo @ git+https://github.com/microsoft/torchgeo.git@e585e2c07f7a",
   "torchvision>=0.15",
-  "tqdm>=4.65",
+  "rich>=13",
+  "typer>=0.9",
 ]
 optional-dependencies.all = [
   "torchgeo-bench[cleanlab]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,12 +42,12 @@ dependencies = [
   "numpy>=1.24",
   "omegaconf>=2.3",
   "pandas>=2",
+  "rich>=13",
   "scikit-learn>=1.3",
   "timm>=0.9",
   "torch>=2",
   "torchgeo @ git+https://github.com/microsoft/torchgeo.git@e585e2c07f7a",
   "torchvision>=0.15",
-  "rich>=13",
   "typer>=0.9",
 ]
 optional-dependencies.all = [

--- a/scripts/slurm/smoke_imports.sh
+++ b/scripts/slurm/smoke_imports.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+#SBATCH --job-name=tgb-smoke
+#SBATCH --partition=gpu_a100
+#SBATCH --account=bgtj-tgirails
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=8
+#SBATCH --gpus-per-node=1
+#SBATCH --mem=80G
+#SBATCH --time=01:00:00
+#SBATCH --output=logs/smoke-%j.out
+#SBATCH --error=logs/smoke-%j.err
+#
+# Smoke-test every torchgeo-bench model wrapper: import, instantiate, run
+# one tiny forward pass.  Catches typo'd kwargs / missing weights / wrong
+# x_dict keys before we burn SUs on a real sweep.
+#
+# Submit as:
+#   sbatch --account=$PROJECT scripts/slurm/smoke_imports.sh
+#
+# Output: results/smoke_imports.json + a summary table in the job log.
+
+set -euo pipefail
+
+mkdir -p logs results
+
+cd "$SLURM_SUBMIT_DIR"
+
+VENV=${TGB_VENV:-$SLURM_SUBMIT_DIR/.venv}
+source "$VENV/bin/activate"
+
+# Geobreeze CROMA reads weights from this dir and downloads on first use.
+export MODEL_WEIGHTS_DIR=${MODEL_WEIGHTS_DIR:-$HOME/.cache/geobreeze_weights}
+mkdir -p "$MODEL_WEIGHTS_DIR"
+
+# Auto-trust torch.hub repos so AnySat etc. don't block on an interactive
+# y/N prompt.  PyTorch reads `<TORCH_HOME>/hub/trusted_list` (default
+# `~/.cache/torch/hub/trusted_list`), one repo per line as
+# `<owner>_<name>`.  Honour TORCH_HOME if it's set in the environment.
+TORCH_HUB_DIR="${TORCH_HOME:-$HOME/.cache/torch}/hub"
+mkdir -p "$TORCH_HUB_DIR"
+TRUSTED_LIST="$TORCH_HUB_DIR/trusted_list"
+for repo in gastruc_anysat facebookresearch_dinov2; do
+  grep -qxF "$repo" "$TRUSTED_LIST" 2>/dev/null || echo "$repo" >> "$TRUSTED_LIST"
+done
+
+# Default: only the new wrappers (terratorch, rslearn, geobreeze).
+# Override with `sbatch --export=MODEL_GROUPS=all,...` to also smoke older configs.
+# rslearn temporarily excluded — its FeatureExtractors expect a
+# ModelContext-boxed batch (RasterImage + timestamps + multimodal dict);
+# wrappers need rework before they can probe via the standard path.
+MODEL_GROUPS=${MODEL_GROUPS:-terratorch,geobreeze}
+
+python scripts/smoke_imports.py \
+  --groups "${MODEL_GROUPS}" \
+  --batch 2 \
+  --device cuda:0 \
+  --out "results/smoke_imports_${SLURM_JOB_ID}.json"

--- a/scripts/tune_dataloader.py
+++ b/scripts/tune_dataloader.py
@@ -23,6 +23,8 @@ from pathlib import Path
 import torch
 from hydra import compose, initialize_config_module
 from hydra.utils import instantiate
+from rich.console import Console
+from rich.table import Table
 from torch.utils.data import DataLoader
 
 from torchgeo_bench.datasets import get_bench_dataset_class
@@ -117,23 +119,34 @@ def main() -> None:
     bands_list = bench_cls.select_band_specs(sel)
     model = _build_model(args.model, bands_list).to(device).eval()
 
-    print(f"\nTuning {args.model} × {args.dataset}/{args.bands} on {device}")
-    print(f"{'bs':>5} {'nw':>4} {'samples/sec':>14} {'peak GB':>10} {'wall':>8}")
+    console = Console()
+    console.rule(f"Tuning [bold]{args.model}[/] × {args.dataset}/{args.bands} on {device}")
+
+    table = Table(show_header=True, header_style="bold cyan")
+    table.add_column("bs", justify="right")
+    table.add_column("nw", justify="right")
+    table.add_column("samples/sec", justify="right")
+    table.add_column("peak GB", justify="right")
+    table.add_column("wall", justify="right")
+
     results = []
     for bs in bs_list:
         for nw in nw_list:
             try:
                 sps, peak, dt = _bench(model, dataset, bs, nw, device, args.max_batches)
                 results.append((sps, bs, nw, peak, dt))
-                print(f"{bs:>5} {nw:>4} {sps:>14.1f} {peak:>10.2f} {dt:>7.2f}s")
+                table.add_row(str(bs), str(nw), f"{sps:.1f}", f"{peak:.2f}", f"{dt:.2f}s")
             except Exception as e:
-                print(f"{bs:>5} {nw:>4} FAIL  {type(e).__name__}: {str(e)[:60]}")
+                table.add_row(
+                    str(bs), str(nw), "[red]FAIL[/]", "", f"{type(e).__name__}: {str(e)[:40]}"
+                )
 
+    console.print(table)
     if results:
         best = max(results, key=lambda r: r[0])
-        print(
-            f"\nBEST: batch_size={best[1]} num_workers={best[2]} "
-            f"-> {best[0]:.1f} samples/sec ({best[3]:.2f} GB peak)"
+        console.print(
+            f"\n[bold green]BEST:[/] batch_size={best[1]} num_workers={best[2]} "
+            f"→ [bold]{best[0]:.1f}[/] samples/sec ({best[3]:.2f} GB peak)"
         )
 
 

--- a/src/torchgeo_bench/cli.py
+++ b/src/torchgeo_bench/cli.py
@@ -10,103 +10,85 @@ The ``run`` subcommand forwards every remaining arg to Hydra by mutating
 restore ``sys.argv`` afterwards so embedded use (tests, notebooks) is safe.
 """
 
-import argparse
 import logging
 import sys
 from pathlib import Path
+from typing import Annotated
 
-logger = logging.getLogger(__name__)
+import typer
+from rich.logging import RichHandler
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(message)s",
+    datefmt="[%X]",
+    handlers=[RichHandler(rich_tracebacks=True, markup=True)],
+)
+
+app = typer.Typer(
+    name="torchgeo-bench",
+    help="Lightweight benchmarking framework for geospatial foundation models.",
+    add_completion=False,
+    no_args_is_help=True,
+)
 
 
-def _run(hydra_args: list[str]) -> int:
-    """Invoke the Hydra-decorated benchmark main, restoring argv afterwards."""
+@app.command(
+    context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
+    help="Run benchmark experiments (extra args forwarded to Hydra).",
+)
+def run(ctx: typer.Context) -> None:
+    """Run benchmark experiments; extra args are forwarded to Hydra."""
     from torchgeo_bench.main import main as hydra_main
 
     saved = sys.argv[:]
     try:
-        sys.argv = [saved[0], *hydra_args]
+        sys.argv = [saved[0], *ctx.args]
         hydra_main()
     finally:
         sys.argv = saved
-    return 0
 
 
-def _download(args: argparse.Namespace) -> int:
+@app.command(help="Download benchmark datasets.")
+def download(
+    target: Annotated[
+        str,
+        typer.Argument(help="What to download: geobench_v1 | geobench_v2 | eurosat"),
+    ],
+    output_dir: Annotated[
+        Path,
+        typer.Option("--output-dir", "-o", help="Benchmark data root."),
+    ] = Path("data"),
+    datasets: Annotated[
+        str | None,
+        typer.Option(help="(geobench_v2 only) Comma-separated dataset names."),
+    ] = None,
+) -> None:
+    """Download a benchmark dataset to disk."""
     from torchgeo_bench.download import (
         download_eurosat,
         download_geobench_v1,
         download_geobench_v2,
     )
 
-    output = Path(args.output_dir)
-    if args.target == "geobench_v1":
-        download_geobench_v1(output)
-    elif args.target == "geobench_v2":
-        names = (
-            [n.strip() for n in args.datasets.split(",") if n.strip()] if args.datasets else None
-        )
-        download_geobench_v2(output, datasets=names)
-    elif args.target == "eurosat":
-        download_eurosat(output)
-    else:  # pragma: no cover — argparse choices guard this
-        raise AssertionError(f"Unknown download target: {args.target}")
-    return 0
+    valid = {"geobench_v1", "geobench_v2", "eurosat"}
+    if target not in valid:
+        typer.echo(f"Unknown target {target!r}. Choose from: {', '.join(sorted(valid))}", err=True)
+        raise typer.Exit(1)
+
+    if target == "geobench_v1":
+        download_geobench_v1(output_dir)
+    elif target == "geobench_v2":
+        names = [n.strip() for n in datasets.split(",") if n.strip()] if datasets else None
+        download_geobench_v2(output_dir, datasets=names)
+    elif target == "eurosat":
+        download_eurosat(output_dir)
 
 
-def _build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
-        prog="torchgeo-bench",
-        description="Lightweight benchmarking framework for geospatial foundation models",
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-    )
-    sub = parser.add_subparsers(dest="command", required=True)
-
-    sub.add_parser(
-        "run",
-        help="Run benchmark experiments (forwards remaining args to Hydra)",
-        add_help=False,
-    )
-
-    dl = sub.add_parser(
-        "download",
-        help="Download benchmark datasets into ./data/",
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-    )
-    dl.add_argument(
-        "target",
-        choices=["geobench_v1", "geobench_v2", "eurosat"],
-        help="What to download.",
-    )
-    dl.add_argument(
-        "--output-dir",
-        type=Path,
-        default=Path("data"),
-        help="Benchmark data root.",
-    )
-    dl.add_argument(
-        "--datasets",
-        type=str,
-        default=None,
-        help="(geobench_v2 only) Comma-separated dataset names. Defaults to all "
-        "benchmark-supported V2 datasets.",
-    )
-    return parser
-
-
-def main() -> int:
+def main() -> None:
     """Entry point for the ``torchgeo-bench`` console script."""
-    logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
-
-    if len(sys.argv) > 1 and sys.argv[1] == "run":
-        return _run(sys.argv[2:])
-
-    parser = _build_parser()
-    args = parser.parse_args()
-    if args.command == "download":
-        return _download(args)
-    parser.print_help()
-    return 1
+    app()
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    main()

--- a/src/torchgeo_bench/download.py
+++ b/src/torchgeo_bench/download.py
@@ -16,8 +16,8 @@ import zipfile
 from pathlib import Path
 
 from huggingface_hub import snapshot_download
+from rich.progress import track
 from torchgeo.datasets import EuroSAT
-from tqdm import tqdm
 
 logger = logging.getLogger(__name__)
 
@@ -47,11 +47,8 @@ DEFAULT_V2_DATASETS: tuple[str, ...] = (
 def _decompress_zip_with_progress(zip_path: Path, extract_to: Path) -> None:
     """Extract ``zip_path`` into ``extract_to`` with a progress bar; delete the zip."""
     with zipfile.ZipFile(zip_path, "r") as zf:
-        names = zf.namelist()
-        with tqdm(total=len(names), unit="file", desc=f"Extracting {zip_path.name}") as pbar:
-            for name in names:
-                zf.extract(name, extract_to)
-                pbar.update(1)
+        for name in track(zf.namelist(), description=f"Extracting {zip_path.name}"):
+            zf.extract(name, extract_to)
     zip_path.unlink()
     logger.info("Removed zip file: %s", zip_path)
 

--- a/src/torchgeo_bench/main.py
+++ b/src/torchgeo_bench/main.py
@@ -15,10 +15,10 @@ import pandas as pd
 import torch
 from hydra.utils import instantiate
 from omegaconf import DictConfig, OmegaConf
+from rich.progress import track
 from sklearn.metrics import accuracy_score, average_precision_score
 from torch.utils.data import ConcatDataset, DataLoader
 from torchgeo.datasets.errors import DatasetNotFoundError
-from tqdm import tqdm
 
 from torchgeo_bench.datasets import (
     get_bench_dataset_class,
@@ -253,7 +253,7 @@ def evaluate_logistic(
             f"[{label_tag}] C sweep start over {len(c_values)} values "
             f"(train={len(x_train)}, val={len(x_val)})"
         )
-        c_value_iterator = tqdm(c_values, desc="C values", leave=False)
+        c_value_iterator = track(c_values, description="C values")
     else:
         c_value_iterator = c_values
 
@@ -788,7 +788,7 @@ def main(cfg: DictConfig) -> None:
     normalization = str(getattr(cfg.dataset, "normalization", "bandspec_zscore"))
     bands_value = _normalize_bands_value(getattr(cfg.dataset, "bands", "rgb"))
 
-    for ds_name in tqdm(dataset_names, desc="Datasets"):
+    for ds_name in track(dataset_names, description="Datasets"):
         try:
             ds_cls = get_bench_dataset_class(ds_name)
         except KeyError:

--- a/src/torchgeo_bench/segmentation_task.py
+++ b/src/torchgeo_bench/segmentation_task.py
@@ -5,6 +5,7 @@ import math
 
 import torch
 import torch.nn as nn
+from rich.progress import track
 from torch.utils.data import DataLoader
 from torchmetrics.classification import (
     MulticlassF1Score,
@@ -12,7 +13,6 @@ from torchmetrics.classification import (
     MulticlassPrecision,
     MulticlassRecall,
 )
-from tqdm import tqdm
 
 from .segmentation_probe import (
     CachedFeaturesDataset,
@@ -146,8 +146,9 @@ class SegmentationSolver:
 
             total_loss = 0.0
 
-            pbar = tqdm(train_loader, desc=f"Epoch {epoch + 1}/{epochs}", disable=not verbose)
-            for _num_batches, batch in enumerate(pbar, start=1):
+            desc = f"Epoch {epoch + 1}/{epochs}"
+            batches = track(train_loader, description=desc) if verbose else train_loader
+            for _num_batches, batch in enumerate(batches, start=1):
                 if isinstance(batch, dict):
                     images = batch["image"].to(self.device)
                     masks = batch["mask"].to(self.device).long()
@@ -167,7 +168,6 @@ class SegmentationSolver:
                 self.scaler.update()
 
                 total_loss += loss.item()
-                pbar.set_postfix({"loss": f"{loss.item():.4f}"})
 
             if scheduler is not None:
                 scheduler.step()
@@ -286,13 +286,10 @@ class SegmentationSolver:
                 self.model.backbone.eval()
 
             total_loss = 0.0
-            pbar = tqdm(
-                gpu_train.shuffled_batches(batch_size),
-                total=num_batches,
-                desc=f"Epoch {epoch + 1}/{epochs}",
-                disable=not verbose,
-            )
-            for features, masks in pbar:
+            desc = f"Epoch {epoch + 1}/{epochs}"
+            batches = gpu_train.shuffled_batches(batch_size)
+            batches = track(batches, total=num_batches, description=desc) if verbose else batches
+            for features, masks in batches:
                 self.optimizer.zero_grad()
                 with torch.autocast(device_type=self.device_type, enabled=self.use_amp):
                     logits = self.model.head(features, *input_hw)
@@ -303,7 +300,6 @@ class SegmentationSolver:
                 self.scaler.update()
 
                 total_loss += loss.item()
-                pbar.set_postfix({"loss": f"{loss.item():.4f}"})
 
             if scheduler is not None:
                 scheduler.step()

--- a/src/torchgeo_bench/utils.py
+++ b/src/torchgeo_bench/utils.py
@@ -2,8 +2,8 @@
 
 import numpy as np
 import torch
+from rich.progress import track
 from torch.utils.data import DataLoader
-from tqdm import tqdm
 
 
 def extract_features(
@@ -28,7 +28,11 @@ def extract_features(
     x_all = []
     y_all = []
 
-    iterator = tqdm(dataloader, total=len(dataloader)) if verbose else dataloader
+    iterator = (
+        track(dataloader, total=len(dataloader), description="Extracting")
+        if verbose
+        else dataloader
+    )
 
     for batch in iterator:
         images = batch["image"].to(device)

--- a/uv.lock
+++ b/uv.lock
@@ -3929,12 +3929,13 @@ dependencies = [
     { name = "numpy" },
     { name = "omegaconf" },
     { name = "pandas" },
+    { name = "rich" },
     { name = "scikit-learn" },
     { name = "timm" },
     { name = "torch" },
     { name = "torchgeo" },
     { name = "torchvision" },
-    { name = "tqdm" },
+    { name = "typer" },
 ]
 
 [package.optional-dependencies]
@@ -4034,6 +4035,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.3" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.6" },
+    { name = "rich", specifier = ">=13" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.0.270" },
     { name = "scikit-learn", specifier = ">=1.3" },
     { name = "sphinx", marker = "extra == 'docs'", specifier = ">=7" },
@@ -4053,8 +4055,8 @@ requires-dist = [
     { name = "torchgeo-bench", extras = ["viz"], marker = "extra == 'all'" },
     { name = "torchid", marker = "python_full_version >= '3.13' and extra == 'id'", specifier = ">=0.3" },
     { name = "torchvision", specifier = ">=0.15" },
-    { name = "tqdm", specifier = ">=4.65" },
     { name = "transformers", marker = "extra == 'sam3'", specifier = ">=4.50" },
+    { name = "typer", specifier = ">=0.9" },
 ]
 provides-extras = ["all", "cleanlab", "cuda", "dev", "docs", "id", "olmoearth", "profile", "sam3", "terratorch", "viz"]
 


### PR DESCRIPTION
## Summary

- **cli.py**: replaces the hand-rolled argparse+`sys.argv` dance with [Typer](https://typer.tiangolo.com/) subcommands; wires `RichHandler` for colored, timestamped log output
- **utils / download / main / segmentation_task**: `tqdm` → `rich.progress.track` throughout `src/`; cleaner API, nicer progress bars, no extra dep beyond `rich`
- **scripts/tune_dataloader.py**: replaces the manual `print(f"{bs:>5}...")` table with `rich.table.Table` (colored header, structured rows, bold BEST line)
- **pyproject.toml**: adds `rich>=13`, `typer>=0.9`; removes `tqdm` from core deps (still usable in scripts but no longer a library requirement)
- **gitignore**: track `smoke_imports.sh` and `slow_tests.sh`

## Test plan

- [ ] `torchgeo-bench --help` shows clean Typer panel
- [ ] `torchgeo-bench run --help` and `torchgeo-bench download --help` work
- [ ] Fast CI suite passes (`pytest -m not slow`)
- [ ] SLURM slow-test job passes end-to-end on GPU node