### PR TITLE
deps: move faiss-cuda-cu128 to [cuda] extra, default to faiss-cpu

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,9 +19,8 @@ jobs:
       - uses: astral-sh/setup-uv@v8.0.0
         with:
           enable-cache: true
-      # Cache `.venv` keyed on uv.lock + python version + OS. When the lock
-      # hasn't changed (the common case on a feature branch), `uv sync
-      # --frozen` becomes a near-no-op and shaves ~30s off this job.
+      # Cache `.venv` keyed on uv.lock + python version + OS so unchanged
+      # locks make `uv sync --frozen` a near-no-op.
       - name: Cache .venv
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
@@ -30,9 +29,8 @@ jobs:
       - name: Install dependencies
         run: uv sync --extra dev --extra id --extra olmoearth --frozen
       - name: Run tests
-        # `-n auto` parallelises across the runner's CPUs (typically 4 on
-        # GitHub-hosted ubuntu-latest). `--dist=loadfile` groups tests by
-        # file so per-file heavy fixtures aren't repeated across workers.
+        # `-n auto` parallelises across CPUs; `--dist=loadfile` groups tests
+        # by file so heavy per-file fixtures aren't repeated across workers.
         run: uv run pytest -n auto --dist=loadfile --cov=torchgeo_bench --cov-report=xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
@@ -41,12 +39,9 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 
-  # Prove the default install works on Linux and macOS. This is the whole
-  # point of moving faiss-cuda-cu128 (Linux-only wheels) into the [cuda]
-  # extra: `pip install torchgeo-bench` must resolve and import on both
-  # OSes, with faiss-cpu (which ships wheels for each) as the default.
-  # Windows is not a supported platform. The full pytest matrix runs on
-  # Linux in the `test` job above.
+  # Prove the default (CPU-only) install resolves and imports on Linux and
+  # macOS — the point of keeping faiss-cuda-cu128 in the [cuda] extra.
+  # Windows is unsupported; the full pytest suite runs on Linux above.
   install:
     name: install (${{ matrix.os }})
     strategy:
@@ -64,16 +59,14 @@ jobs:
       - uses: astral-sh/setup-uv@v8.0.0
         with:
           enable-cache: true
-      # No `.venv` cache here: this job exists to prove a from-scratch
-      # install works, so we want `uv sync` to actually run each time.
-      # setup-uv's wheel cache keeps it fast without faking the install.
+      # No `.venv` cache: this job exists to prove a from-scratch install
+      # works. setup-uv's wheel cache keeps it fast.
       # No `--extra`, so only the default (CPU) dependency set is installed.
       - name: Install (CPU only, no [cuda] extra)
         run: uv sync --frozen
       - name: Smoke test (CLI entry point)
         # `torchgeo-bench --help` proves the package installed, the console
-        # script is wired up, and the import graph loads on this OS — the
-        # cross-platform signal this matrix exists to provide.
+        # script is wired up, and the import graph loads on this OS.
         run: uv run torchgeo-bench --help
 
   pre-commit:
@@ -95,9 +88,8 @@ jobs:
           key: venv-${{ runner.os }}-py3.13-${{ hashFiles('uv.lock') }}-dev-id
       - name: Install dependencies
         run: uv sync --extra dev --extra id --frozen
-      # Cache the pre-commit hook environments (~/.cache/pre-commit/),
-      # keyed on the pinned hook revisions in .pre-commit-config.yaml.
-      # Saves ~20-30s on every CI run by skipping hook-env setup.
+      # Cache pre-commit hook environments, keyed on the pinned hook
+      # revisions in .pre-commit-config.yaml.
       - name: Cache pre-commit hooks
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,17 +41,18 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 
-  # Prove the default install works on Linux, macOS and Windows. This is
-  # the whole point of moving faiss-cuda-cu128 (Linux-only wheels) into the
-  # [cuda] extra: `pip install torchgeo-bench` must resolve and import on
-  # all three OSes, with faiss-cpu (which ships wheels for each) as the
-  # default. The full pytest matrix runs on Linux in the `test` job above.
+  # Prove the default install works on Linux and macOS. This is the whole
+  # point of moving faiss-cuda-cu128 (Linux-only wheels) into the [cuda]
+  # extra: `pip install torchgeo-bench` must resolve and import on both
+  # OSes, with faiss-cpu (which ships wheels for each) as the default.
+  # Windows is not a supported platform. The full pytest matrix runs on
+  # Linux in the `test` job above.
   install:
     name: install (${{ matrix.os }})
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,16 +60,26 @@ jobs:
           key: venv-${{ runner.os }}-py3.13-${{ hashFiles('uv.lock') }}-dev
       - name: Install dependencies (CPU only, no [cuda] extra)
         run: uv sync --extra dev --frozen
-      - name: Smoke test (import + KNN + main entrypoint)
-        # macOS-latest is ARM. We only need to prove that the default
-        # install works without the [cuda] extra and that the core
-        # CPU code paths import cleanly. A full pytest run on macOS
-        # ARM is very slow (~30+ min on a cold cache) and adds no
-        # signal over the Linux `test` job above, so we restrict to
-        # a focused subset.
+      - name: Smoke test (import + tiny KNN round-trip)
+        # macOS-latest is ARM and slow at torch CPU ops; the Linux `test`
+        # job above already exercises the full pytest matrix. We just
+        # need to prove `pip install torchgeo-bench` works end-to-end on
+        # macOS without the [cuda] extra, that `faiss` (the CPU wheel
+        # this PR makes the default) imports cleanly, and that KNN
+        # actually round-trips.
         run: |
-          uv run python -c "import torchgeo_bench, faiss; print('import OK', faiss.__version__)"
-          uv run pytest tests/test_main_fast.py tests/test_multilabel.py -v --no-cov
+          uv run python -c "
+          import faiss, numpy as np, torchgeo_bench
+          from torchgeo_bench.knn import KNNClassifier
+          print('imports OK; faiss', faiss.__version__)
+          rng = np.random.default_rng(0)
+          X = rng.standard_normal((50, 8)).astype(np.float32)
+          y = rng.integers(0, 3, size=50)
+          clf = KNNClassifier(n_neighbors=3, device='cpu').fit(X, y)
+          pred = clf.predict(X[:5])
+          assert pred.shape == (5,), pred.shape
+          print('KNN round-trip OK:', pred)
+          "
 
   pre-commit:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,8 +41,18 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 
-  macos-smoke:
-    runs-on: macos-latest
+  # Prove the default install works on Linux, macOS and Windows. This is
+  # the whole point of moving faiss-cuda-cu128 (Linux-only wheels) into the
+  # [cuda] extra: `pip install torchgeo-bench` must resolve and import on
+  # all three OSes, with faiss-cpu (which ships wheels for each) as the
+  # default. The full pytest matrix runs on Linux in the `test` job above.
+  install:
+    name: install (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: read
     steps:
@@ -53,33 +63,17 @@ jobs:
       - uses: astral-sh/setup-uv@v8.0.0
         with:
           enable-cache: true
-      - name: Cache .venv
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-py3.13-${{ hashFiles('uv.lock') }}-dev
-      - name: Install dependencies (CPU only, no [cuda] extra)
-        run: uv sync --extra dev --frozen
-      - name: Smoke test (import + tiny KNN round-trip)
-        # macOS-latest is ARM and slow at torch CPU ops; the Linux `test`
-        # job above already exercises the full pytest matrix. We just
-        # need to prove `pip install torchgeo-bench` works end-to-end on
-        # macOS without the [cuda] extra, that `faiss` (the CPU wheel
-        # this PR makes the default) imports cleanly, and that KNN
-        # actually round-trips.
-        run: |
-          uv run python -c "
-          import faiss, numpy as np, torchgeo_bench
-          from torchgeo_bench.knn import KNNClassifier
-          print('imports OK; faiss', faiss.__version__)
-          rng = np.random.default_rng(0)
-          X = rng.standard_normal((50, 8)).astype(np.float32)
-          y = rng.integers(0, 3, size=50)
-          clf = KNNClassifier(n_neighbors=3, device='cpu').fit(X, y)
-          pred = clf.predict(X[:5])
-          assert pred.shape == (5,), pred.shape
-          print('KNN round-trip OK:', pred)
-          "
+      # No `.venv` cache here: this job exists to prove a from-scratch
+      # install works, so we want `uv sync` to actually run each time.
+      # setup-uv's wheel cache keeps it fast without faking the install.
+      # No `--extra`, so only the default (CPU) dependency set is installed.
+      - name: Install (CPU only, no [cuda] extra)
+        run: uv sync --frozen
+      - name: Smoke test (CLI entry point)
+        # `torchgeo-bench --help` proves the package installed, the console
+        # script is wired up, and the import graph loads on this OS — the
+        # cross-platform signal this matrix exists to provide.
+        run: uv run torchgeo-bench --help
 
   pre-commit:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,6 +41,31 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 
+  macos-smoke:
+    runs-on: macos-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - uses: astral-sh/setup-uv@v8.0.0
+        with:
+          enable-cache: true
+      - name: Cache .venv
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-py3.13-${{ hashFiles('uv.lock') }}-dev
+      - name: Install dependencies (CPU only, no [cuda] extra)
+        run: uv sync --extra dev --frozen
+      - name: Run tests
+        # macOS runners are ARM. Some tests (model_profile pynvml,
+        # faissknn GPU paths) auto-skip without CUDA / NVML; that's
+        # expected and fine.
+        run: uv run pytest -n auto --dist=loadfile --no-cov
+
   pre-commit:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,8 +19,6 @@ jobs:
       - uses: astral-sh/setup-uv@v8.0.0
         with:
           enable-cache: true
-      # Cache `.venv` keyed on uv.lock + python version + OS so unchanged
-      # locks make `uv sync --frozen` a near-no-op.
       - name: Cache .venv
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
@@ -29,8 +27,6 @@ jobs:
       - name: Install dependencies
         run: uv sync --extra dev --extra id --extra olmoearth --frozen
       - name: Run tests
-        # `-n auto` parallelises across CPUs; `--dist=loadfile` groups tests
-        # by file so heavy per-file fixtures aren't repeated across workers.
         run: uv run pytest -n auto --dist=loadfile --cov=torchgeo_bench --cov-report=xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
@@ -39,9 +35,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 
-  # Prove the default (CPU-only) install resolves and imports on Linux and
-  # macOS — the point of keeping faiss-cuda-cu128 in the [cuda] extra.
-  # Windows is unsupported; the full pytest suite runs on Linux above.
+  # Prove the default CPU-only install works on Linux and macOS.
   install:
     name: install (${{ matrix.os }})
     strategy:
@@ -59,14 +53,9 @@ jobs:
       - uses: astral-sh/setup-uv@v8.0.0
         with:
           enable-cache: true
-      # No `.venv` cache: this job exists to prove a from-scratch install
-      # works. setup-uv's wheel cache keeps it fast.
-      # No `--extra`, so only the default (CPU) dependency set is installed.
       - name: Install (CPU only, no [cuda] extra)
         run: uv sync --frozen
       - name: Smoke test (CLI entry point)
-        # `torchgeo-bench --help` proves the package installed, the console
-        # script is wired up, and the import graph loads on this OS.
         run: uv run torchgeo-bench --help
 
   pre-commit:
@@ -88,8 +77,6 @@ jobs:
           key: venv-${{ runner.os }}-py3.13-${{ hashFiles('uv.lock') }}-dev-id
       - name: Install dependencies
         run: uv sync --extra dev --extra id --frozen
-      # Cache pre-commit hook environments, keyed on the pinned hook
-      # revisions in .pre-commit-config.yaml.
       - name: Cache pre-commit hooks
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,11 +60,16 @@ jobs:
           key: venv-${{ runner.os }}-py3.13-${{ hashFiles('uv.lock') }}-dev
       - name: Install dependencies (CPU only, no [cuda] extra)
         run: uv sync --extra dev --frozen
-      - name: Run tests
-        # macOS runners are ARM. Some tests (model_profile pynvml,
-        # faissknn GPU paths) auto-skip without CUDA / NVML; that's
-        # expected and fine.
-        run: uv run pytest -n auto --dist=loadfile --no-cov
+      - name: Smoke test (import + KNN + main entrypoint)
+        # macOS-latest is ARM. We only need to prove that the default
+        # install works without the [cuda] extra and that the core
+        # CPU code paths import cleanly. A full pytest run on macOS
+        # ARM is very slow (~30+ min on a cold cache) and adds no
+        # signal over the Linux `test` job above, so we restrict to
+        # a focused subset.
+        run: |
+          uv run python -c "import torchgeo_bench, faiss; print('import OK', faiss.__version__)"
+          uv run pytest tests/test_main_fast.py tests/test_multilabel.py -v --no-cov
 
   pre-commit:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ For GPU-accelerated KNN (Linux + CUDA 12 + glibc ≥ 2.28):
 pip install 'torchgeo-bench[cuda]'
 ```
 
-Requires Python 3.12+.
+Requires Python 3.12+. Supported on **Linux** and **macOS**. Windows is not
+supported — on Windows, install inside [WSL2](https://learn.microsoft.com/windows/wsl/).
 
 ## Download a dataset
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ cd torchgeo-bench
 uv sync --extra dev
 ```
 
+For GPU-accelerated KNN (Linux + CUDA 12 + glibc ≥ 2.28):
+
+```bash
+pip install 'torchgeo-bench[cuda]'
+```
+
 Requires Python 3.12+.
 
 ## Download a dataset

--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -7,6 +7,12 @@ canonical workflow.
 
 .. _uv: https://docs.astral.sh/uv/
 
+.. note::
+
+   ``torchgeo-bench`` is supported on **Linux** and **macOS**.  Windows is
+   not supported; on Windows, install inside `WSL2
+   <https://learn.microsoft.com/windows/wsl/>`_.
+
 uv (recommended)
 ----------------
 

--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -19,6 +19,12 @@ development dependencies:
    $ cd torchgeo-bench
    $ uv sync --extra dev
 
+For GPU-accelerated KNN (Linux + CUDA 12 + glibc ≥ 2.28):
+
+.. code-block:: console
+
+   $ pip install 'torchgeo-bench[cuda]'
+
 The ``torchgeo-bench`` console script is then available via ``uv run``:
 
 .. code-block:: console

--- a/docs/user/results-format.rst
+++ b/docs/user/results-format.rst
@@ -99,10 +99,9 @@ Atomic appends
 --------------
 
 Rows are appended via :func:`~torchgeo_bench.main.append_rows_atomic`,
-which uses a cross-process advisory lock (via ``filelock``, which is
-``fcntl`` on POSIX and ``msvcrt`` on Windows).  This makes it safe to
-point multiple parallel jobs (e.g. one per GPU or per dataset) at the
-same output file without corrupting it.
+which uses ``fcntl`` advisory file locking (available on Linux and
+macOS).  This makes it safe to point multiple parallel jobs (e.g. one
+per GPU or per dataset) at the same output file without corrupting it.
 
 Resume mode
 -----------

--- a/docs/user/results-format.rst
+++ b/docs/user/results-format.rst
@@ -99,9 +99,10 @@ Atomic appends
 --------------
 
 Rows are appended via :func:`~torchgeo_bench.main.append_rows_atomic`,
-which uses ``fcntl`` advisory file locking.  This makes it safe to point
-multiple parallel jobs (e.g. one per GPU or per dataset) at the same
-output file without corrupting it.
+which uses a cross-process advisory lock (via ``filelock``, which is
+``fcntl`` on POSIX and ``msvcrt`` on Windows).  This makes it safe to
+point multiple parallel jobs (e.g. one per GPU or per dataset) at the
+same output file without corrupting it.
 
 Resume mode
 -----------

--- a/experiments/scripts/slurm/slow_tests.sh
+++ b/experiments/scripts/slurm/slow_tests.sh
@@ -19,8 +19,9 @@ VENV=${TGB_VENV:-$SLURM_SUBMIT_DIR/.venv}
 # shellcheck disable=SC1091
 source "$VENV/bin/activate"
 
-# faiss-cpu and faiss-cuda share the faiss/ Python namespace.  When both are
-# present, _loader.py prefers faiss-cpu's CPU-only AVX2 .abi3.so and hides
+# faiss-cpu is installed by default, and the [cuda] extra adds faiss-cuda.
+# Both wheels share the faiss/ Python namespace.  When both are present,
+# _loader.py prefers faiss-cpu's CPU-only AVX2 .abi3.so and hides
 # StandardGpuResources.  Fix: remove faiss-cpu, then reinstall faiss-cuda so
 # its Python files (shared with faiss-cpu) are restored.
 FAISS_CUDA_WHEEL="${SLURM_SUBMIT_DIR}/../faiss-cuda/wheelhouse/faiss_cuda-1.14.1.post3-cp313-cp313-manylinux_2_34_x86_64.whl"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,8 @@ classifiers = [
   "Development Status :: 3 - Alpha",
   "Intended Audience :: Science/Research",
   "License :: OSI Approved :: MIT License",
+  "Operating System :: MacOS",
+  "Operating System :: POSIX :: Linux",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ classifiers = [
 ]
 dependencies = [
   "faiss-cpu>=1.7",
-  "filelock>=3",
   "geobenchv2>=0.9",
   "h5py>=3.8",
   "huggingface-hub>=0.20",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
   "Topic :: Scientific/Engineering :: GIS",
 ]
 dependencies = [
-  "faiss-cuda-cu128>=1.14.1.post3",
+  "faiss-cpu>=1.7",
   "geobenchv2>=0.9",
   "h5py>=3.8",
   "huggingface-hub>=0.20",
@@ -69,8 +69,13 @@ optional-dependencies.cleanlab = [
   "pillow>=9",
 ]
 optional-dependencies.cuda = [
-  # GPU-accelerated KNN via faissknn (CUDA 12.x).
-  # faiss-cuda-cu128 wheels are manylinux_2_28 (glibc >= 2.28 / RHEL8+).
+  # GPU-accelerated KNN via faissknn (CUDA 12.x). faiss-cuda-cu128
+  # wheels are manylinux_2_28 (glibc >= 2.28 / RHEL8+). Both packages
+  # share the `faiss/` namespace; installing this extra into a venv
+  # that already has faiss-cpu will result in faiss-cpu's loader
+  # winning. Either start from a fresh venv or `pip uninstall
+  # faiss-cpu` first.
+  "faiss-cuda-cu128>=1.14.1.post3",
   "faissknn>=0.0.3",
 ]
 optional-dependencies.dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ classifiers = [
 ]
 dependencies = [
   "faiss-cpu>=1.7",
+  "filelock>=3",
   "geobenchv2>=0.9",
   "h5py>=3.8",
   "huggingface-hub>=0.20",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,12 +69,8 @@ optional-dependencies.cleanlab = [
   "pillow>=9",
 ]
 optional-dependencies.cuda = [
-  # GPU-accelerated KNN via faissknn (CUDA 12.x). faiss-cuda-cu128
-  # wheels are manylinux_2_28 (glibc >= 2.28 / RHEL8+). Both packages
-  # share the `faiss/` namespace; installing this extra into a venv
-  # that already has faiss-cpu will result in faiss-cpu's loader
-  # winning. Either start from a fresh venv or `pip uninstall
-  # faiss-cpu` first.
+  # GPU-accelerated KNN (Linux, glibc >= 2.28). Conflicts with faiss-cpu in
+  # the same venv; install from a fresh venv or uninstall faiss-cpu first.
   "faiss-cuda-cu128>=1.14.1.post3",
   "faissknn>=0.0.3",
 ]

--- a/src/torchgeo_bench/knn.py
+++ b/src/torchgeo_bench/knn.py
@@ -2,10 +2,10 @@
 
 Single-label and multi-label k-nearest neighbours backed by FAISS.
 
-CPU path uses ``faiss-cuda-cu128`` with ``IndexFlatL2``. GPU path (opt-in
-via the ``cuda`` extra: ``pip install -e ".[cuda]"``) delegates to
-:mod:`faissknn`. The two paths produce identical predictions modulo
-float-precision noise.
+CPU path uses ``faiss-cpu`` with ``IndexFlatL2`` (or ``faiss-cuda-cu128``'s
+CPU index when the ``cuda`` extra is installed). GPU path (opt-in via the
+``cuda`` extra: ``pip install -e ".[cuda]"``) delegates to :mod:`faissknn`.
+The two paths produce identical predictions modulo float-precision noise.
 """
 
 import logging
@@ -34,9 +34,10 @@ class KNNClassifier:
     Args:
         n_neighbors: Number of neighbours (k). Clamped to ``min(k, n_train)``
             on the CPU path; faissknn does not clamp internally.
-        device: ``"cpu"`` (default) → ``faiss-cuda-cu128`` CPU index. Anything else
-            (``"cuda"``, ``"cuda:0"``) requires the ``cuda`` extra
-            (``faissknn``); raises :class:`ImportError` if not installed.
+        device: ``"cpu"`` (default) → ``faiss-cpu`` (or ``faiss-cuda-cu128``'s CPU
+            index when the ``cuda`` extra is installed). Anything else (``"cuda"``,
+            ``"cuda:0"``) requires the ``cuda`` extra (``faissknn``); raises
+            :class:`ImportError` if not installed.
         metric: Distance metric — ``"l2"`` (default), ``"ip"`` (inner
             product), or ``"cosine"`` (cosine similarity; auto-normalizes
             inputs). GPU path only; CPU path always uses L2.

--- a/src/torchgeo_bench/main.py
+++ b/src/torchgeo_bench/main.py
@@ -1,5 +1,6 @@
 """Benchmark script for torchgeo-bench."""
 
+import fcntl
 import io
 import logging
 import os
@@ -12,7 +13,6 @@ import hydra
 import numpy as np
 import pandas as pd
 import torch
-from filelock import FileLock
 from hydra.utils import instantiate
 from omegaconf import DictConfig, OmegaConf
 from rich.progress import track
@@ -830,13 +830,14 @@ def append_rows_atomic(path: str, rows: list[dict]) -> None:
         return
     df_local = pd.DataFrame(rows)
     # Serialise concurrent writers (e.g. SLURM array jobs appending to a
-    # shared results CSV) with a cross-process advisory lock so their
-    # read-modify-write cycles don't interleave and drop rows. filelock is
-    # cross-platform (fcntl on POSIX, msvcrt on Windows) and already in the
-    # dependency tree, so this behaves identically on Linux/macOS/Windows.
-    with FileLock(f"{path}.lock"):
-        fd = os.open(path, os.O_RDWR | os.O_CREAT)
-        with os.fdopen(fd, "r+", closefd=True) as f:
+    # shared results CSV) with a POSIX advisory lock so their
+    # read-modify-write cycles don't interleave and drop rows. fcntl is
+    # available on Linux and macOS; Windows is not a supported platform
+    # (see docs/user/installation.rst).
+    fd = os.open(path, os.O_RDWR | os.O_CREAT)
+    with os.fdopen(fd, "r+", closefd=True) as f:
+        fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+        try:
             f.seek(0, os.SEEK_END)
             empty = f.tell() == 0
             buf = io.StringIO()
@@ -870,6 +871,8 @@ def append_rows_atomic(path: str, rows: list[dict]) -> None:
                     f.write(buf.getvalue())
             f.flush()
             os.fsync(f.fileno())
+        finally:
+            fcntl.flock(f.fileno(), fcntl.LOCK_UN)
 
 
 @hydra.main(config_path="conf", config_name="config", version_base=None)

--- a/src/torchgeo_bench/main.py
+++ b/src/torchgeo_bench/main.py
@@ -829,11 +829,7 @@ def append_rows_atomic(path: str, rows: list[dict]) -> None:
     if not rows:
         return
     df_local = pd.DataFrame(rows)
-    # Serialise concurrent writers (e.g. SLURM array jobs appending to a
-    # shared results CSV) with a POSIX advisory lock so their
-    # read-modify-write cycles don't interleave and drop rows. fcntl is
-    # available on Linux and macOS; Windows is not a supported platform
-    # (see docs/user/installation.rst).
+    # fcntl advisory locking is Unix-only (Linux + macOS); Windows is unsupported.
     fd = os.open(path, os.O_RDWR | os.O_CREAT)
     with os.fdopen(fd, "r+", closefd=True) as f:
         fcntl.flock(f.fileno(), fcntl.LOCK_EX)

--- a/src/torchgeo_bench/main.py
+++ b/src/torchgeo_bench/main.py
@@ -1,6 +1,5 @@
 """Benchmark script for torchgeo-bench."""
 
-import fcntl
 import io
 import logging
 import os
@@ -13,6 +12,7 @@ import hydra
 import numpy as np
 import pandas as pd
 import torch
+from filelock import FileLock
 from hydra.utils import instantiate
 from omegaconf import DictConfig, OmegaConf
 from rich.progress import track
@@ -829,10 +829,14 @@ def append_rows_atomic(path: str, rows: list[dict]) -> None:
     if not rows:
         return
     df_local = pd.DataFrame(rows)
-    fd = os.open(path, os.O_RDWR | os.O_CREAT)
-    with os.fdopen(fd, "r+", closefd=True) as f:
-        fcntl.flock(f.fileno(), fcntl.LOCK_EX)
-        try:
+    # Serialise concurrent writers (e.g. SLURM array jobs appending to a
+    # shared results CSV) with a cross-process advisory lock so their
+    # read-modify-write cycles don't interleave and drop rows. filelock is
+    # cross-platform (fcntl on POSIX, msvcrt on Windows) and already in the
+    # dependency tree, so this behaves identically on Linux/macOS/Windows.
+    with FileLock(f"{path}.lock"):
+        fd = os.open(path, os.O_RDWR | os.O_CREAT)
+        with os.fdopen(fd, "r+", closefd=True) as f:
             f.seek(0, os.SEEK_END)
             empty = f.tell() == 0
             buf = io.StringIO()
@@ -866,8 +870,6 @@ def append_rows_atomic(path: str, rows: list[dict]) -> None:
                     f.write(buf.getvalue())
             f.flush()
             os.fsync(f.fileno())
-        finally:
-            fcntl.flock(f.fileno(), fcntl.LOCK_UN)
 
 
 @hydra.main(config_path="conf", config_name="config", version_base=None)

--- a/uv.lock
+++ b/uv.lock
@@ -723,6 +723,24 @@ wheels = [
 ]
 
 [[package]]
+name = "faiss-cpu"
+version = "1.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "packaging" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/8b/5d2cd7c9fd60bc4d1ca6e9f5e8b0eb57254a7b301daaa12d5853fdf48afe/faiss_cpu-1.14.2-cp310-abi3-macosx_14_0_arm64.whl", hash = "sha256:a20011b8a97318e6d5e29143a773277ca71f1c33140024aeec91f05ad56cdd04", size = 4621203, upload-time = "2026-05-22T19:58:27.415Z" },
+    { url = "https://files.pythonhosted.org/packages/84/b1/05876aa7ceafd67a8c53667f574c0354e50ebadfdaf0632d7d9f5c80fffe/faiss_cpu-1.14.2-cp310-abi3-macosx_15_0_x86_64.whl", hash = "sha256:6ba528b5803fe5206bbb38e6ea2c537de0d1482a47c5765982af4e4a48c135e2", size = 6681426, upload-time = "2026-05-22T19:58:29.193Z" },
+    { url = "https://files.pythonhosted.org/packages/35/b4/d130a1908ad548671cd5ee9a1b537c7d3753cfdf0b2b134f3c10ccc6b537/faiss_cpu-1.14.2-cp310-abi3-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b340c33212351f04d4f167cb7b22c9e756705a634d3b7b58987651f3ba1f6217", size = 9592827, upload-time = "2026-05-22T19:58:30.772Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/66/108f7075591b84852a6b285a81922e773c1c6d3b2c45da8ec4822f1bfab4/faiss_cpu-1.14.2-cp310-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ec4784d9a14973f2eead3a3480e6d14e74253b234e2c12717d4319f21dfadfcd", size = 18234781, upload-time = "2026-05-22T19:58:33.268Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/42/af4df8012e0ed817df2c4094a816b538d99bfbbcbf567cd9f5f36d5fb9b4/faiss_cpu-1.14.2-cp312-cp312-win_amd64.whl", hash = "sha256:292124ba3d2bbeed920ef8519451cfba0f139b77db1607170cffbe68dc72e604", size = 16115701, upload-time = "2026-05-22T19:58:41.85Z" },
+    { url = "https://files.pythonhosted.org/packages/60/04/555551ceec73248e76b758014a6fba702349824270be27d0e5db1f740feb/faiss_cpu-1.14.2-cp313-cp313-win_amd64.whl", hash = "sha256:d81857f1fcf6c5dc76f75b35112158f731aeb7804ca971c51d74edf6e9b1b8c7", size = 16116212, upload-time = "2026-05-22T19:58:45.154Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/59/ff73cb48bd1a98a355ff5a6a2018f3cfe4980ec2196b4938bf8af4fb828b/faiss_cpu-1.14.2-cp314-cp314-win_amd64.whl", hash = "sha256:b736813d853d36693f7b5affdc8788adfa73efa2f45ac6493c8ce2cbb2584f19", size = 16394291, upload-time = "2026-05-22T19:58:48.062Z" },
+]
+
+[[package]]
 name = "faiss-cuda-cu128"
 version = "1.14.1.post3"
 source = { registry = "https://pypi.org/simple" }
@@ -3898,7 +3916,7 @@ name = "torchgeo-bench"
 version = "0.3.0"
 source = { editable = "." }
 dependencies = [
-    { name = "faiss-cuda-cu128" },
+    { name = "faiss-cpu" },
     { name = "geobenchv2" },
     { name = "h5py" },
     { name = "huggingface-hub" },
@@ -3919,6 +3937,7 @@ dependencies = [
 [package.optional-dependencies]
 all = [
     { name = "cleanlab" },
+    { name = "faiss-cuda-cu128" },
     { name = "faissknn" },
     { name = "imagehash" },
     { name = "linkify-it-py" },
@@ -3947,6 +3966,7 @@ cleanlab = [
     { name = "pillow" },
 ]
 cuda = [
+    { name = "faiss-cuda-cu128" },
     { name = "faissknn" },
 ]
 dev = [
@@ -3988,7 +4008,8 @@ viz = [
 [package.metadata]
 requires-dist = [
     { name = "cleanlab", marker = "extra == 'cleanlab'", specifier = ">=2.7" },
-    { name = "faiss-cuda-cu128", specifier = ">=1.14.1.post3" },
+    { name = "faiss-cpu", specifier = ">=1.7" },
+    { name = "faiss-cuda-cu128", marker = "extra == 'cuda'", specifier = ">=1.14.1.post3" },
     { name = "faissknn", marker = "extra == 'cuda'", specifier = ">=0.0.3" },
     { name = "geobenchv2", specifier = ">=0.9" },
     { name = "h5py", specifier = ">=3.8" },

--- a/uv.lock
+++ b/uv.lock
@@ -3917,7 +3917,6 @@ version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "faiss-cpu" },
-    { name = "filelock" },
     { name = "geobenchv2" },
     { name = "h5py" },
     { name = "huggingface-hub" },
@@ -4012,7 +4011,6 @@ requires-dist = [
     { name = "faiss-cpu", specifier = ">=1.7" },
     { name = "faiss-cuda-cu128", marker = "extra == 'cuda'", specifier = ">=1.14.1.post3" },
     { name = "faissknn", marker = "extra == 'cuda'", specifier = ">=0.0.3" },
-    { name = "filelock", specifier = ">=3" },
     { name = "geobenchv2", specifier = ">=0.9" },
     { name = "h5py", specifier = ">=3.8" },
     { name = "huggingface-hub", specifier = ">=0.20" },

--- a/uv.lock
+++ b/uv.lock
@@ -3917,6 +3917,7 @@ version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "faiss-cpu" },
+    { name = "filelock" },
     { name = "geobenchv2" },
     { name = "h5py" },
     { name = "huggingface-hub" },
@@ -4011,6 +4012,7 @@ requires-dist = [
     { name = "faiss-cpu", specifier = ">=1.7" },
     { name = "faiss-cuda-cu128", marker = "extra == 'cuda'", specifier = ">=1.14.1.post3" },
     { name = "faissknn", marker = "extra == 'cuda'", specifier = ">=0.0.3" },
+    { name = "filelock", specifier = ">=3" },
     { name = "geobenchv2", specifier = ">=0.9" },
     { name = "h5py", specifier = ">=3.8" },
     { name = "huggingface-hub", specifier = ">=0.20" },


### PR DESCRIPTION
Fixes #107.

`faiss-cuda-cu128` was a hard dependency, but it only ships wheels for `manylinux_2_27_x86_64` / `manylinux_2_28_x86_64`. That broke `pip install torchgeo-bench` on macOS, Linux with glibc < 2.28, and Linux ARM.

This PR makes the default install portable across **Linux and macOS** and moves the GPU stack into a `[cuda]` extra. **Windows is explicitly not supported** — per the two options in #107, rather than ship an untested claim of Windows support we document Linux + macOS as the supported platforms and point Windows users at WSL2.

### Changes

- `pyproject.toml`:
  - main `dependencies`: drop `faiss-cuda-cu128`, add `faiss-cpu>=1.7`
  - `optional-dependencies.cuda`: installs `faiss-cuda-cu128` alongside `faissknn`
- `uv.lock`: regenerated.
- `src/torchgeo_bench/knn.py`: docstrings refreshed (no code change — `import faiss` works for both packages).
- `src/torchgeo_bench/main.py`: `append_rows_atomic` uses `fcntl.flock` (POSIX advisory locking — Linux + macOS).
- `README.md` / `docs/user/installation.rst`: added the `[cuda]` install note and documented that only Linux + macOS are supported (Windows → WSL2).
- `.github/workflows/ci.yaml`: added an `install` job that proves the default (CPU-only) install + `torchgeo-bench --help` smoke test on `ubuntu-latest` and `macos-latest`.

### Behavioural impact

- **CPU users (Linux/macOS)**: same behaviour. `faiss-cpu` provides `IndexFlatL2`, the only faiss class the CPU path uses.
- **GPU users**: must now `pip install 'torchgeo-bench[cuda]'`. The existing `experiments/scripts/slurm/slow_tests.sh` already does this dance, so no SLURM job needs to change.
- **Windows users**: unsupported; use WSL2.

### Verification

- `uv sync` (default extras) + `torchgeo-bench --help` succeed on Linux.
- `pytest tests/test_append_rows_atomic.py` passes (7/7) against the `fcntl` path.
- `uv lock` succeeds; `faiss-cpu` is the only direct faiss dep, `faiss-cuda-cu128` is confined to the `cuda` extra, and `filelock` is no longer a dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
