### PR TITLE
feat(olmoearth): add nano Landsat/SAR/NAIP experiment configs

### DIFF
--- a/src/torchgeo_bench/conf/model/olmoearth_nano_landsat_10m.yaml
+++ b/src/torchgeo_bench/conf/model/olmoearth_nano_landsat_10m.yaml
@@ -1,0 +1,8 @@
+_target_: torchgeo_bench.models.OlmoEarthBenchModel
+model_size: nano
+patch_size: 8
+input_res: 10  # upsample Landsat to 10 m (OlmoEarth trains Landsat at 10 m); Landsat normalizer used
+time_steps: 3
+std_multiplier: 2.0
+normalize: false
+name: olmoearth_v1_nano_lsat_10m

--- a/src/torchgeo_bench/conf/model/olmoearth_nano_landsat_10m_x150.yaml
+++ b/src/torchgeo_bench/conf/model/olmoearth_nano_landsat_10m_x150.yaml
@@ -1,0 +1,9 @@
+_target_: torchgeo_bench.models.OlmoEarthBenchModel
+model_size: nano
+patch_size: 8
+input_res: 10
+time_steps: 3
+std_multiplier: 2.0
+normalize: false
+landsat_scale_factor: 3.825  # uint8*(10000/255)*3.825 ≈ uint8*150
+name: olmoearth_v1_nano_lsat_10m_x150

--- a/src/torchgeo_bench/conf/model/olmoearth_nano_landsat_as_s2.yaml
+++ b/src/torchgeo_bench/conf/model/olmoearth_nano_landsat_as_s2.yaml
@@ -1,0 +1,10 @@
+_target_: torchgeo_bench.models.OlmoEarthBenchModel
+model_size: nano
+patch_size: 8
+input_res: 30
+time_steps: 3
+std_multiplier: 2.0
+normalize: false
+sensor_remap:
+  landsat: landsat_as_s2  # route through S2 normalizer; wavelengths align well
+name: olmoearth_v1_nano_lsat_as_s2

--- a/src/torchgeo_bench/conf/model/olmoearth_nano_landsat_raw.yaml
+++ b/src/torchgeo_bench/conf/model/olmoearth_nano_landsat_raw.yaml
@@ -1,0 +1,9 @@
+_target_: torchgeo_bench.models.OlmoEarthBenchModel
+model_size: nano
+patch_size: 8
+input_res: null
+time_steps: 3
+std_multiplier: 2.0
+normalize: false
+landsat_scale_factor: 0.02550  # undoes the *(10000/255) so values stay as raw uint8 [0,255]
+name: olmoearth_v1_nano_lsat_raw

--- a/src/torchgeo_bench/conf/model/olmoearth_nano_landsat_x100.yaml
+++ b/src/torchgeo_bench/conf/model/olmoearth_nano_landsat_x100.yaml
@@ -1,0 +1,9 @@
+_target_: torchgeo_bench.models.OlmoEarthBenchModel
+model_size: nano
+patch_size: 8
+input_res: null
+time_steps: 3
+std_multiplier: 2.0
+normalize: false
+landsat_scale_factor: 2.55  # uint8*(10000/255)*2.55 ≈ uint8*100; maps mean~72 → ~7200
+name: olmoearth_v1_nano_lsat_x100

--- a/src/torchgeo_bench/conf/model/olmoearth_nano_landsat_x143.yaml
+++ b/src/torchgeo_bench/conf/model/olmoearth_nano_landsat_x143.yaml
@@ -1,0 +1,9 @@
+_target_: torchgeo_bench.models.OlmoEarthBenchModel
+model_size: nano
+patch_size: 8
+input_res: null
+time_steps: 3
+std_multiplier: 2.0
+normalize: false
+landsat_scale_factor: 3.643  # uint8*(10000/255)*3.643 ≈ uint8*142.9 ≈ uint8/255/0.0000275 (invert LC2 SR scale)
+name: olmoearth_v1_nano_lsat_x143

--- a/src/torchgeo_bench/conf/model/olmoearth_nano_landsat_x150.yaml
+++ b/src/torchgeo_bench/conf/model/olmoearth_nano_landsat_x150.yaml
@@ -1,0 +1,9 @@
+_target_: torchgeo_bench.models.OlmoEarthBenchModel
+model_size: nano
+patch_size: 8
+input_res: null
+time_steps: 3
+std_multiplier: 2.0
+normalize: false
+landsat_scale_factor: 3.825  # uint8*(10000/255)*3.825 ≈ uint8*150; maps mean~72 → ~10800 ≈ OlmoEarth B2 mean
+name: olmoearth_v1_nano_lsat_x150

--- a/src/torchgeo_bench/conf/model/olmoearth_nano_naip_rgb.yaml
+++ b/src/torchgeo_bench/conf/model/olmoearth_nano_naip_rgb.yaml
@@ -1,0 +1,10 @@
+_target_: torchgeo_bench.models.OlmoEarthBenchModel
+model_size: nano
+patch_size: 8
+input_res: 30
+time_steps: 3
+std_multiplier: 2.0
+normalize: false
+sensor_remap:
+  landsat: aerial  # treat as NAIP/aerial RGB+NIR through S2 path
+name: olmoearth_v1_nano_naip_rgb

--- a/src/torchgeo_bench/conf/model/olmoearth_nano_sar_db.yaml
+++ b/src/torchgeo_bench/conf/model/olmoearth_nano_sar_db.yaml
@@ -1,0 +1,9 @@
+_target_: torchgeo_bench.models.OlmoEarthBenchModel
+model_size: nano
+patch_size: 8
+input_res: null
+time_steps: 3
+std_multiplier: 2.0
+normalize: false
+sar_log_scale: true  # converts SAR intensity to dB: 10*log10(v), matching OlmoEarth S1 stats (VH mean≈-17.75dB)
+name: olmoearth_v1_nano_sar_db

--- a/src/torchgeo_bench/conf/model/olmoearth_nano_t1.yaml
+++ b/src/torchgeo_bench/conf/model/olmoearth_nano_t1.yaml
@@ -1,0 +1,10 @@
+_target_: torchgeo_bench.models.OlmoEarthBenchModel
+model_size: nano
+patch_size: 8
+input_res: null
+time_steps: 1
+std_multiplier: 2.0
+normalize: false
+sensor_remap:
+  landsat: landsat_as_s2
+name: olmoearth_v1_nano_t1

--- a/src/torchgeo_bench/conf/model/olmoearth_nano_t6.yaml
+++ b/src/torchgeo_bench/conf/model/olmoearth_nano_t6.yaml
@@ -1,0 +1,10 @@
+_target_: torchgeo_bench.models.OlmoEarthBenchModel
+model_size: nano
+patch_size: 8
+input_res: null
+time_steps: 6
+std_multiplier: 2.0
+normalize: false
+sensor_remap:
+  landsat: landsat_as_s2
+name: olmoearth_v1_nano_t6


### PR DESCRIPTION
## Summary

Adds ablation configs for `OlmoEarth nano` covering the full sweep of Landsat normalisation strategies, input resolutions, time-step counts, SAR log-scaling, and NAIP/aerial routing that were used to determine the best default (now `landsat_as_s2`, baked into `olmoearth_nano.yaml`).

| Config | Key setting |
|---|---|
| `olmoearth_nano_landsat_10m` | `input_res: 10` — upsample Landsat to 10 m |
| `olmoearth_nano_landsat_10m_x150` | 10 m + `landsat_scale_factor: 3.825` |
| `olmoearth_nano_landsat_as_s2` | Route through S2 normalizer at native 30 m |
| `olmoearth_nano_landsat_raw` | Scale factor reverting to raw uint8 range |
| `olmoearth_nano_landsat_x100/x143/x150` | Various scale factors for mean-matching |
| `olmoearth_nano_naip_rgb` | Aerial/NAIP routing via `sensor_remap` |
| `olmoearth_nano_sar_db` | SAR intensity → dB conversion |
| `olmoearth_nano_t1` / `olmoearth_nano_t6` | Single / 6 time-step ablations |

Note: `min_image_size: 64` and the `olmoearth.py` implementation are already in main via #97.

## Test plan

- [ ] Configs parse without error: `python -c "from hydra import compose, initialize_config_dir; ..."`
- [ ] CI green