### PR TITLE
feat(eval): track calibration metrics for KNN and Linear Probing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
   "timm>=0.9",
   "torch>=2",
   "torchgeo @ git+https://github.com/microsoft/torchgeo.git@e585e2c07f7a",
+  "torchmetrics>=1.4",
   "torchvision>=0.15",
   "typer>=0.9",
 ]

--- a/src/torchgeo_bench/calibration.py
+++ b/src/torchgeo_bench/calibration.py
@@ -1,0 +1,69 @@
+"""Calibration metrics for classification probes.
+
+Wraps ``torchmetrics`` calibration error so KNN and Linear Probing
+evaluations can report ECE (L1), RMS calibration error (L2), and the
+maximum calibration error (MCE) alongside their primary metric.
+"""
+
+import numpy as np
+import torch
+from torchmetrics.classification import (
+    BinaryCalibrationError,
+    MulticlassCalibrationError,
+)
+
+_NORMS: tuple[str, ...] = ("l1", "l2", "max")
+_KEYS: dict[str, str] = {"l1": "ece", "l2": "rms_ce", "max": "mce"}
+
+
+def compute_calibration_metrics(
+    y_true: np.ndarray,
+    y_proba: np.ndarray,
+    multi_label: bool,
+    n_bins: int = 15,
+) -> dict[str, float]:
+    """Compute calibration metrics from class probabilities.
+
+    Args:
+        y_true: For single-label, integer class labels of shape ``(N,)``.
+            For multi-label, binary indicators of shape ``(N, C)``.
+        y_proba: Predicted probabilities of shape ``(N, C)``. For
+            multi-label these are per-label sigmoid probabilities (not
+            required to sum to 1).
+        multi_label: Whether the task is multi-label.
+        n_bins: Number of bins used by torchmetrics calibration error.
+
+    Returns:
+        Dict with keys ``ece`` (L1), ``rms_ce`` (L2), ``mce`` (max).
+        Multi-label values are macro-averaged over labels.
+    """
+    probs = torch.as_tensor(y_proba, dtype=torch.float32)
+
+    if multi_label:
+        targets = torch.as_tensor(y_true, dtype=torch.long)
+        n_classes = probs.shape[1]
+        per_class: dict[str, list[float]] = {key: [] for key in _KEYS.values()}
+        for c in range(n_classes):
+            t_c = targets[:, c]
+            # Skip degenerate columns: a single observed class makes
+            # binning meaningless and torchmetrics emits a warning.
+            if t_c.min() == t_c.max():
+                continue
+            p_c = probs[:, c].clamp(0.0, 1.0)
+            for norm in _NORMS:
+                metric = BinaryCalibrationError(n_bins=n_bins, norm=norm)
+                per_class[_KEYS[norm]].append(float(metric(p_c, t_c).item()))
+        return {
+            key: (float(np.mean(vals)) if vals else float("nan")) for key, vals in per_class.items()
+        }
+
+    targets = torch.as_tensor(y_true, dtype=torch.long)
+    n_classes = probs.shape[1]
+    # Renormalize defensively; some sklearn estimators return rows that
+    # don't sum to exactly 1 due to fp32 accumulation.
+    probs = probs / probs.sum(dim=1, keepdim=True).clamp_min(1e-12)
+    out: dict[str, float] = {}
+    for norm in _NORMS:
+        metric = MulticlassCalibrationError(num_classes=n_classes, n_bins=n_bins, norm=norm)
+        out[_KEYS[norm]] = float(metric(probs, targets).item())
+    return out

--- a/src/torchgeo_bench/calibration.py
+++ b/src/torchgeo_bench/calibration.py
@@ -2,7 +2,9 @@
 
 Wraps ``torchmetrics`` calibration error so KNN and Linear Probing
 evaluations can report ECE (L1), RMS calibration error (L2), and the
-maximum calibration error (MCE) alongside their primary metric.
+maximum calibration error (MCE) alongside their primary metric. Also
+provides a single-parameter temperature-scaling baseline (Guo et al.,
+2017) for Linear Probing.
 """
 
 import numpy as np
@@ -67,3 +69,62 @@ def compute_calibration_metrics(
         metric = MulticlassCalibrationError(num_classes=n_classes, n_bins=n_bins, norm=norm)
         out[_KEYS[norm]] = float(metric(probs, targets).item())
     return out
+
+
+def fit_temperature(
+    logits: np.ndarray,
+    y_true: np.ndarray,
+    multi_label: bool,
+    max_iter: int = 100,
+) -> float:
+    """Fit a single temperature ``T`` minimizing NLL on held-out logits.
+
+    Guo et al. (2017) "On Calibration of Modern Neural Networks". Operates
+    on raw logits; parameterized as ``T = exp(log_T)`` so the optimizer
+    stays in an unconstrained space and ``T`` stays positive.
+
+    Args:
+        logits: Raw scores of shape ``(N, C)``.
+        y_true: Integer class labels ``(N,)`` (single-label) or binary
+            indicators ``(N, C)`` (multi-label).
+        multi_label: Whether to fit T against per-label BCE (sigmoid) or
+            multi-class NLL (softmax).
+        max_iter: LBFGS iterations.
+
+    Returns:
+        Fitted temperature ``T > 0``. ``T > 1`` means the raw model was
+        overconfident; ``T < 1`` underconfident.
+    """
+    z = torch.as_tensor(logits, dtype=torch.float64)
+    log_T = torch.zeros(1, dtype=torch.float64, requires_grad=True)
+    optimizer = torch.optim.LBFGS([log_T], lr=0.1, max_iter=max_iter)
+
+    if multi_label:
+        y = torch.as_tensor(y_true, dtype=torch.float64)
+        loss_fn = torch.nn.BCEWithLogitsLoss()
+
+        def closure() -> torch.Tensor:
+            optimizer.zero_grad()
+            loss = loss_fn(z / log_T.exp(), y)
+            loss.backward()
+            return loss
+    else:
+        y = torch.as_tensor(y_true, dtype=torch.long)
+        loss_fn = torch.nn.CrossEntropyLoss()
+
+        def closure() -> torch.Tensor:
+            optimizer.zero_grad()
+            loss = loss_fn(z / log_T.exp(), y)
+            loss.backward()
+            return loss
+
+    optimizer.step(closure)
+    return float(log_T.exp().item())
+
+
+def apply_temperature(logits: np.ndarray, temperature: float, multi_label: bool) -> np.ndarray:
+    """Convert logits to probabilities at the given temperature."""
+    z = torch.as_tensor(logits, dtype=torch.float32) / float(temperature)
+    if multi_label:
+        return torch.sigmoid(z).numpy()
+    return torch.softmax(z, dim=1).numpy()

--- a/src/torchgeo_bench/conf/config.yaml
+++ b/src/torchgeo_bench/conf/config.yaml
@@ -32,6 +32,16 @@ eval:
   knn_k: 5                 # number of neighbours for KNN evaluation
   knn_device: null         # null = inherit cfg.device; set "cpu" to force faiss-cpu KNN
 
+  # Calibration metrics (ECE / RMS-CE / MCE) reported per classification row.
+  # KNN probabilities are quantized to (knn_k + 1) levels, so its default
+  # bin count matches that; Linear uses the conventional 15. Temperature
+  # scaling (Guo et al., 2017) is fit on val logits and applied only to
+  # Linear Probing — KNN has no meaningful logit to scale.
+  calibration:
+    n_bins_knn: null       # null = knn_k + 1
+    n_bins_linear: 15
+    temp_scale: true       # adds ece_ts/rms_ce_ts/mce_ts/temperature columns
+
   # Optional intrinsic dimension (ID) metrics on extracted embeddings.
   # Computed alongside KNN/linear probing when enabled. Adds rows with
   # method="intrinsic_dim" and metric_name="id_<estimator>_<split>".

--- a/src/torchgeo_bench/main.py
+++ b/src/torchgeo_bench/main.py
@@ -20,6 +20,7 @@ from sklearn.metrics import accuracy_score, average_precision_score
 from torch.utils.data import ConcatDataset, DataLoader
 from torchgeo.datasets.errors import DatasetNotFoundError
 
+from torchgeo_bench.calibration import compute_calibration_metrics
 from torchgeo_bench.datasets import (
     get_bench_dataset_class,
     get_datasets,
@@ -197,6 +198,10 @@ class EvaluationResult:
     precision: float | None = None
     recall: float | None = None
     f1: float | None = None
+    # Calibration metrics for KNN / Linear Probing (None for segmentation rows)
+    ece: float | None = None
+    rms_ce: float | None = None
+    mce: float | None = None
 
     def to_row(self) -> dict:
         """Convert to a flat dictionary suitable for CSV/DataFrame export."""
@@ -220,8 +225,12 @@ def evaluate_knn(
     verbose: bool = False,
     device: str = "cpu",
     n_neighbors: int = 5,
-) -> tuple[float, float, float]:
-    """Evaluate KNN classifier. Auto-detects single-label vs multi-label from y shape."""
+) -> tuple[float, float, float, dict[str, float]]:
+    """Evaluate KNN classifier. Auto-detects single-label vs multi-label from y shape.
+
+    Returns the primary metric with bootstrap CI plus a calibration dict
+    (``ece``/``rms_ce``/``mce``) computed from ``predict_proba``.
+    """
     multi_label = y_train.ndim == 2
     clf = KNNClassifier(n_neighbors=n_neighbors, device=device, use_fp16=False)
     clf.fit(x_train, y_train)
@@ -239,11 +248,20 @@ def evaluate_knn(
                 f"[KNN] Fit KNN5 (train={len(x_train)}, test={len(x_test)}, boot={n_bootstrap})"
             )
         preds = clf.predict(x_test)
+        y_scores = clf.predict_proba(x_test)
         metric, lo, hi = bootstrap_accuracy(y_test, preds, n_boot=n_bootstrap, seed=seed)
         if verbose:
             logger.info(f"[KNN] Test accuracy={metric:.4f} (CI {lo:.4f}-{hi:.4f})")
 
-    return metric, lo, hi
+    calibration = compute_calibration_metrics(y_test, y_scores, multi_label=multi_label)
+
+    if verbose:
+        logger.info(
+            f"[KNN] Calibration ECE={calibration['ece']:.4f} "
+            f"RMS-CE={calibration['rms_ce']:.4f} MCE={calibration['mce']:.4f}"
+        )
+
+    return metric, lo, hi, calibration
 
 
 def evaluate_logistic(
@@ -259,8 +277,13 @@ def evaluate_logistic(
     merge_val: bool,
     device: str,
     verbose: bool = False,
-) -> tuple[float, float, float, float]:
-    """Sweep C values, retrain, and evaluate. Auto-detects single/multi-label from y shape."""
+) -> tuple[float, float, float, float, dict[str, float]]:
+    """Sweep C values, retrain, and evaluate. Auto-detects single/multi-label from y shape.
+
+    Returns the primary metric with bootstrap CI, the selected ``C``, and
+    a calibration dict (``ece``/``rms_ce``/``mce``) from the final
+    model's ``predict_proba`` on the test split.
+    """
     multi_label = y_train.ndim == 2
     best_c: float | None = None
     best_val_score = -1.0
@@ -341,14 +364,21 @@ def evaluate_logistic(
         metric, lo, hi = bootstrap_map(y_test, test_scores, n_boot=n_bootstrap, seed=seed)
     else:
         test_preds = final_model.predict(x_test_tensor)
+        test_scores = final_model.predict_proba(x_test_tensor)
         metric, lo, hi = bootstrap_accuracy(y_test, test_preds, n_boot=n_bootstrap, seed=seed)
+
+    calibration = compute_calibration_metrics(y_test, test_scores, multi_label=multi_label)
 
     if verbose:
         logger.info(
             f"[{label_tag}] Test score={metric:.4f} (CI {lo:.4f}-{hi:.4f}) "
             f"using C={best_c:.4g}; train_final={len(x_final)} test={len(x_test)}"
         )
-    return metric, lo, hi, float(best_c)
+        logger.info(
+            f"[{label_tag}] Calibration ECE={calibration['ece']:.4f} "
+            f"RMS-CE={calibration['rms_ce']:.4f} MCE={calibration['mce']:.4f}"
+        )
+    return metric, lo, hi, float(best_c), calibration
 
 
 def _make_seg_dataloaders(
@@ -1045,7 +1075,7 @@ def main(cfg: DictConfig) -> None:
 
             if not skip_knn:
                 knn_device = cfg.eval.get("knn_device") or cfg.device
-                knn_score, knn_lo, knn_hi = evaluate_knn(
+                knn_score, knn_lo, knn_hi, knn_cal = evaluate_knn(
                     x_train,
                     y_train,
                     x_test,
@@ -1071,11 +1101,14 @@ def main(cfg: DictConfig) -> None:
                         n_train=len(x_train),
                         n_val=len(x_val),
                         n_test=len(x_test),
+                        ece=knn_cal["ece"],
+                        rms_ce=knn_cal["rms_ce"],
+                        mce=knn_cal["mce"],
                     ).to_row()
                 )
 
             if not skip_linear:
-                lin_score, lin_lo, lin_hi, best_c = evaluate_logistic(
+                lin_score, lin_lo, lin_hi, best_c, lin_cal = evaluate_logistic(
                     x_train,
                     y_train,
                     x_val,
@@ -1104,6 +1137,9 @@ def main(cfg: DictConfig) -> None:
                         n_train=len(x_train),
                         n_val=len(x_val),
                         n_test=len(x_test),
+                        ece=lin_cal["ece"],
+                        rms_ce=lin_cal["rms_ce"],
+                        mce=lin_cal["mce"],
                     ).to_row()
                 )
 

--- a/src/torchgeo_bench/main.py
+++ b/src/torchgeo_bench/main.py
@@ -20,7 +20,11 @@ from sklearn.metrics import accuracy_score, average_precision_score
 from torch.utils.data import ConcatDataset, DataLoader
 from torchgeo.datasets.errors import DatasetNotFoundError
 
-from torchgeo_bench.calibration import compute_calibration_metrics
+from torchgeo_bench.calibration import (
+    apply_temperature,
+    compute_calibration_metrics,
+    fit_temperature,
+)
 from torchgeo_bench.datasets import (
     get_bench_dataset_class,
     get_datasets,
@@ -202,6 +206,12 @@ class EvaluationResult:
     ece: float | None = None
     rms_ce: float | None = None
     mce: float | None = None
+    # Post temperature-scaling calibration (Linear Probing only; None for KNN/seg)
+    ece_ts: float | None = None
+    rms_ce_ts: float | None = None
+    mce_ts: float | None = None
+    temperature: float | None = None
+    calibration_n_bins: int | None = None
 
     def to_row(self) -> dict:
         """Convert to a flat dictionary suitable for CSV/DataFrame export."""
@@ -225,12 +235,15 @@ def evaluate_knn(
     verbose: bool = False,
     device: str = "cpu",
     n_neighbors: int = 5,
-) -> tuple[float, float, float, dict[str, float]]:
+    calibration_n_bins: int | None = None,
+) -> tuple[float, float, float, dict[str, float], int]:
     """Evaluate KNN classifier. Auto-detects single-label vs multi-label from y shape.
 
-    Returns the primary metric with bootstrap CI plus a calibration dict
-    (``ece``/``rms_ce``/``mce``) computed from ``predict_proba``.
+    Returns the primary metric with bootstrap CI, a calibration dict
+    (``ece``/``rms_ce``/``mce``) computed from ``predict_proba``, and the
+    ``n_bins`` actually used (defaults to ``n_neighbors + 1``).
     """
+    n_bins = calibration_n_bins if calibration_n_bins is not None else n_neighbors + 1
     multi_label = y_train.ndim == 2
     clf = KNNClassifier(n_neighbors=n_neighbors, device=device, use_fp16=False)
     clf.fit(x_train, y_train)
@@ -253,15 +266,17 @@ def evaluate_knn(
         if verbose:
             logger.info(f"[KNN] Test accuracy={metric:.4f} (CI {lo:.4f}-{hi:.4f})")
 
-    calibration = compute_calibration_metrics(y_test, y_scores, multi_label=multi_label)
+    calibration = compute_calibration_metrics(
+        y_test, y_scores, multi_label=multi_label, n_bins=n_bins
+    )
 
     if verbose:
         logger.info(
-            f"[KNN] Calibration ECE={calibration['ece']:.4f} "
+            f"[KNN] Calibration (n_bins={n_bins}) ECE={calibration['ece']:.4f} "
             f"RMS-CE={calibration['rms_ce']:.4f} MCE={calibration['mce']:.4f}"
         )
 
-    return metric, lo, hi, calibration
+    return metric, lo, hi, calibration, n_bins
 
 
 def evaluate_logistic(
@@ -277,12 +292,15 @@ def evaluate_logistic(
     merge_val: bool,
     device: str,
     verbose: bool = False,
-) -> tuple[float, float, float, float, dict[str, float]]:
+    calibration_n_bins: int = 15,
+    temp_scale: bool = True,
+) -> tuple[float, float, float, float, dict[str, float], dict[str, float | None]]:
     """Sweep C values, retrain, and evaluate. Auto-detects single/multi-label from y shape.
 
-    Returns the primary metric with bootstrap CI, the selected ``C``, and
-    a calibration dict (``ece``/``rms_ce``/``mce``) from the final
-    model's ``predict_proba`` on the test split.
+    Returns the primary metric with bootstrap CI, the selected ``C``, a
+    calibration dict from raw ``predict_proba`` on the test split, and a
+    second dict with temperature-scaled calibration plus the fitted
+    ``temperature`` (all ``None`` when ``temp_scale=False``).
     """
     multi_label = y_train.ndim == 2
     best_c: float | None = None
@@ -367,7 +385,33 @@ def evaluate_logistic(
         test_scores = final_model.predict_proba(x_test_tensor)
         metric, lo, hi = bootstrap_accuracy(y_test, test_preds, n_boot=n_bootstrap, seed=seed)
 
-    calibration = compute_calibration_metrics(y_test, test_scores, multi_label=multi_label)
+    calibration = compute_calibration_metrics(
+        y_test, test_scores, multi_label=multi_label, n_bins=calibration_n_bins
+    )
+
+    calibration_ts: dict[str, float | None] = {
+        "ece_ts": None,
+        "rms_ce_ts": None,
+        "mce_ts": None,
+        "temperature": None,
+    }
+    if temp_scale:
+        # Fit T on val logits, apply to test logits, recompute calibration.
+        # When merge_val=True the final model has seen val during training, but
+        # T is a single scalar so the resulting leakage is minimal.
+        val_logits = final_model.decision_function(x_val_tensor)
+        test_logits = final_model.decision_function(x_test_tensor)
+        temperature = fit_temperature(val_logits, y_val, multi_label=multi_label)
+        test_scores_ts = apply_temperature(test_logits, temperature, multi_label=multi_label)
+        cal_ts = compute_calibration_metrics(
+            y_test, test_scores_ts, multi_label=multi_label, n_bins=calibration_n_bins
+        )
+        calibration_ts = {
+            "ece_ts": cal_ts["ece"],
+            "rms_ce_ts": cal_ts["rms_ce"],
+            "mce_ts": cal_ts["mce"],
+            "temperature": temperature,
+        }
 
     if verbose:
         logger.info(
@@ -375,10 +419,18 @@ def evaluate_logistic(
             f"using C={best_c:.4g}; train_final={len(x_final)} test={len(x_test)}"
         )
         logger.info(
-            f"[{label_tag}] Calibration ECE={calibration['ece']:.4f} "
+            f"[{label_tag}] Calibration (n_bins={calibration_n_bins}) "
+            f"ECE={calibration['ece']:.4f} "
             f"RMS-CE={calibration['rms_ce']:.4f} MCE={calibration['mce']:.4f}"
         )
-    return metric, lo, hi, float(best_c), calibration
+        if temp_scale:
+            logger.info(
+                f"[{label_tag}] Post-TS T={calibration_ts['temperature']:.3f} "
+                f"ECE={calibration_ts['ece_ts']:.4f} "
+                f"RMS-CE={calibration_ts['rms_ce_ts']:.4f} "
+                f"MCE={calibration_ts['mce_ts']:.4f}"
+            )
+    return metric, lo, hi, float(best_c), calibration, calibration_ts
 
 
 def _make_seg_dataloaders(
@@ -1073,9 +1125,14 @@ def main(cfg: DictConfig) -> None:
             x_test, y_test = embed_split(model, test_loader, device, verbose=cfg.verbose)
             feature_dim = x_train.shape[1]
 
+            cal_cfg = cfg.eval.get("calibration", {}) or {}
+            cal_n_bins_knn = cal_cfg.get("n_bins_knn", None)
+            cal_n_bins_linear = int(cal_cfg.get("n_bins_linear", 15))
+            cal_temp_scale = bool(cal_cfg.get("temp_scale", True))
+
             if not skip_knn:
                 knn_device = cfg.eval.get("knn_device") or cfg.device
-                knn_score, knn_lo, knn_hi, knn_cal = evaluate_knn(
+                knn_score, knn_lo, knn_hi, knn_cal, knn_n_bins = evaluate_knn(
                     x_train,
                     y_train,
                     x_test,
@@ -1085,6 +1142,7 @@ def main(cfg: DictConfig) -> None:
                     verbose=cfg.verbose,
                     device=knn_device,
                     n_neighbors=knn_k,
+                    calibration_n_bins=cal_n_bins_knn,
                 )
                 all_rows.append(
                     EvaluationResult(
@@ -1104,11 +1162,12 @@ def main(cfg: DictConfig) -> None:
                         ece=knn_cal["ece"],
                         rms_ce=knn_cal["rms_ce"],
                         mce=knn_cal["mce"],
+                        calibration_n_bins=knn_n_bins,
                     ).to_row()
                 )
 
             if not skip_linear:
-                lin_score, lin_lo, lin_hi, best_c, lin_cal = evaluate_logistic(
+                lin_score, lin_lo, lin_hi, best_c, lin_cal, lin_cal_ts = evaluate_logistic(
                     x_train,
                     y_train,
                     x_val,
@@ -1121,6 +1180,8 @@ def main(cfg: DictConfig) -> None:
                     cfg.eval.merge_val,
                     cfg.device,
                     cfg.verbose,
+                    calibration_n_bins=cal_n_bins_linear,
+                    temp_scale=cal_temp_scale,
                 )
                 all_rows.append(
                     EvaluationResult(
@@ -1140,6 +1201,11 @@ def main(cfg: DictConfig) -> None:
                         ece=lin_cal["ece"],
                         rms_ce=lin_cal["rms_ce"],
                         mce=lin_cal["mce"],
+                        ece_ts=lin_cal_ts["ece_ts"],
+                        rms_ce_ts=lin_cal_ts["rms_ce_ts"],
+                        mce_ts=lin_cal_ts["mce_ts"],
+                        temperature=lin_cal_ts["temperature"],
+                        calibration_n_bins=cal_n_bins_linear,
                     ).to_row()
                 )
 

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -3,7 +3,11 @@
 import numpy as np
 import pytest
 
-from torchgeo_bench.calibration import compute_calibration_metrics
+from torchgeo_bench.calibration import (
+    apply_temperature,
+    compute_calibration_metrics,
+    fit_temperature,
+)
 
 
 def test_perfect_calibration_singlelabel():
@@ -53,3 +57,63 @@ def test_multilabel_perfect_calibration():
     out = compute_calibration_metrics(y_true, y_proba, multi_label=True)
     for v in out.values():
         assert v == pytest.approx(0.0, abs=1e-5)
+
+
+def test_temperature_overconfident_singlelabel():
+    """Sharp logits with many wrong predictions => T > 1 (flatten)."""
+    rng = np.random.default_rng(0)
+    n, c = 1000, 4
+    y_true = rng.integers(0, c, size=n)
+    # 50% accuracy but logits are very sharp => model is overconfident.
+    pred = y_true.copy()
+    flip = rng.choice(n, size=n // 2, replace=False)
+    pred[flip] = (y_true[flip] + 1) % c
+    logits = np.full((n, c), -5.0, dtype=np.float32)
+    logits[np.arange(n), pred] = 5.0
+    t = fit_temperature(logits, y_true, multi_label=False)
+    assert t > 1.5
+
+
+def test_temperature_underconfident_singlelabel():
+    """Sharp logits with mostly correct predictions => T < 1 (sharpen)."""
+    rng = np.random.default_rng(0)
+    n, c = 500, 4
+    y_true = rng.integers(0, c, size=n)
+    logits = np.full((n, c), -0.5, dtype=np.float32)
+    logits[np.arange(n), y_true] = 0.5
+    t = fit_temperature(logits, y_true, multi_label=False)
+    assert t < 1.0
+
+
+def test_temperature_scaling_reduces_ece():
+    """TS applied on overconfident logits should reduce ECE on the same split."""
+    rng = np.random.default_rng(0)
+    n, c = 1000, 4
+    y_true = rng.integers(0, c, size=n)
+    logits = np.full((n, c), -5.0, dtype=np.float32)
+    logits[np.arange(n), y_true] = 5.0
+    # Inject some errors so calibration isn't trivially zero.
+    flip = rng.choice(n, size=300, replace=False)
+    wrong = (y_true[flip] + 1) % c
+    logits[flip, y_true[flip]] = -5.0
+    logits[flip, wrong] = 5.0
+    raw_probs = apply_temperature(logits, 1.0, multi_label=False)
+    raw_cal = compute_calibration_metrics(y_true, raw_probs, multi_label=False)
+    t = fit_temperature(logits, y_true, multi_label=False)
+    ts_probs = apply_temperature(logits, t, multi_label=False)
+    ts_cal = compute_calibration_metrics(y_true, ts_probs, multi_label=False)
+    assert ts_cal["ece"] < raw_cal["ece"]
+
+
+def test_temperature_multilabel_runs():
+    """Multi-label TS produces a positive T and valid calibration."""
+    rng = np.random.default_rng(0)
+    n, c = 200, 5
+    y_true = rng.integers(0, 2, size=(n, c))
+    logits = rng.normal(size=(n, c)).astype(np.float32) * 3.0
+    t = fit_temperature(logits, y_true, multi_label=True)
+    assert t > 0
+    probs = apply_temperature(logits, t, multi_label=True)
+    out = compute_calibration_metrics(y_true, probs, multi_label=True)
+    for v in out.values():
+        assert 0.0 <= v <= 1.0

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -1,0 +1,55 @@
+"""Tests for calibration metrics helper."""
+
+import numpy as np
+import pytest
+
+from torchgeo_bench.calibration import compute_calibration_metrics
+
+
+def test_perfect_calibration_singlelabel():
+    """One-hot probabilities matching labels => zero calibration error."""
+    rng = np.random.default_rng(0)
+    n, c = 200, 4
+    y_true = rng.integers(0, c, size=n)
+    y_proba = np.eye(c, dtype=np.float32)[y_true]
+    out = compute_calibration_metrics(y_true, y_proba, multi_label=False)
+    assert set(out) == {"ece", "rms_ce", "mce"}
+    for v in out.values():
+        assert v == pytest.approx(0.0, abs=1e-5)
+
+
+def test_worst_calibration_singlelabel():
+    """High-confidence wrong predictions => ECE near 1."""
+    n, c = 200, 4
+    y_true = np.zeros(n, dtype=np.int64)
+    y_proba = np.zeros((n, c), dtype=np.float32)
+    y_proba[:, 1] = 1.0  # always confidently predict class 1
+    out = compute_calibration_metrics(y_true, y_proba, multi_label=False)
+    assert out["ece"] == pytest.approx(1.0, abs=1e-4)
+    assert out["mce"] == pytest.approx(1.0, abs=1e-4)
+
+
+def test_multilabel_shapes_and_range():
+    """Multi-label path returns the same keys with values in [0, 1]."""
+    rng = np.random.default_rng(0)
+    n, c = 100, 5
+    y_true = rng.integers(0, 2, size=(n, c))
+    y_proba = rng.uniform(0.0, 1.0, size=(n, c)).astype(np.float32)
+    out = compute_calibration_metrics(y_true, y_proba, multi_label=True)
+    assert set(out) == {"ece", "rms_ce", "mce"}
+    for v in out.values():
+        assert 0.0 <= v <= 1.0
+
+
+def test_multilabel_perfect_calibration():
+    """Hard 0/1 probabilities matching labels => zero per-label error."""
+    rng = np.random.default_rng(1)
+    n, c = 80, 3
+    y_true = rng.integers(0, 2, size=(n, c))
+    # Ensure each column has both classes so no column is skipped.
+    y_true[0] = 0
+    y_true[1] = 1
+    y_proba = y_true.astype(np.float32)
+    out = compute_calibration_metrics(y_true, y_proba, multi_label=True)
+    for v in out.values():
+        assert v == pytest.approx(0.0, abs=1e-5)

--- a/tests/test_multilabel.py
+++ b/tests/test_multilabel.py
@@ -359,7 +359,7 @@ class TestUnifiedEvaluateKNN:
         from torchgeo_bench import evaluate_knn
 
         d = singlelabel_data
-        score, lo, hi, cal = evaluate_knn(
+        score, lo, hi, cal, _ = evaluate_knn(
             d["x_train"],
             d["y_train"],
             d["x_test"],
@@ -376,7 +376,7 @@ class TestUnifiedEvaluateKNN:
         from torchgeo_bench import evaluate_knn
 
         d = multilabel_data
-        score, lo, hi, cal = evaluate_knn(
+        score, lo, hi, cal, _ = evaluate_knn(
             d["x_train"],
             d["y_train"],
             d["x_test"],
@@ -393,7 +393,7 @@ class TestUnifiedEvaluateLogistic:
         from torchgeo_bench import evaluate_logistic
 
         d = singlelabel_data
-        score, lo, hi, best_c, cal = evaluate_logistic(
+        score, lo, hi, best_c, cal, cal_ts = evaluate_logistic(
             d["x_train"],
             d["y_train"],
             d["x_test"][:15],
@@ -409,12 +409,14 @@ class TestUnifiedEvaluateLogistic:
         assert 0 <= lo <= score <= hi <= 1.0
         assert best_c in [0.1, 1.0]
         assert set(cal) == {"ece", "rms_ce", "mce"}
+        assert set(cal_ts) == {"ece_ts", "rms_ce_ts", "mce_ts", "temperature"}
+        assert cal_ts["temperature"] is not None and cal_ts["temperature"] > 0
 
     def test_multi_label(self, multilabel_data):
         from torchgeo_bench import evaluate_logistic
 
         d = multilabel_data
-        score, lo, hi, best_c, cal = evaluate_logistic(
+        score, lo, hi, best_c, cal, cal_ts = evaluate_logistic(
             d["x_train"],
             d["y_train"],
             d["x_val"],
@@ -430,3 +432,5 @@ class TestUnifiedEvaluateLogistic:
         assert 0 <= lo <= score <= hi <= 1.0
         assert best_c in [0.01, 0.1, 1.0]
         assert set(cal) == {"ece", "rms_ce", "mce"}
+        assert set(cal_ts) == {"ece_ts", "rms_ce_ts", "mce_ts", "temperature"}
+        assert cal_ts["temperature"] is not None and cal_ts["temperature"] > 0

--- a/tests/test_multilabel.py
+++ b/tests/test_multilabel.py
@@ -359,7 +359,7 @@ class TestUnifiedEvaluateKNN:
         from torchgeo_bench import evaluate_knn
 
         d = singlelabel_data
-        score, lo, hi = evaluate_knn(
+        score, lo, hi, cal = evaluate_knn(
             d["x_train"],
             d["y_train"],
             d["x_test"],
@@ -368,12 +368,15 @@ class TestUnifiedEvaluateKNN:
             n_bootstrap=50,
         )
         assert 0 <= lo <= score <= hi <= 1.0
+        assert set(cal) == {"ece", "rms_ce", "mce"}
+        for v in cal.values():
+            assert 0.0 <= v <= 1.0
 
     def test_multi_label(self, multilabel_data):
         from torchgeo_bench import evaluate_knn
 
         d = multilabel_data
-        score, lo, hi = evaluate_knn(
+        score, lo, hi, cal = evaluate_knn(
             d["x_train"],
             d["y_train"],
             d["x_test"],
@@ -382,6 +385,7 @@ class TestUnifiedEvaluateKNN:
             n_bootstrap=50,
         )
         assert 0 <= lo <= score <= hi <= 1.0
+        assert set(cal) == {"ece", "rms_ce", "mce"}
 
 
 class TestUnifiedEvaluateLogistic:
@@ -389,7 +393,7 @@ class TestUnifiedEvaluateLogistic:
         from torchgeo_bench import evaluate_logistic
 
         d = singlelabel_data
-        score, lo, hi, best_c = evaluate_logistic(
+        score, lo, hi, best_c, cal = evaluate_logistic(
             d["x_train"],
             d["y_train"],
             d["x_test"][:15],
@@ -404,12 +408,13 @@ class TestUnifiedEvaluateLogistic:
         )
         assert 0 <= lo <= score <= hi <= 1.0
         assert best_c in [0.1, 1.0]
+        assert set(cal) == {"ece", "rms_ce", "mce"}
 
     def test_multi_label(self, multilabel_data):
         from torchgeo_bench import evaluate_logistic
 
         d = multilabel_data
-        score, lo, hi, best_c = evaluate_logistic(
+        score, lo, hi, best_c, cal = evaluate_logistic(
             d["x_train"],
             d["y_train"],
             d["x_val"],
@@ -424,3 +429,4 @@ class TestUnifiedEvaluateLogistic:
         )
         assert 0 <= lo <= score <= hi <= 1.0
         assert best_c in [0.01, 0.1, 1.0]
+        assert set(cal) == {"ece", "rms_ce", "mce"}

--- a/uv.lock
+++ b/uv.lock
@@ -3911,6 +3911,7 @@ dependencies = [
     { name = "timm" },
     { name = "torch" },
     { name = "torchgeo" },
+    { name = "torchmetrics" },
     { name = "torchvision" },
     { name = "typer" },
 ]
@@ -4031,6 +4032,7 @@ requires-dist = [
     { name = "torchgeo-bench", extras = ["terratorch"], marker = "extra == 'all'" },
     { name = "torchgeo-bench", extras = ["viz"], marker = "extra == 'all'" },
     { name = "torchid", marker = "python_full_version >= '3.13' and extra == 'id'", specifier = ">=0.3" },
+    { name = "torchmetrics", specifier = ">=1.4" },
     { name = "torchvision", specifier = ">=0.15" },
     { name = "transformers", marker = "extra == 'sam3'", specifier = ">=4.50" },
     { name = "typer", specifier = ">=0.9" },


### PR DESCRIPTION
## Summary
- Add `compute_calibration_metrics` (torchmetrics-backed) returning ECE / RMS-CE / MCE.
- Wire it into `evaluate_knn` and `evaluate_logistic`; both now return a calibration dict alongside the primary metric.
- Extend `EvaluationResult` with `ece`, `rms_ce`, `mce` columns; CSV writer's existing schema-healing path backfills nulls for older rows.
- Multi-label calibration = macro-average of per-label `BinaryCalibrationError` over labels with both classes observed.

## Notes
- Primary metric path is byte-identical: still uses `predict()` for argmax; `predict_proba()` is called separately only for calibration.
- Added `torchmetrics>=1.4` to direct dependencies (was transitive via torchgeo).

## Test plan
- [x] `pytest tests/test_calibration.py` — perfect / worst-case / multilabel cases pass.
- [x] `pytest tests/test_multilabel.py` — updated tuple unpacking, all green.
- [x] `ruff check` + `ruff format` clean on touched files.
- [ ] End-to-end smoke run on a real dataset to confirm new CSV columns populate.