### PR TITLE
deps: simplify environment.yml to single source of truth

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,20 +1,15 @@
+# Conda environment for torchgeo-bench. The actual Python dependencies
+# live in pyproject.toml; this file exists so contributors who prefer
+# conda can bootstrap a working interpreter with `conda env create -f
+# environment.yml`, then `pip install -e .` (already triggered by the
+# pip section below) pulls in everything else from PyPI.
+#
+# Add development extras with: pip install -e ".[dev]"
 name: torchgeo-bench
 channels:
   - conda-forge
 dependencies:
-  - python>=3.12,<3.13
+  - python>=3.12
   - pip
   - pip:
-      - numpy>=1.24.0
-      - pandas>=2.0.0
-      - scikit-learn>=1.3.0
-      - h5py>=3.8.0
-      - hydra-core>=1.3.0
-      - omegaconf>=2.3.0
-      - tqdm>=4.65.0
-      - timm>=0.9.0
-      - huggingface_hub>=0.20.0
-      - torchgeo>=0.8.0
-      - faiss-cpu>=1.7.0
-      - GeoBenchV2
       - -e .


### PR DESCRIPTION
Fixes #109.

`environment.yml` was duplicating a hand-maintained pin list alongside `pyproject.toml`. The two had drifted:

- missing: `typer`, `rich`, `torchmetrics`, `torchvision`
- unused: `tqdm`
- miscased: `GeoBenchV2` (should be `geobenchv2`)
- mismatched: `faiss-cpu` vs pyproject's `faiss-cuda-cu128`
- underscored: `huggingface_hub` (PyPI canonical is `huggingface-hub`)

Rather than rewriting the pin list (which would just drift again the next time pyproject changes), this PR collapses `environment.yml` to a thin conda wrapper. Conda gives you Python + pip; pip runs `-e .`, which reads pyproject.toml. Single source of truth, no drift possible.

```yaml
name: torchgeo-bench
channels:
  - conda-forge
dependencies:
  - python>=3.12
  - pip
  - pip:
      - -e .
```

Contributors who want dev extras can run `pip install -e ".[dev]"` after activation, or use the recommended `uv sync --extra dev` path from the README/AGENTS.md.

🤖 Generated with the GitHub Copilot CLI.