### PR TITLE
Restructure Docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,6 +38,7 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
     "sphinx_copybutton",
+    "sphinx_design",
 ]
 
 # Files / directories the builder should ignore.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@ torchgeo-bench
 ==============
 
 A lightweight benchmarking framework for frozen geospatial foundation models.
-Evaluate any backbone on GeoBench V1 / V2 in minutes — choose your path below.
+Choose your path below.
 
 .. grid:: 3
 
@@ -12,7 +12,7 @@ Evaluate any backbone on GeoBench V1 / V2 in minutes — choose your path below.
       :link: user/quickstart
       :link-type: doc
 
-      Evaluate any frozen backbone on GeoBench V1 / V2 in minutes.
+      Evaluate any frozen backbone on GeoBench V1 / V2.
 
    .. grid-item-card:: Bring your own model
       :link: user/eval_own_model

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,17 +1,30 @@
 .. module:: torchgeo_bench
 
-.. The README is included in two parts so the docs-landing page can skip
-   the redundant "Learn more" section (its primary "Documentation" link
-   would just self-redirect here).  The HTML-comment markers in
-   README.md are invisible on GitHub.
+torchgeo-bench
+==============
 
-.. include:: ../README.md
-   :parser: myst_parser.sphinx_
-   :end-before: <!-- skip-on-docs-landing-start -->
+A lightweight benchmarking framework for frozen geospatial foundation models.
+Evaluate any backbone on GeoBench V1 / V2 in minutes — choose your path below.
 
-.. include:: ../README.md
-   :parser: myst_parser.sphinx_
-   :start-after: <!-- skip-on-docs-landing-end -->
+.. grid:: 3
+
+   .. grid-item-card:: Benchmark a model
+      :link: user/quickstart
+      :link-type: doc
+
+      Evaluate any frozen backbone on GeoBench V1 / V2 in minutes.
+
+   .. grid-item-card:: Bring your own model
+      :link: user/eval_own_model
+      :link-type: doc
+
+      Implement ``BenchModel`` and run your pretrained GeoFM against the full suite.
+
+   .. grid-item-card:: Add a dataset
+      :link: user/contribute_dataset
+      :link-type: doc
+
+      Wire a new geospatial dataset into the benchmark and generate results.
 
 .. toctree::
    :maxdepth: 2
@@ -19,4 +32,3 @@
 
    user/index
    api/index
-   interesting-findings

--- a/docs/interesting-findings.md
+++ b/docs/interesting-findings.md
@@ -1,3 +1,7 @@
+---
+orphan: true
+---
+
 # Interesting findings
 
 Running notes on things we've noticed during torchgeo-bench sweeps that

--- a/docs/user/contribute_dataset.rst
+++ b/docs/user/contribute_dataset.rst
@@ -1,0 +1,108 @@
+Add a Dataset
+=============
+
+This page explains how to wire a new geospatial dataset into torchgeo-bench
+so that any registered model can be evaluated on it automatically.
+
+Prerequisites
+-------------
+
+Clone the repository and install the development dependencies:
+
+.. code-block:: console
+
+   $ git clone https://github.com/torchgeo/torchgeo-bench.git
+   $ cd torchgeo-bench
+   $ conda activate torchgeo-bench
+   $ uv sync --extra dev
+
+This is the same setup used in :doc:`eval_own_model`.  Download the dataset
+files so you can test loading locally:
+
+.. code-block:: console
+
+   $ torchgeo-bench download <dataset_name>
+
+Implement BenchDataset
+----------------------
+
+Create a new module under :file:`src/torchgeo_bench/datasets/` and subclass
+:class:`~torchgeo_bench.datasets.base.BenchDataset`:
+
+.. code-block:: python
+
+   from torchgeo_bench.datasets.base import BenchDataset, BandSpec
+
+   class MyDataset(BenchDataset):
+       name = "my_dataset"
+       task = "classification"        # or "segmentation"
+       num_classes = 10
+       bands: list[BandSpec] = [...]
+       split_sizes = {"train": 5000, "val": 1000, "test": 2000}
+
+       def get_dataset(self, split: str, bands) -> torch.utils.data.Dataset:
+           ...  # return a Dataset yielding (image_tensor, label) pairs
+
+Required class-level attributes:
+
+* ``name`` — unique string identifier used by the Hydra registry and CLI
+* ``task`` — ``"classification"`` or ``"segmentation"``
+* ``num_classes`` — integer label count
+* ``bands`` — list of :class:`~torchgeo_bench.datasets.base.BandSpec` objects
+  supplying per-channel sensor / wavelength / normalisation stats
+* ``split_sizes`` — dict with ``train``, ``val``, and ``test`` keys
+
+The ``get_dataset`` method must accept ``split`` (``"train"``, ``"val"``, or
+``"test"``) and ``bands`` (the subset of bands requested by the model), and
+return a :class:`torch.utils.data.Dataset` whose ``__getitem__`` yields
+``(image_tensor, label)`` pairs.
+
+.. note::
+
+   **V1 vs V2 loader patterns.** V1 datasets (``m-`` prefix) read images
+   directly from HDF5 files via
+   :class:`~torchgeo_bench.datasets.geobench_v1._V1Dataset`.  V2 datasets use
+   torchgeo dataset classes as the underlying loader and inherit from
+   :class:`~torchgeo_bench.datasets.geobench_v2._V2Dataset`.  When adding a
+   genuinely new dataset, prefer the V2 torchgeo pattern so the loader can
+   participate in torchgeo's transform pipeline.
+
+Register and configure
+----------------------
+
+**1. Export the class** from :file:`src/torchgeo_bench/datasets/__init__.py`:
+
+.. code-block:: python
+
+   from .my_dataset import MyDataset
+
+**2. Add a Hydra dataset config YAML** under
+:file:`src/torchgeo_bench/conf/dataset/` named after your dataset
+(e.g. :file:`my_dataset.yaml`):
+
+.. code-block:: yaml
+
+   # @package _global_
+   defaults:
+     - base_dataset
+
+   dataset:
+     name: my_dataset
+     num_classes: 10
+     task: classification
+
+Adjust keys as needed; see existing configs in that directory for reference.
+
+Run the smoke test
+------------------
+
+With the dataset on disk, run a quick benchmark to verify the dataset loads
+and produces sensible results:
+
+.. code-block:: console
+
+   $ torchgeo-bench run model=timm/resnet50 dataset.names=[my_dataset] \
+       eval.skip_linear=true eval.bootstrap=10
+
+Once results look sensible, follow the PR workflow described in
+:doc:`contribute_model` to open a pull request.

--- a/docs/user/index.rst
+++ b/docs/user/index.rst
@@ -6,20 +6,37 @@ installing the framework, running your first benchmark, configuring datasets
 and models, and interpreting the results.
 
 .. toctree::
+   :caption: Getting Started
    :maxdepth: 2
 
    installation
    quickstart
+
+.. toctree::
+   :caption: User Guide
+   :maxdepth: 2
+
    datasets
    models
-   eval_own_model
-   contribute_model
    configuration
    results-format
    results-explorer
    methodology
    segmentation-layers
+
+.. toctree::
+   :caption: Contributing
+   :maxdepth: 2
+
+   eval_own_model
+   contribute_model
+   contribute_dataset
    contributing
-   troubleshooting
+
+.. toctree::
+   :caption: Reference
+   :maxdepth: 2
+
    glossary
+   troubleshooting
    changelog

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ optional-dependencies.docs = [
   "pydata-sphinx-theme>=0.15",
   "sphinx>=7",
   "sphinx-copybutton>=0.5",
+  "sphinx-design>=0.5",
 ]
 optional-dependencies.id = [
   "torchid>=0.3; python_version>='3.13'",


### PR DESCRIPTION
This PR restructures the docs page to have a more appealing landing page and also give some hierarchical structure to docs based on the assumption that we mainly have three user groups:

1. Benchmark any frozen encoder available in torchgeo-bench with the existing datasets
2. Implementing your ned Model and benchmarking on the existing datasets to compare to existing leaderboard
3. Have a new dataset and wanting to use all the model and benchmark logic to generate some results