### PR TITLE
fix: use public torchgeo.datasets import for DatasetNotFoundError

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -176,7 +176,7 @@ Download with `torchgeo-bench download {geobench_v1|geobench_v2|eurosat}`.
       DatasetNotFoundError = FileNotFoundError
 
   # ✅ GOOD
-  from torchgeo.datasets.errors import DatasetNotFoundError
+  from torchgeo.datasets import DatasetNotFoundError
   ```
 
   Same rule for bare `except Exception:` blocks that swallow errors to

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,7 +205,7 @@ except ImportError:  # pragma: no cover - older torchgeo versions
     DatasetNotFoundError = FileNotFoundError
 
 # ✅ GOOD: torchgeo is a hard dep, just import it
-from torchgeo.datasets.errors import DatasetNotFoundError
+from torchgeo.datasets import DatasetNotFoundError
 ```
 
 The same rule applies to bare `except Exception:` blocks that swallow errors

--- a/src/torchgeo_bench/main.py
+++ b/src/torchgeo_bench/main.py
@@ -18,7 +18,7 @@ from omegaconf import DictConfig, OmegaConf
 from rich.progress import track
 from sklearn.metrics import accuracy_score, average_precision_score
 from torch.utils.data import ConcatDataset, DataLoader
-from torchgeo.datasets.errors import DatasetNotFoundError
+from torchgeo.datasets import DatasetNotFoundError
 
 from torchgeo_bench.calibration import (
     apply_temperature,

--- a/tests/test_main_fast.py
+++ b/tests/test_main_fast.py
@@ -10,7 +10,7 @@ import torch
 from hydra import compose, initialize_config_module
 from omegaconf import DictConfig
 from torch.utils.data import DataLoader, Dataset
-from torchgeo.datasets.errors import DatasetNotFoundError
+from torchgeo.datasets import DatasetNotFoundError
 
 from torchgeo_bench.main import main
 

--- a/tests/test_split_sizes.py
+++ b/tests/test_split_sizes.py
@@ -20,7 +20,7 @@ or a bug in our wrapper's ``get_dataset`` plumbing.
 """
 
 import pytest
-from torchgeo.datasets.errors import DatasetNotFoundError
+from torchgeo.datasets import DatasetNotFoundError
 
 from torchgeo_bench.datasets import (
     get_bench_dataset_class,


### PR DESCRIPTION
Fixes #112.

`from torchgeo.datasets.errors import DatasetNotFoundError` reaches into torchgeo's private `.errors` submodule. The exception is re-exported from `torchgeo.datasets`, which is the documented public API.

### Changes

- `src/torchgeo_bench/main.py`
- `tests/test_main_fast.py`
- `tests/test_split_sizes.py`
- `AGENTS.md` (the ✅ GOOD example in the no-defensive-imports section)
- `.github/copilot-instructions.md` (matching ✅ GOOD example)

The ❌ BAD examples in the docs intentionally still reference the private path — that's the anti-pattern they're warning against.

### Verification

- `python -c "from torchgeo.datasets import DatasetNotFoundError"` succeeds
- `ruff check src tests` passes
- `pytest tests/test_main_fast.py tests/test_split_sizes.py` passes

🤖 Generated with the GitHub Copilot CLI.