### PR TITLE
fix: address fresh-install shakedown findings (resume bug, docs, extras)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,25 +38,45 @@ pyproject.toml             # Project config, dependencies, tool settings
 
 ## Environment Setup
 
+Two supported workflows — pick **one** (they manage *separate* environments):
+
 ```bash
-conda activate torchgeo-bench       # do this first
-uv sync --extra dev                 # install dependencies and dev tools
+# Option A — uv (the README's canonical path). Creates and manages its own
+# .venv and ignores any active conda env. Run tools via `uv run …`:
+uv sync --extra dev
+
+# Option B — conda (matches the Makefile). Create the env with `make install`,
+# then install editable:
+conda activate torchgeo-bench
+pip install -e ".[dev]"
 ```
+
+> Note: `uv sync` always uses its own `.venv`, so a preceding
+> `conda activate` does **not** change what `uv sync` installs into.
 
 ## Build/Lint/Test Commands
 
 ### Running Tests
 
 ```bash
-pytest                                    # Run ALL tests (after activating env)
+pytest                                    # Run the fast suite (excludes `slow`)
 pytest tests/test_geobench_dataset.py -v  # Run a SINGLE test file
 pytest tests/test_geobench_dataset.py::TestClass::test_method -v  # Single function
 pytest -k "m-eurosat" -v                  # Run tests matching a pattern
 pytest --no-cov                           # Skip coverage for faster iteration
+pytest -m slow                            # Include the slow integration suite
 ```
+
+The default `addopts` include `-m "not slow"`, so a bare `pytest` runs only the
+fast subset; use `-m slow` (or `-m ""` for everything) to run the integration
+tests, which load real data and run models.
 
 Tests skip gracefully if GeoBench data is missing — they look for it under
 `./data/classification_v1.0`, `./data/geobenchv2`, and `./data/eurosat`.
+Note the V1 *slow* tests need the legacy HDF5 bundle from
+`torchgeo-bench download geobench_v1`; the single-dataset auto-download writes a
+webdataset layout under `./data/classification_v1.0_wds/` that those tests do
+**not** read (they will skip).
 
 ### Linting and Formatting
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CONDA_RUN := conda run --no-capture-output -n torchgeo-bench
 .PHONY: install sync tests lint format clean docs docs-clean help
 
 install:
-	conda create -y -n torchgeo-bench 'python>=3.12,<3.13' || true
+	conda create -y -n torchgeo-bench 'python>=3.13' || true
 	$(CONDA_RUN) pip install -e ".[dev]"
 
 sync:
@@ -22,7 +22,8 @@ format:
 	$(CONDA_RUN) ruff check --fix --select I src/ tests/
 
 docs:
-	sphinx-build -b html docs/ docs/_build/html
+	$(CONDA_RUN) pip install -e ".[docs]"
+	$(CONDA_RUN) sphinx-build -b html docs/ docs/_build/html
 
 docs-clean:
 	rm -rf docs/_build

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ For GPU-accelerated KNN (Linux + CUDA 12 + glibc ≥ 2.28):
 pip install 'torchgeo-bench[cuda]'
 ```
 
-Requires Python 3.12+. Supported on **Linux** and **macOS**. Windows is not
-supported — on Windows, install inside [WSL2](https://learn.microsoft.com/windows/wsl/).
+Requires Python 3.12+. The default (CPU) install runs on **Linux**, **macOS**,
+and **Windows**; GPU-accelerated KNN (the `[cuda]` extra) is Linux-only.
 
 ## Download a dataset
 
@@ -73,8 +73,18 @@ torchgeo-bench run
 torchgeo-bench run model=timm/resnet50 dataset.names=[m-eurosat]
 ```
 
-Results are appended to `results/all_results.csv`. Re-run with `resume=true`
-to skip already-completed rows.
+The default device is `cuda:0`. On a machine without a working CUDA GPU (or if
+a GPU run crashes — see [troubleshooting](https://torchgeo.org/torchgeo-bench/user/troubleshooting.html)),
+fall back to CPU:
+
+```bash
+torchgeo-bench run dataset.names=[m-eurosat] device=cpu
+```
+
+Results are appended to `results/all_results.csv`, which **ships pre-populated
+with reference results** — to start from a clean slate, write to your own file
+with `output=results/my_run.csv`. Re-run with `resume=true` to skip
+already-completed rows.
 
 <!-- skip-on-docs-landing-start -->
 ## Learn more

--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -63,16 +63,27 @@ default.  Combine extras with comma-separated lists:
    $ # or
    $ pip install -e ".[docs,viz]"
 
+.. note::
+
+   ``uv sync`` installs *exactly* the extras you pass and removes anything not
+   listed, so extras do **not** accumulate across calls.  Request them together
+   in one command (``uv sync --extra docs --extra viz``) rather than running
+   ``uv sync --extra docs`` and then ``uv sync --extra viz`` (the second drops
+   the first).
+
 ================  ==============================================================
 Extra             Pulls in
 ================  ==============================================================
-``dev``           ruff, pytest, pre-commit, mdformat, pyproject-fmt
-``docs``          sphinx, pydata-sphinx-theme, myst-parser, sphinx-copybutton
-``id``            ``torchid`` for intrinsic-dimension metrics (Python ≥ 3.13)
+``cleanlab``      ``cleanlab``, ``imagehash``, ``matplotlib``, ``pillow`` (label-noise audit)
+``cuda``          ``faissknn[cuda]`` → ``faiss-cuda-cu128`` for GPU KNN (Linux only; shares the ``faiss`` namespace with the default ``faissknn[cpu]`` — install in a fresh env)
+``dev``           ruff, pytest, pytest-cov, pytest-xdist, pre-commit, mdformat, pyproject-fmt
+``docs``          sphinx, pydata-sphinx-theme, myst-parser, sphinx-copybutton, sphinx-design
+``id``            ``torchid`` for intrinsic-dimension metrics (Python ≥ 3.13 only)
 ``olmoearth``     ``olmoearth-pretrain-minimal`` for the OlmoEarth backbone
 ``sam3``          ``transformers`` for the SAM 3 encoder
+``terratorch``    ``terratorch`` for TerraTorch backbones
 ``viz``           ``matplotlib``, ``pillow`` for segmentation visualisations
-``all``           every extra above
+``all``           every extra above **except** ``cuda`` (FAISS conflict) and ``olmoearth``
 ================  ==============================================================
 
 Datasets are not installed by these extras — see :doc:`datasets` for how to

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -8,8 +8,10 @@ Prerequisites
 -------------
 
 * ``torchgeo-bench`` installed (see :doc:`installation`).
-* At least one GeoBench dataset downloaded into ``./data/`` — easiest is
-  the small ``m-eurosat`` split.
+* At least one GeoBench dataset under ``./data/``.  The lightest path is to
+  skip the bulk download entirely and let the **single-dataset auto-download**
+  run: the first time you benchmark a V1 dataset (e.g.
+  ``dataset.names=[m-eurosat]``) only that dataset is pulled.
 
 Download data
 -------------
@@ -20,10 +22,15 @@ variables).  The bundled downloader fetches each family by name:
 
 .. code-block:: console
 
-   $ torchgeo-bench download geobench_v1                       # all V1 classification datasets
+   $ torchgeo-bench download geobench_v1                       # ALL V1 classification datasets
    $ torchgeo-bench download geobench_v2                       # default V2 set (cls + seg)
    $ torchgeo-bench download geobench_v2 --datasets benv2,burn_scars
    $ torchgeo-bench download eurosat                           # torchgeo's EuroSAT mirror
+
+Note that ``download geobench_v1`` fetches the **entire** V1 classification
+bundle, not just one split.  For a quick first run you usually don't need it —
+just benchmark a single dataset and let the per-dataset auto-download fetch
+only what's used (see :doc:`datasets`).
 
 See :doc:`datasets` for the full list of supported names and the
 canonical destination subdirectories.
@@ -50,6 +57,13 @@ Skip the (slow) linear probe and reduce bootstrap noise to iterate quickly:
 
    $ torchgeo-bench run eval.skip_linear=true eval.bootstrap=100
 
+The default device is ``cuda:0``.  On a machine without a working CUDA GPU
+(or if a GPU run crashes — see :doc:`troubleshooting`), add ``device=cpu``:
+
+.. code-block:: console
+
+   $ torchgeo-bench run dataset.names=[m-eurosat] device=cpu
+
 Resume mode
 -----------
 
@@ -66,9 +80,11 @@ See :doc:`results-format` for the exact key schema used by resume mode.
 Inspect the results
 -------------------
 
-By default results land in ``results/all_results.csv``.  Each row is a
-flat :class:`~torchgeo_bench.main.EvaluationResult`, so you can read it
-directly with pandas:
+By default results land in ``results/all_results.csv``.  That file **ships
+pre-populated** with reference results, so to start from a clean slate write to
+your own file with ``output=results/my_run.csv``.  Each row is a flat
+:class:`~torchgeo_bench.main.EvaluationResult`, so you can read it directly with
+pandas:
 
 .. code-block:: python
 

--- a/docs/user/troubleshooting.rst
+++ b/docs/user/troubleshooting.rst
@@ -44,6 +44,31 @@ For segmentation, also try
 
 if RAM (rather than GPU memory) is the bottleneck.
 
+GPU run crashes immediately
+---------------------------
+
+The default config is ``device: cuda:0``, so the first documented run uses the
+GPU.  ``uv sync`` installs the latest ``torch``, whose bundled CUDA and kernel
+architectures may not match your GPU or driver.  Two distinct failures:
+
+* ``RuntimeError: The NVIDIA driver on your system is too old`` — the installed
+  ``torch`` was built against a newer CUDA than your driver supports.
+* ``CUDA error: no kernel image is available for execution on the device``
+  (``cudaErrorNoKernelImageForDevice``) — torch's CUDA 12.8 wheels dropped
+  Volta (``sm_70``) kernels, so they fail on a V100 *even though* CUDA
+  initialises.  Older GPUs need a **cu126** (or earlier) build, e.g.
+  ``torch==2.7.1+cu126`` + ``torchvision==0.22.1+cu126`` from
+  ``https://download.pytorch.org``.
+
+Either way you can fall back to CPU (slower, but always works):
+
+.. code-block:: console
+
+   $ torchgeo-bench run dataset.names=[m-eurosat] device=cpu
+
+CPU is fine for the small V1 splits, but large V2 datasets (e.g. ``benv2`` /
+BigEarthNet) can take far longer — prefer a working GPU for those.
+
 ``KeyError: 's2'`` on a V2 dataset
 ----------------------------------
 
@@ -51,6 +76,26 @@ A known V2 issue: ``geobench_v2.rearrange_bands`` expects modality keys
 (``'s2'``, ``'s1'``, …) that aren't present when a flat band list is
 requested.  Workaround: use ``dataset.bands=all`` for affected V2
 datasets.
+
+``eurosat-spatial`` reports ``Dataset not found``
+-------------------------------------------------
+
+``torchgeo-bench download eurosat`` fetches EuroSAT plus the standard
+``eurosat-{train,val,test}.txt`` splits, but the ``eurosat-spatial`` dataset
+uses ``torchgeo.datasets.EuroSATSpatial``, which needs its own *spatial* split
+files.  Those download automatically on the first CLI run that uses
+``eurosat-spatial``; the plain ``download eurosat`` command does not provision
+them, so its slow test skips until that first run.
+
+V1 slow tests skip after the auto-download
+------------------------------------------
+
+The per-dataset auto-download (triggered by running a V1 dataset such as
+``dataset.names=[m-eurosat]``) writes the webdataset layout under
+``data/classification_v1.0_wds/``.  The V1 *slow* integration tests instead
+read the legacy HDF5 layout under ``data/classification_v1.0/`` and skip if only
+the ``_wds`` data is present.  Fetch the legacy bundle with
+``torchgeo-bench download geobench_v1`` to run them.
 
 Build / docs warnings
 ---------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ dependencies = [
 ]
 optional-dependencies.all = [
   "torchgeo-bench[cleanlab]",
-  "torchgeo-bench[cuda]",
   "torchgeo-bench[dev]",
   "torchgeo-bench[docs]",
   "torchgeo-bench[id]",

--- a/src/torchgeo_bench/main.py
+++ b/src/torchgeo_bench/main.py
@@ -91,6 +91,38 @@ def _normalize_bands_value(bands: object) -> str:
     return ",".join(items)
 
 
+def _canonical_key_cell(value: object) -> str:
+    """Canonicalize a single resume-key cell to a comparable string.
+
+    Resume keys are assembled from two sources that format values
+    differently: the Hydra config (``image_size`` is the int ``224`` →
+    ``"224"``) and the results CSV (pandas types any column containing a
+    missing value as ``float64``, so ``224`` round-trips as ``"224.0"``).
+    Without canonicalization those never compare equal, so ``resume=true``
+    silently recomputes and appends duplicate rows.
+
+    Whole-number floats collapse to their integer form (``"224.0"`` →
+    ``"224"``); values that don't parse as numbers (dataset names, band
+    lists, …) pass through unchanged.
+
+    Args:
+        value: A raw key cell from either a config tuple or a CSV row.
+
+    Returns:
+        A canonical string suitable for equality comparison across sources.
+    """
+    if value is None:
+        return ""
+    s = str(value).strip()
+    if not s:
+        return ""
+    try:
+        f = float(s)
+    except (TypeError, ValueError):
+        return s
+    return str(int(f)) if f.is_integer() else s
+
+
 def _completed_run_keys(
     existing_df: pd.DataFrame,
     key_cols: Sequence[str],
@@ -102,12 +134,13 @@ def _completed_run_keys(
         if "metric_name" not in df.columns:
             return set()
         df = df[df["metric_name"].fillna("").astype(str) == metric_name]
-    return set(map(tuple, df[list(key_cols)].fillna("").astype(str).to_numpy()))
+    rows = df[list(key_cols)].fillna("").to_numpy()
+    return {tuple(_canonical_key_cell(cell) for cell in row) for row in rows}
 
 
 def _row_key(row: dict, key_cols: Sequence[str]) -> tuple[str, ...]:
     """Build a normalized resume key tuple from a result row dict."""
-    return tuple(str(row.get(col, "")) for col in key_cols)
+    return tuple(_canonical_key_cell(row.get(col, "")) for col in key_cols)
 
 
 def _filter_completed_metric_rows(
@@ -931,12 +964,15 @@ def main(cfg: DictConfig) -> None:
             logger.warning(f"Skipping dataset {ds_name} (not in registry)")
             continue
 
-        config_tuple = (
-            normalization,
-            str(getattr(cfg.dataset, "image_size", None)),
-            getattr(cfg.dataset, "interpolation", "bilinear"),
-            cfg.dataset.partition,
-            bands_value,
+        config_tuple = tuple(
+            _canonical_key_cell(v)
+            for v in (
+                normalization,
+                getattr(cfg.dataset, "image_size", None),
+                getattr(cfg.dataset, "interpolation", "bilinear"),
+                cfg.dataset.partition,
+                bands_value,
+            )
         )
 
         # Merge model-specific eval config early so resume key and result rows

--- a/tests/test_main_fast.py
+++ b/tests/test_main_fast.py
@@ -177,6 +177,31 @@ def test_resume_skips_completed_knn_row(tmp_path: Path):
     assert int((df["method"] == "knn5").sum()) == 1
 
 
+def test_resume_skips_when_image_size_read_as_float(tmp_path: Path):
+    """Regression for the resume-key int/float mismatch (image_size).
+
+    A populated results CSV with any missing ``image_size`` cell is typed by
+    pandas as ``float64``, so the default ``224`` round-trips as ``"224.0"``
+    while the config-side key is ``"224"``. Resume must still treat the row
+    as complete instead of recomputing and appending a duplicate.
+    """
+    out = tmp_path / "out.csv"
+    cfg = _compose_cfg(out, overrides=["resume=true", "eval.skip_linear=true"])
+    df = pd.DataFrame([_resume_row(cfg, method="knn5", metric_name="accuracy")])
+    # Reproduce the float64 dtype a real (partially-NaN) results CSV exhibits.
+    df["image_size"] = df["image_size"].astype(float)
+    df.to_csv(out, index=False)
+
+    with (
+        mock.patch("torchgeo_bench.main.get_datasets", return_value=_synthetic_loaders()),
+        mock.patch("torchgeo_bench.main.evaluate_knn") as knn_mock,
+    ):
+        main.__wrapped__(cfg)
+
+    knn_mock.assert_not_called()
+    assert int((pd.read_csv(out)["method"] == "knn5").sum()) == 1
+
+
 def test_dataset_not_found_skips(tmp_path: Path):
     out = tmp_path / "out.csv"
     cfg = _compose_cfg(out)

--- a/uv.lock
+++ b/uv.lock
@@ -3936,7 +3936,6 @@ dependencies = [
 [package.optional-dependencies]
 all = [
     { name = "cleanlab" },
-    { name = "faissknn", extra = ["cuda"] },
     { name = "imagehash" },
     { name = "linkify-it-py" },
     { name = "matplotlib" },
@@ -4039,7 +4038,6 @@ requires-dist = [
     { name = "torch", specifier = ">=2" },
     { name = "torchgeo", git = "https://github.com/microsoft/torchgeo.git?rev=e585e2c07f7a" },
     { name = "torchgeo-bench", extras = ["cleanlab"], marker = "extra == 'all'" },
-    { name = "torchgeo-bench", extras = ["cuda"], marker = "extra == 'all'" },
     { name = "torchgeo-bench", extras = ["dev"], marker = "extra == 'all'" },
     { name = "torchgeo-bench", extras = ["docs"], marker = "extra == 'all'" },
     { name = "torchgeo-bench", extras = ["id"], marker = "extra == 'all'" },


### PR DESCRIPTION
A clean clone + install shakedown (documented in FINDINGS.md) surfaced 15 friction points. This PR fixes the actionable ones — one real bug, two build/config issues, and a batch of documentation corrections.

## Code / config fixes

### `resume=true` recomputed everything at the default image size (bug #3)
The resume key includes `image_size`, built from config as `str(224)` → `"224"`, but a populated `results/all_results.csv` is read by pandas as `float64` (any missing cell types the column), so the same value round-trips as `"224.0"`. `"224" != "224.0"` → resume never matched and appended **duplicate** rows. Fixed by canonicalizing numeric key cells on both sides (`_canonical_key_cell`), with a regression test that reproduces the float64 dtype.

### `[all]` extra was self-conflicting (#7)
`all` pulled in `cuda` (`faiss-cuda-cu128`), which by its own comment conflicts with the default `faiss-cpu` in the same venv — so `pip install -e ".[all]"` could produce a broken FAISS install. Dropped `cuda` from `all` and relocked.

### Makefile (#6, #10)
- `install` now creates a `python>=3.13` conda env (was pinned `>=3.12,<3.13`), matching `.python-version` so the `id`/`torchid` extra isn't silently skipped.
- `docs` now runs through `$(CONDA_RUN)` and installs the `docs` extra first (previously bare `sphinx-build`, which used whatever global sphinx was on PATH and failed after `make install`, which lacks the docs extra).

## Documentation fixes

| # | Fix |
|---|-----|
| #1, #11 | troubleshooting: GPU `driver too old` vs `no kernel image` (cu128 dropped Volta/sm_70) with the cu126 workaround; CPU is slow for large V2 datasets |
| #2 | README + quickstart document the `device=cpu` fallback |
| #4 | README + quickstart note `results/all_results.csv` ships pre-populated; use `output=...` for a clean slate |
| #5 | AGENTS.md: fix the misleading "conda activate **then** uv sync" pairing (uv uses its own `.venv`) |
| #7, #14 | installation: regenerate the extras table (adds `cleanlab`/`cuda`/`terratorch`; notes `all` excludes `cuda`+`olmoearth`); warn that `uv sync --extra` does not accumulate |
| #8 | AGENTS.md: bare `pytest` runs the *fast* suite, not ALL tests; document `-m slow` |
| #9 | quickstart: `download geobench_v1` pulls the **whole** V1 bundle; point users at the per-dataset auto-download |
| #12 | troubleshooting + AGENTS.md: V1 slow tests read legacy HDF5 (`data/classification_v1.0/`), not the `_wds` auto-download layout |
| #13 | troubleshooting: `eurosat-spatial` needs its own spatial split files (not fetched by `download eurosat`) |

## Not changed (deliberately)
- **#4 (delete the CSV):** `results/all_results.csv` powers the docs results-explorer and is referenced across many docs, so it's documented rather than removed.
- **#1 (pin old torch):** can't pin a Volta-compatible torch for everyone without breaking newer GPUs; documented the matrix + fallback instead.
- **#15 (intersphinx SSL warnings):** environmental/offline-only; `conf.py` already suppresses `intersphinx.fetch_inventory` and the build isn't run with `-W` locally.

## Verification
- `pytest tests/test_main_fast.py` — 6 passed incl. the new `test_resume_skips_when_image_size_read_as_float` (verified it fails against the unfixed code).
- Full fast suite: 351 passed, 32 skipped, 86 deselected.
- `ruff check` / `ruff format` / `pre-commit run` clean; `uv lock --locked` passes; docs build succeeds (only the known offline-intersphinx warnings).

🤖 Generated with the GitHub Copilot CLI.