### PR TITLE
deps: default to faissknn[cpu] for cross-platform CPU KNN + Windows CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,9 +8,26 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    name: test (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            extras: --extra dev --extra id --extra olmoearth
+            cache-tag: dev-id-olmoearth
+          - os: macos-latest
+            extras: --extra dev
+            cache-tag: dev
+          - os: windows-latest
+            extras: --extra dev
+            cache-tag: dev
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: read
+    env:
+      OMP_NUM_THREADS: "1"
+      KMP_DUPLICATE_LIB_OK: "TRUE"
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -19,16 +36,20 @@ jobs:
       - uses: astral-sh/setup-uv@v8.0.0
         with:
           enable-cache: true
+      - name: Enable Git long paths (Windows)
+        if: runner.os == 'Windows'
+        run: git config --global core.longpaths true
       - name: Cache .venv
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: .venv
-          key: venv-${{ runner.os }}-py3.13-${{ hashFiles('uv.lock') }}-dev-id-olmoearth
+          key: venv-${{ runner.os }}-py3.13-${{ hashFiles('uv.lock') }}-${{ matrix.cache-tag }}
       - name: Install dependencies
-        run: uv sync --extra dev --extra id --extra olmoearth --frozen
+        run: uv sync ${{ matrix.extras }} --frozen
       - name: Run tests
         run: uv run pytest -n auto --dist=loadfile --cov=torchgeo_bench --cov-report=xml
       - name: Upload coverage to Codecov
+        if: runner.os == 'Linux'
         uses: codecov/codecov-action@v5
         with:
           files: ./coverage.xml
@@ -56,14 +77,9 @@ jobs:
         if: runner.os == 'Windows'
         run: git config --global core.longpaths true
       - name: Install (CPU only, no [cuda] extra)
-        run: uv sync --extra dev --frozen
+        run: uv sync --frozen
       - name: Smoke test (CLI entry point)
         run: uv run torchgeo-bench --help
-      - name: CPU KNN tests (faiss-cpu path)
-        env:
-          OMP_NUM_THREADS: "1"
-          KMP_DUPLICATE_LIB_OK: "TRUE"
-        run: uv run pytest tests/test_multilabel.py -v
 
   pre-commit:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,8 +35,6 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 
-  # Prove the default CPU-only install (faissknn[cpu]) works on Linux, macOS,
-  # and Windows, and that the CPU KNN path actually runs on each.
   install:
     name: install (${{ matrix.os }})
     strategy:
@@ -55,8 +53,6 @@ jobs:
         with:
           enable-cache: true
       - name: Enable Git long paths (Windows)
-        # The torchgeo git dependency has paths exceeding the Windows
-        # MAX_PATH (260 char) limit; uv's git checkout fails without this.
         if: runner.os == 'Windows'
         run: git config --global core.longpaths true
       - name: Install (CPU only, no [cuda] extra)
@@ -64,10 +60,6 @@ jobs:
       - name: Smoke test (CLI entry point)
         run: uv run torchgeo-bench --help
       - name: CPU KNN tests (faiss-cpu path)
-        # faiss-cpu and torch each bundle their own libomp; on macOS arm64
-        # faiss's OpenMP-parallel search segfaults under torch's runtime.
-        # Single-threaded + allow-duplicate sidesteps the conflict (no-op on
-        # Linux/Windows).
         env:
           OMP_NUM_THREADS: "1"
           KMP_DUPLICATE_LIB_OK: "TRUE"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,13 +35,14 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 
-  # Prove the default CPU-only install works on Linux and macOS.
+  # Prove the default CPU-only install (faissknn[cpu]) works on Linux, macOS,
+  # and Windows, and that the CPU KNN path actually runs on each.
   install:
     name: install (${{ matrix.os }})
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -53,10 +54,24 @@ jobs:
       - uses: astral-sh/setup-uv@v8.0.0
         with:
           enable-cache: true
+      - name: Enable Git long paths (Windows)
+        # The torchgeo git dependency has paths exceeding the Windows
+        # MAX_PATH (260 char) limit; uv's git checkout fails without this.
+        if: runner.os == 'Windows'
+        run: git config --global core.longpaths true
       - name: Install (CPU only, no [cuda] extra)
-        run: uv sync --frozen
+        run: uv sync --extra dev --frozen
       - name: Smoke test (CLI entry point)
         run: uv run torchgeo-bench --help
+      - name: CPU KNN tests (faiss-cpu path)
+        # faiss-cpu and torch each bundle their own libomp; on macOS arm64
+        # faiss's OpenMP-parallel search segfaults under torch's runtime.
+        # Single-threaded + allow-duplicate sidesteps the conflict (no-op on
+        # Linux/Windows).
+        env:
+          OMP_NUM_THREADS: "1"
+          KMP_DUPLICATE_LIB_OK: "TRUE"
+        run: uv run pytest tests/test_multilabel.py -v
 
   pre-commit:
     runs-on: ubuntu-latest

--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -9,9 +9,8 @@ canonical workflow.
 
 .. note::
 
-   ``torchgeo-bench`` is supported on **Linux** and **macOS**.  Windows is
-   not supported; on Windows, install inside `WSL2
-   <https://learn.microsoft.com/windows/wsl/>`_.
+   The default (CPU) install runs on **Linux**, **macOS**, and **Windows**.
+   GPU-accelerated KNN (the ``[cuda]`` extra) is Linux-only.
 
 uv (recommended)
 ----------------
@@ -25,7 +24,9 @@ development dependencies:
    $ cd torchgeo-bench
    $ uv sync --extra dev
 
-For GPU-accelerated KNN (Linux + CUDA 12 + glibc ≥ 2.28):
+The default install pulls in ``faissknn[cpu]`` (CPU FAISS), which works on
+all three platforms.  For GPU-accelerated KNN (Linux + CUDA 12 + glibc ≥ 2.28),
+which swaps in ``faissknn[cuda]``:
 
 .. code-block:: console
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
   "Intended Audience :: Science/Research",
   "License :: OSI Approved :: MIT License",
   "Operating System :: MacOS",
+  "Operating System :: Microsoft :: Windows",
   "Operating System :: POSIX :: Linux",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.12",
@@ -36,7 +37,9 @@ classifiers = [
   "Topic :: Scientific/Engineering :: GIS",
 ]
 dependencies = [
-  "faiss-cpu>=1.7",
+  # CPU KNN, cross-platform (macOS/Windows/Linux). Pulls faiss-cpu transitively
+  # and always makes faissknn importable. The [cuda] extra swaps in faiss-cuda.
+  "faissknn[cpu]>=0.3",
   "geobenchv2>=0.9",
   "h5py>=3.8",
   "huggingface-hub>=0.20",
@@ -70,10 +73,10 @@ optional-dependencies.cleanlab = [
   "pillow>=9",
 ]
 optional-dependencies.cuda = [
-  # GPU-accelerated KNN (Linux, glibc >= 2.28). Conflicts with faiss-cpu in
-  # the same venv; install from a fresh venv or uninstall faiss-cpu first.
-  "faiss-cuda-cu128>=1.14.1.post3",
-  "faissknn>=0.0.3",
+  # GPU-accelerated KNN (Linux, glibc >= 2.28). Swaps faiss-cpu for
+  # faiss-cuda-cu128 via faissknn's [cuda] extra. Install from a fresh venv
+  # or uninstall faiss-cpu first to avoid the two faiss builds clashing.
+  "faissknn[cuda]>=0.3",
 ]
 optional-dependencies.dev = [
   "mdformat>=0.7.22",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,9 +37,8 @@ classifiers = [
   "Topic :: Scientific/Engineering :: GIS",
 ]
 dependencies = [
-  # CPU KNN, cross-platform (macOS/Windows/Linux). Pulls faiss-cpu transitively
-  # and always makes faissknn importable. The [cuda] extra swaps in faiss-cuda.
   "faissknn[cpu]>=0.3",
+  "filelock>=3.12",
   "geobenchv2>=0.9",
   "h5py>=3.8",
   "huggingface-hub>=0.20",
@@ -73,9 +72,6 @@ optional-dependencies.cleanlab = [
   "pillow>=9",
 ]
 optional-dependencies.cuda = [
-  # GPU-accelerated KNN (Linux, glibc >= 2.28). Swaps faiss-cpu for
-  # faiss-cuda-cu128 via faissknn's [cuda] extra. Install from a fresh venv
-  # or uninstall faiss-cpu first to avoid the two faiss builds clashing.
   "faissknn[cuda]>=0.3",
 ]
 optional-dependencies.dev = [

--- a/src/torchgeo_bench/knn.py
+++ b/src/torchgeo_bench/knn.py
@@ -83,7 +83,7 @@ class KNNClassifier:
             self._fit_gpu(X, y)
         return self
 
-    # ---- CPU path (faiss-cuda-cu128 IndexFlatL2) --------------------------
+    # ---- CPU path (faiss IndexFlatL2) -------------------------------------
 
     def _fit_cpu(self, X: np.ndarray, y: np.ndarray) -> None:
         self._index = faiss.IndexFlatL2(X.shape[1])

--- a/src/torchgeo_bench/main.py
+++ b/src/torchgeo_bench/main.py
@@ -1,6 +1,5 @@
 """Benchmark script for torchgeo-bench."""
 
-import fcntl
 import io
 import logging
 import os
@@ -13,6 +12,7 @@ import hydra
 import numpy as np
 import pandas as pd
 import torch
+from filelock import FileLock
 from hydra.utils import instantiate
 from omegaconf import DictConfig, OmegaConf
 from rich.progress import track
@@ -829,11 +829,11 @@ def append_rows_atomic(path: str, rows: list[dict]) -> None:
     if not rows:
         return
     df_local = pd.DataFrame(rows)
-    # fcntl advisory locking is Unix-only (Linux + macOS); Windows is unsupported.
-    fd = os.open(path, os.O_RDWR | os.O_CREAT)
-    with os.fdopen(fd, "r+", closefd=True) as f:
-        fcntl.flock(f.fileno(), fcntl.LOCK_EX)
-        try:
+    # Cross-platform advisory lock (Linux/macOS/Windows) so concurrent SLURM
+    # array tasks don't interleave their read-modify-append and corrupt the CSV.
+    with FileLock(f"{path}.lock"):
+        fd = os.open(path, os.O_RDWR | os.O_CREAT)
+        with os.fdopen(fd, "r+", closefd=True) as f:
             f.seek(0, os.SEEK_END)
             empty = f.tell() == 0
             buf = io.StringIO()
@@ -867,8 +867,6 @@ def append_rows_atomic(path: str, rows: list[dict]) -> None:
                     f.write(buf.getvalue())
             f.flush()
             os.fsync(f.fileno())
-        finally:
-            fcntl.flock(f.fileno(), fcntl.LOCK_UN)
 
 
 @hydra.main(config_path="conf", config_name="config", version_base=None)

--- a/src/torchgeo_bench/main.py
+++ b/src/torchgeo_bench/main.py
@@ -833,7 +833,9 @@ def append_rows_atomic(path: str, rows: list[dict]) -> None:
     # array tasks don't interleave their read-modify-append and corrupt the CSV.
     with FileLock(f"{path}.lock"):
         fd = os.open(path, os.O_RDWR | os.O_CREAT)
-        with os.fdopen(fd, "r+", closefd=True) as f:
+        # newline="" keeps the csv line terminators from being translated to
+        # CRLF on Windows, which would otherwise inject blank rows.
+        with os.fdopen(fd, "r+", newline="", closefd=True) as f:
             f.seek(0, os.SEEK_END)
             empty = f.tell() == 0
             buf = io.StringIO()

--- a/uv.lock
+++ b/uv.lock
@@ -758,16 +758,23 @@ wheels = [
 
 [[package]]
 name = "faissknn"
-version = "0.1.1"
+version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "faiss-cuda-cu128" },
     { name = "numpy" },
     { name = "torch" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c7/dd/215c7534599ffa9a17e1b1127afea2cc4ed4c16a2da24031d647b0ef0f1a/faissknn-0.1.1.tar.gz", hash = "sha256:ec21ece0fa0eb407a156acce1f43e6fbcae6118950887062234d8e3b5c1c6b26", size = 6530, upload-time = "2026-05-14T02:29:30.8Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/fd/40f72308cc258b784ac530b0d3202a10b4e028190ecf5906d4a8f1fcd396/faissknn-0.3.0.tar.gz", hash = "sha256:e571593b8afde29f3397469aff6eab1f63f9f7f6e8280f53e1e316647e3dae31", size = 7671, upload-time = "2026-06-18T01:57:01.644Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/a1/aa5cdd7c123d7ba5bc5b12a407e8216d0aa18dfb3f052bc2904b7713ba6c/faissknn-0.1.1-py3-none-any.whl", hash = "sha256:4a32d00fc59d01b070257e06130744e8a9e26cb1b4a5af478c35f43c3aa55ca5", size = 6184, upload-time = "2026-05-14T02:29:29.574Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/26/ec40a4513fdaad8d4e48764d47001dd6cfaa1b778cbcd98c22eaf940fae8/faissknn-0.3.0-py3-none-any.whl", hash = "sha256:91e6b514405f3870985654533b2cfefe77fb47873987f6d152f1d8b8e0a3c548", size = 7200, upload-time = "2026-06-18T01:57:02.515Z" },
+]
+
+[package.optional-dependencies]
+cpu = [
+    { name = "faiss-cpu" },
+]
+cuda = [
+    { name = "faiss-cuda-cu128" },
 ]
 
 [[package]]
@@ -3907,7 +3914,7 @@ name = "torchgeo-bench"
 version = "0.3.0"
 source = { editable = "." }
 dependencies = [
-    { name = "faiss-cpu" },
+    { name = "faissknn", extra = ["cpu"] },
     { name = "geobenchv2" },
     { name = "h5py" },
     { name = "huggingface-hub" },
@@ -3928,8 +3935,7 @@ dependencies = [
 [package.optional-dependencies]
 all = [
     { name = "cleanlab" },
-    { name = "faiss-cuda-cu128" },
-    { name = "faissknn" },
+    { name = "faissknn", extra = ["cuda"] },
     { name = "imagehash" },
     { name = "linkify-it-py" },
     { name = "matplotlib" },
@@ -3957,8 +3963,7 @@ cleanlab = [
     { name = "pillow" },
 ]
 cuda = [
-    { name = "faiss-cuda-cu128" },
-    { name = "faissknn" },
+    { name = "faissknn", extra = ["cuda"] },
 ]
 dev = [
     { name = "mdformat" },
@@ -3997,9 +4002,8 @@ viz = [
 [package.metadata]
 requires-dist = [
     { name = "cleanlab", marker = "extra == 'cleanlab'", specifier = ">=2.7" },
-    { name = "faiss-cpu", specifier = ">=1.7" },
-    { name = "faiss-cuda-cu128", marker = "extra == 'cuda'", specifier = ">=1.14.1.post3" },
-    { name = "faissknn", marker = "extra == 'cuda'", specifier = ">=0.0.3" },
+    { name = "faissknn", extras = ["cpu"], specifier = ">=0.3" },
+    { name = "faissknn", extras = ["cuda"], marker = "extra == 'cuda'", specifier = ">=0.3" },
     { name = "geobenchv2", specifier = ">=0.9" },
     { name = "h5py", specifier = ">=3.8" },
     { name = "huggingface-hub", specifier = ">=0.20" },

--- a/uv.lock
+++ b/uv.lock
@@ -3915,6 +3915,7 @@ version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "faissknn", extra = ["cpu"] },
+    { name = "filelock" },
     { name = "geobenchv2" },
     { name = "h5py" },
     { name = "huggingface-hub" },
@@ -4004,6 +4005,7 @@ requires-dist = [
     { name = "cleanlab", marker = "extra == 'cleanlab'", specifier = ">=2.7" },
     { name = "faissknn", extras = ["cpu"], specifier = ">=0.3" },
     { name = "faissknn", extras = ["cuda"], marker = "extra == 'cuda'", specifier = ">=0.3" },
+    { name = "filelock", specifier = ">=3.12" },
     { name = "geobenchv2", specifier = ">=0.9" },
     { name = "h5py", specifier = ">=3.8" },
     { name = "huggingface-hub", specifier = ">=0.20" },


### PR DESCRIPTION
faissknn 0.3 has proper `[cpu]`/`[cuda]` extras, so the default install can use `faissknn[cpu]` (faiss-cpu, all platforms) and `[cuda]` becomes `faissknn[cuda]` (Linux-only). CI now runs the CPU KNN tests on ubuntu/macOS/windows to prove it.

Two portability fixes that surfaced along the way: dropped the Unix-only `fcntl` lock in `append_rows_atomic` for cross-platform `filelock`, and enabled git long paths on Windows so uv can check out the torchgeo git dep.