### PR TITLE
Fall back to CPU KNN when FAISS lacks GPU support

### DIFF
--- a/docs/user/configuration.rst
+++ b/docs/user/configuration.rst
@@ -77,6 +77,7 @@ selection semantics.
      c_range: [-6, 4, 40]          # log10 sweep start, stop, num samples for linear probe
      merge_val: true               # merge train+val before training the final logistic head
      skip_linear: false            # skip the (slower) linear probe entirely
+     knn_device: null              # auto: GPU FAISS when available, otherwise CPU
 
      intrinsic_dim:                # optional ID metrics on extracted embeddings
        enabled: false

--- a/docs/user/configuration.rst
+++ b/docs/user/configuration.rst
@@ -77,7 +77,7 @@ selection semantics.
      c_range: [-6, 4, 40]          # log10 sweep start, stop, num samples for linear probe
      merge_val: true               # merge train+val before training the final logistic head
      skip_linear: false            # skip the (slower) linear probe entirely
-     knn_device: null              # auto: GPU FAISS when available, otherwise CPU
+     knn_device: null              # inherit device; fall back to CPU if FAISS lacks GPU support
 
      intrinsic_dim:                # optional ID metrics on extracted embeddings
        enabled: false

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -64,6 +64,10 @@ The default device is ``cuda:0``.  On a machine without a working CUDA GPU
 
    $ torchgeo-bench run dataset.names=[m-eurosat] device=cpu
 
+When the selected FAISS backend has no GPU resources, the runner evaluates KNN
+on CPU while keeping feature extraction on the configured accelerator. It logs
+this fallback; use ``eval.knn_device=cpu`` to select it explicitly.
+
 Resume mode
 -----------
 

--- a/src/torchgeo_bench/conf/config.yaml
+++ b/src/torchgeo_bench/conf/config.yaml
@@ -30,7 +30,7 @@ eval:
   merge_val: true          # merge train+val for final logistic training
   skip_linear: false       # if true, skip LogisticRegression evaluation
   knn_k: 5                 # number of neighbours for KNN evaluation
-  knn_device: null         # null = inherit cfg.device; set "cpu" to force faiss-cpu KNN
+  knn_device: null         # null = use GPU FAISS if available, otherwise CPU; set explicitly to require a device
 
   # Calibration metrics (ECE / RMS-CE / MCE) reported per classification row.
   # KNN probabilities are quantized to (knn_k + 1) levels, so its default

--- a/src/torchgeo_bench/conf/config.yaml
+++ b/src/torchgeo_bench/conf/config.yaml
@@ -30,7 +30,7 @@ eval:
   merge_val: true          # merge train+val for final logistic training
   skip_linear: false       # if true, skip LogisticRegression evaluation
   knn_k: 5                 # number of neighbours for KNN evaluation
-  knn_device: null         # null = use GPU FAISS if available, otherwise CPU; set explicitly to require a device
+  knn_device: null         # null = inherit device, falling back to CPU if FAISS lacks GPU support
 
   # Calibration metrics (ECE / RMS-CE / MCE) reported per classification row.
   # KNN probabilities are quantized to (knn_k + 1) levels, so its default

--- a/src/torchgeo_bench/knn.py
+++ b/src/torchgeo_bench/knn.py
@@ -2,10 +2,10 @@
 
 Single-label and multi-label k-nearest neighbours backed by FAISS.
 
-CPU path uses ``faiss-cpu`` with ``IndexFlatL2`` (or ``faiss-cuda-cu128``'s
-CPU index when the ``cuda`` extra is installed). GPU path (opt-in via the
-``cuda`` extra: ``pip install -e ".[cuda]"``) delegates to :mod:`faissknn`.
-The two paths produce identical predictions modulo float-precision noise.
+The CPU path uses the selected FAISS backend's ``IndexFlatL2`` implementation.
+The GPU path delegates to :mod:`faissknn` when that backend provides CUDA
+resources. The two paths produce identical predictions modulo float-precision
+noise.
 """
 
 import logging
@@ -32,6 +32,37 @@ def _is_cpu_device(device: str) -> bool:
     return str(device).lower() == "cpu"
 
 
+def gpu_faiss_available() -> bool:
+    """Return whether the installed FAISS package provides CUDA resources."""
+    return hasattr(faiss, "StandardGpuResources")
+
+
+def resolve_knn_device(requested_device: str | None, model_device: str) -> str:
+    """Resolve the KNN device, falling back for an implicit CUDA request.
+
+    Args:
+        requested_device: Explicit KNN device, or ``None`` to follow the model.
+        model_device: Device used by the feature extractor.
+
+    Returns:
+        Device to use for KNN evaluation.
+    """
+    device = requested_device if requested_device is not None else model_device
+    if _is_cpu_device(device) or gpu_faiss_available():
+        return device
+    if requested_device is not None:
+        raise RuntimeError(
+            f"GPU-enabled FAISS is unavailable for explicit KNN device {requested_device!r}. "
+            "Set eval.knn_device=cpu or install a GPU-enabled FAISS backend."
+        )
+    logger.warning(
+        "GPU-enabled FAISS is unavailable; using CPU for KNN while the model remains on %s. "
+        "Set eval.knn_device=cpu to make this choice explicit.",
+        model_device,
+    )
+    return "cpu"
+
+
 class KNNClassifier:
     """FAISS-backed KNN classifier with single- and multi-label support.
 
@@ -43,8 +74,8 @@ class KNNClassifier:
             on the CPU path; faissknn does not clamp internally.
         device: ``"cpu"`` (default) → the FAISS CPU index. Anything else
             (``"cuda"``, ``"cuda:0"``) requires ``faissknn`` with a GPU FAISS
-            backend (installed automatically on Linux x86_64); raises
-            :class:`ImportError` if missing.
+            backend (installed automatically on Linux x86_64); raises an
+            actionable error if unavailable.
         metric: Distance metric — ``"l2"`` (default), ``"ip"`` (inner
             product), or ``"cosine"`` (cosine similarity; auto-normalizes
             inputs). GPU path only; CPU path always uses L2.
@@ -146,6 +177,12 @@ class KNNClassifier:
                 "GPU KNN requires Linux x86_64, where it installs automatically; "
                 'otherwise request device="cpu".'
             ) from exc
+
+        if not gpu_faiss_available():
+            raise RuntimeError(
+                f"KNNClassifier(device={self.device!r}): GPU-enabled FAISS is unavailable. "
+                "Set eval.knn_device=cpu for CLI runs or request device='cpu'."
+            )
 
         kwargs = {
             "n_neighbors": self.n_neighbors,

--- a/src/torchgeo_bench/main.py
+++ b/src/torchgeo_bench/main.py
@@ -1088,6 +1088,10 @@ def main(cfg: DictConfig) -> None:
                 logger.info(f"[{ds_name}] Resume preflight: all requested work already complete")
             continue
 
+        knn_device: str | None = None
+        if ds_cls.task != "segmentation" and not plan.skip_knn:
+            knn_device = resolve_knn_device(cfg.eval.get("knn_device"), cfg.device)
+
         try:
             result = get_datasets(
                 dataset_name=ds_name,
@@ -1231,8 +1235,6 @@ def main(cfg: DictConfig) -> None:
         else:
             # Classification (single-label or multi-label)
             metric_name = plan.metric_name
-            if not plan.skip_knn:
-                knn_device = resolve_knn_device(cfg.eval.get("knn_device"), cfg.device)
             x_train, y_train = embed_split(model, train_loader, device, verbose=cfg.verbose)
             x_val, y_val = embed_split(model, val_loader, device, verbose=cfg.verbose)
             x_test, y_test = embed_split(model, test_loader, device, verbose=cfg.verbose)
@@ -1244,6 +1246,7 @@ def main(cfg: DictConfig) -> None:
             cal_temp_scale = bool(cal_cfg.get("temp_scale", True))
 
             if not plan.skip_knn:
+                assert knn_device is not None
                 knn_score, knn_lo, knn_hi, knn_cal, knn_n_bins = evaluate_knn(
                     x_train,
                     y_train,

--- a/src/torchgeo_bench/main.py
+++ b/src/torchgeo_bench/main.py
@@ -31,7 +31,7 @@ from torchgeo_bench.datasets import (
     list_datasets,
 )
 from torchgeo_bench.intrinsic_dim import DegenerateManifoldError, compute_intrinsic_dim
-from torchgeo_bench.knn import KNNClassifier
+from torchgeo_bench.knn import KNNClassifier, resolve_knn_device
 from torchgeo_bench.linear import LogisticRegression
 from torchgeo_bench.model_profile import measure_profile
 from torchgeo_bench.models.interface import BenchModel
@@ -1231,6 +1231,8 @@ def main(cfg: DictConfig) -> None:
         else:
             # Classification (single-label or multi-label)
             metric_name = plan.metric_name
+            if not plan.skip_knn:
+                knn_device = resolve_knn_device(cfg.eval.get("knn_device"), cfg.device)
             x_train, y_train = embed_split(model, train_loader, device, verbose=cfg.verbose)
             x_val, y_val = embed_split(model, val_loader, device, verbose=cfg.verbose)
             x_test, y_test = embed_split(model, test_loader, device, verbose=cfg.verbose)
@@ -1242,7 +1244,6 @@ def main(cfg: DictConfig) -> None:
             cal_temp_scale = bool(cal_cfg.get("temp_scale", True))
 
             if not plan.skip_knn:
-                knn_device = cfg.eval.get("knn_device") or cfg.device
                 knn_score, knn_lo, knn_hi, knn_cal, knn_n_bins = evaluate_knn(
                     x_train,
                     y_train,

--- a/tests/test_knn_gpu_parity.py
+++ b/tests/test_knn_gpu_parity.py
@@ -8,10 +8,11 @@ import numpy as np
 import pytest
 import torch
 
-from torchgeo_bench.knn import KNNClassifier
+from torchgeo_bench.knn import KNNClassifier, gpu_faiss_available
 
 pytestmark = pytest.mark.skipif(
-    not torch.cuda.is_available(), reason="requires CUDA for cpu/cuda parity"
+    not torch.cuda.is_available() or not gpu_faiss_available(),
+    reason="requires torch CUDA and GPU-enabled FAISS for cpu/cuda parity",
 )
 
 N_TRAIN, N_TEST, DIM, K, N_CLASSES = 2000, 500, 64, 5, 10

--- a/tests/test_main_fast.py
+++ b/tests/test_main_fast.py
@@ -6,6 +6,7 @@ from unittest import mock
 
 import numpy as np
 import pandas as pd
+import pytest
 import torch
 from hydra import compose, initialize_config_module
 from omegaconf import DictConfig
@@ -136,6 +137,50 @@ def test_knn_row_emitted(tmp_path: Path):
     row = df[df["method"] == "knn5"].iloc[0]
     assert row["metric_name"] == "accuracy"
     assert row["dataset"] == "m-eurosat"
+
+
+def test_implicit_gpu_knn_fallback_reaches_evaluator_as_cpu(tmp_path: Path, monkeypatch):
+    import torchgeo_bench.knn as knn
+
+    out = tmp_path / "out.csv"
+    cfg = _compose_cfg(
+        out,
+        overrides=["device=cuda:0", "eval.knn_device=null", "eval.skip_linear=true"],
+    )
+    model = _chainable_model_mock()
+    monkeypatch.setattr(knn, "gpu_faiss_available", lambda: False)
+
+    with (
+        mock.patch("torchgeo_bench.main.get_datasets", return_value=_synthetic_loaders()),
+        mock.patch("torchgeo_bench.main.instantiate", return_value=model),
+        mock.patch("torchgeo_bench.main.embed_split", side_effect=_synthetic_embeddings()),
+        mock.patch(
+            "torchgeo_bench.main.evaluate_knn",
+            return_value=(0.5, 0.45, 0.55, {"ece": 0.05, "rms_ce": 0.07, "mce": 0.1}, 6),
+        ) as knn_mock,
+    ):
+        main.__wrapped__(cfg)
+
+    assert knn_mock.call_args.kwargs["device"] == "cpu"
+
+
+def test_explicit_gpu_knn_without_gpu_faiss_fails_before_data_loading(tmp_path: Path, monkeypatch):
+    import torchgeo_bench.knn as knn
+
+    out = tmp_path / "out.csv"
+    cfg = _compose_cfg(
+        out,
+        overrides=["device=cuda:0", "eval.knn_device=cuda", "eval.skip_linear=true"],
+    )
+    monkeypatch.setattr(knn, "gpu_faiss_available", lambda: False)
+
+    with (
+        mock.patch("torchgeo_bench.main.get_datasets") as data_mock,
+        pytest.raises(RuntimeError, match="explicit KNN device 'cuda'"),
+    ):
+        main.__wrapped__(cfg)
+
+    data_mock.assert_not_called()
 
 
 def test_linear_row_emitted(tmp_path: Path):

--- a/tests/test_multilabel.py
+++ b/tests/test_multilabel.py
@@ -1,12 +1,14 @@
 """Tests for multi-label support and KNNClassifier."""
 
 import builtins
+import logging
 
 import numpy as np
 import pytest
 import torch
 
-from torchgeo_bench.knn import KNNClassifier
+import torchgeo_bench.knn as knn
+from torchgeo_bench.knn import KNNClassifier, resolve_knn_device
 from torchgeo_bench.linear import LogisticRegression
 
 
@@ -218,8 +220,8 @@ _cuda_available = pytest.mark.skipif(
     not __import__("torch").cuda.is_available(), reason="CUDA not available"
 )
 _faissknn_available = pytest.mark.skipif(
-    __import__("importlib").util.find_spec("faissknn") is None,
-    reason="faissknn not installed (pip install torchgeo-bench[cuda])",
+    not knn.gpu_faiss_available(),
+    reason="GPU-enabled FAISS is not installed",
 )
 
 
@@ -349,6 +351,39 @@ class TestKNNGPUPath:
         clf = KNNClassifier(n_neighbors=5, device="cuda")
         with pytest.raises(ImportError, match='request device="cpu"'):
             clf.fit(d["x_train"], d["y_train"])
+
+    def test_explicit_gpu_with_cpu_faiss_raises_actionable_error(
+        self, singlelabel_data, monkeypatch
+    ):
+        monkeypatch.setattr(knn, "gpu_faiss_available", lambda: False)
+        d = singlelabel_data
+        clf = KNNClassifier(n_neighbors=5, device="cuda")
+        with pytest.raises(RuntimeError, match="eval.knn_device=cpu"):
+            clf.fit(d["x_train"], d["y_train"])
+
+
+class TestResolveKNNDevice:
+    def test_implicit_gpu_falls_back_to_cpu(self, monkeypatch, caplog: pytest.LogCaptureFixture):
+        monkeypatch.setattr(knn, "gpu_faiss_available", lambda: False)
+
+        with caplog.at_level(logging.WARNING):
+            device = resolve_knn_device(None, "cuda:0")
+
+        assert device == "cpu"
+        assert "using CPU for KNN" in caplog.text
+
+    def test_implicit_gpu_uses_available_gpu_faiss(self, monkeypatch):
+        monkeypatch.setattr(knn, "gpu_faiss_available", lambda: True)
+        assert resolve_knn_device(None, "cuda:1") == "cuda:1"
+
+    def test_explicit_gpu_requires_gpu_faiss(self, monkeypatch):
+        monkeypatch.setattr(knn, "gpu_faiss_available", lambda: False)
+        with pytest.raises(RuntimeError, match="explicit KNN device 'cuda:1'"):
+            resolve_knn_device("cuda:1", "cuda:0")
+
+    def test_explicit_cpu_is_preserved(self, monkeypatch):
+        monkeypatch.setattr(knn, "gpu_faiss_available", lambda: False)
+        assert resolve_knn_device("cpu", "cuda:0") == "cpu"
 
 
 # ---- Unified evaluate_knn / evaluate_logistic tests ----


### PR DESCRIPTION
## Summary

- follow the configured model device for KNN when `eval.knn_device=null`, but automatically use CPU KNN—with a warning—when the platform-selected FAISS backend has no GPU resources
- keep explicit unsupported KNN device requests fail-loud and reject them before loading datasets or instantiating models
- make GPU parity tests require both torch CUDA and a GPU-enabled FAISS backend

## Stacked dependency

This branch is rebased directly onto #152 (`b4a8787`). Because #152’s source ref is not exposed as a repository branch, `copilot/pr152-stack-base` temporarily mirrors that exact commit so GitHub displays only this PR’s fallback delta.

After #152 merges, rebase these three commits onto updated `main`, retarget this PR to `main`, and delete the temporary stack-base branch. This final rebase is required if #152 is squash-merged.

This PR intentionally contains no dependency, lockfile, CUDA-extra, manual backend-install, or V100 torch changes beyond its #152 base.

## Why the fallback remains useful

#152 selects `faissknn[cuda]` automatically on Linux x86_64 and `faissknn[cpu]` elsewhere. Mixed accelerator/model + CPU-KNN configurations still occur, including macOS MPS, Linux non-x86 accelerators, and deliberate CPU-backend installs. Without this fallback, `knn_device=null` inherits the accelerator and tries the GPU faissknn path against CPU-only FAISS.

## Semantics

- `knn_device=null`, `device=cpu` → CPU KNN
- `knn_device=null`, accelerator model + GPU FAISS → same accelerator KNN
- `knn_device=null`, accelerator model + CPU-only FAISS → warning + CPU KNN
- explicit unsupported `eval.knn_device=<accelerator>` → actionable error before data/model work

## Validation

- focused orchestration/KNN suite: 45 passed
- full fast suite: 368 passed, 37 skipped, 116 deselected
- slow GPU KNN suite: 7 passed
- Ruff check/format and diff checks pass
- previously validated end-to-end with GPU feature extraction plus automatic CPU KNN fallback