### PR TITLE
chore: release v0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [ "uv-build>=0.11.6,<0.12" ]
 
 [project]
 name = "torchgeo-bench"
-version = "0.3.0"
+version = "0.4.0"
 description = "Lightweight benchmarking framework for geospatial models"
 readme = "README.md"
 keywords = [

--- a/src/torchgeo_bench/__init__.py
+++ b/src/torchgeo_bench/__init__.py
@@ -7,7 +7,7 @@ from .main import bootstrap_map, evaluate_knn, evaluate_logistic
 try:
     __version__ = version("torchgeo-bench")
 except PackageNotFoundError:  # editable / pre-install fallback
-    __version__ = "0.3.0"
+    __version__ = "0.4.0"
 
 __author__ = "torchgeo-bench contributors"
 

--- a/uv.lock
+++ b/uv.lock
@@ -3914,7 +3914,7 @@ wheels = [
 
 [[package]]
 name = "torchgeo-bench"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "faissknn", extra = ["cpu"] },


### PR DESCRIPTION
Version bump for the **0.4.0** release.

- `pyproject.toml` version `0.3.0` → `0.4.0`
- `__init__.py` fallback `__version__` → `0.4.0`
- relock `uv.lock`

Verified `uv build` produces clean sdist+wheel; wheel metadata shows `Version: 0.4.0` and `torchgeo>=0.9` (no direct-reference/git deps) — publishable to PyPI.

After merge: cut the `v0.4.0` GitHub release, which tags `main` and triggers the PyPI publish workflow.

## Highlights since v0.3.0 (88 commits)
- GeoFM probing wrappers: Prithvi, TerraMind, Clay, CROMA, Panopticon, OlmoEarth, DINOv3
- EuroSAT spatial-split benchmark dataset
- Calibration metrics (ECE/RMS-CE/MCE) + temperature scaling
- typer+rich CLI; GPU KNN path; results explorer
- torchgeo dependency back to a PyPI release (`>=0.9`)