### PR TITLE
fix(knn): prevent macOS OpenMP segfault when torch and faiss-cpu coexist

### DIFF
--- a/src/torchgeo_bench/knn.py
+++ b/src/torchgeo_bench/knn.py
@@ -9,14 +9,21 @@ The two paths produce identical predictions modulo float-precision noise.
 """
 
 import logging
+import os
+import sys
 from typing import Literal, Self
 
-# Suppress noisy INFO messages from faiss loader (AVX512/AVX2 fallback probing)
+if sys.platform == "darwin":
+    os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
+
 logging.getLogger("faiss.loader").setLevel(logging.WARNING)
 
 import faiss  # noqa: E402
 import numpy as np  # noqa: E402
 import torch  # noqa: E402
+
+if sys.platform == "darwin":
+    faiss.omp_set_num_threads(1)
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
macOS pytest segfaults on the first CPU KNN test because torch and faiss-cpu each bundle their own `libomp.dylib` — with both loaded the second OpenMP runtime aborts (`OMP: Error #15`) and faiss segfaults in its parallel search kernel.

Fix (macOS only): set `KMP_DUPLICATE_LIB_OK=TRUE` before importing faiss and pin faiss to a single OpenMP thread. Linux/CUDA keeps faiss multithreaded.
