### PR TITLE
pytest: do not duplicate defaults

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,10 +153,6 @@ lint.per-file-ignores."tests/**/*.py" = [ "ARG", "D" ]
 lint.pydocstyle.convention = "google"
 
 [tool.pytest]
-ini_options.testpaths = [ "tests" ]
-ini_options.python_files = [ "test_*.py" ]
-ini_options.python_classes = [ "Test*" ]
-ini_options.python_functions = [ "test_*" ]
 ini_options.addopts = [
   "--verbose",
   "-m not slow",


### PR DESCRIPTION
These are all default settings, these lines don't change anything. I confirmed that the total number of tests before and after this change remains the same.
```console
> pytest --cov=src/torchgeo_bench/
=================================================================================== test session starts ===================================================================================
platform darwin -- Python 3.13.7, pytest-9.0.3, pluggy-1.6.0 -- /Users/Adam/torchgeo-bench/.venv/bin/python3
cachedir: .pytest_cache
rootdir: /Users/Adam/torchgeo-bench
configfile: pyproject.toml
plugins: cov-7.1.0, xdist-3.8.0, hydra-core-1.3.2, anyio-4.13.0
collected 471 items / 86 deselected / 385 selected            
```
P.S. I'm not a huge fan of `--verbose`, but if y'all like it it's fine.