### PR TITLE
Skip resume-only datasets before model initialization

### DIFF
--- a/src/torchgeo_bench/main.py
+++ b/src/torchgeo_bench/main.py
@@ -276,8 +276,6 @@ class EvaluationResult:
 class DatasetRunPlan:
     """Resume-aware execution plan for one dataset/config combination."""
 
-    eval_cfg: DictConfig
-    is_segmentation: bool
     metric_name: str
     knn_k: int
     seg_method: str
@@ -286,37 +284,24 @@ class DatasetRunPlan:
     skip_linear: bool
     skip_id: bool
     skip_profile: bool
-    id_cfg: DictConfig | None = None
-    profile_cfg: DictConfig | None = None
-
-
-def _merged_eval_cfg(cfg: DictConfig) -> DictConfig:
-    """Return the global eval config with model-specific overrides applied."""
-    return OmegaConf.merge(
-        cfg.eval,
-        cfg.model.eval if "eval" in cfg.model and cfg.model.eval is not None else {},
-    )
 
 
 def _plan_dataset_run(
     cfg: DictConfig,
     ds_name: str,
     ds_cls: type,
-    eval_cfg: DictConfig,
+    knn_k: int,
+    seg_method: str,
     config_tuple: tuple[str, ...],
     completed_runs: set[tuple[str, ...]],
     completed_metrics: dict[str, set[tuple[str, ...]]],
 ) -> DatasetRunPlan:
     """Plan which work remains for a dataset before loading data or a model."""
-    knn_k = int(getattr(eval_cfg, "knn_k", 5))
-    seg_method = f"seg-{eval_cfg.segmentation.head_type}"
     model_key = (cfg.model._target_, cfg.model.name, *config_tuple)
 
     if ds_cls.task == "segmentation":
         seg_key = (ds_name, seg_method, *model_key)
         return DatasetRunPlan(
-            eval_cfg=eval_cfg,
-            is_segmentation=True,
             metric_name="mIoU",
             knn_k=knn_k,
             seg_method=seg_method,
@@ -333,9 +318,9 @@ def _plan_dataset_run(
     profile_key = (ds_name, "profile", *model_key)
 
     skip_knn = bool(cfg.resume and knn_key in completed_runs)
-    skip_linear = bool((cfg.resume and linear_key in completed_runs) or eval_cfg.get("skip_linear"))
+    skip_linear = bool((cfg.resume and linear_key in completed_runs) or cfg.eval.skip_linear)
 
-    id_cfg = getattr(eval_cfg, "intrinsic_dim", None)
+    id_cfg = getattr(cfg.eval, "intrinsic_dim", None)
     id_enabled = bool(id_cfg and id_cfg.get("enabled", False))
     id_metric_names = (
         [f"id_{est}_{split}" for split in id_cfg.splits for est in id_cfg.estimators]
@@ -348,7 +333,7 @@ def _plan_dataset_run(
         and all(id_key in completed_metrics.get(metric, set()) for metric in id_metric_names)
     )
 
-    profile_cfg = getattr(eval_cfg, "profile", None)
+    profile_cfg = getattr(cfg.eval, "profile", None)
     profile_enabled = bool(profile_cfg and profile_cfg.get("enabled", False))
     profile_metric_names = _profile_metric_names(profile_cfg) if profile_enabled else []
     skip_profile = (not profile_enabled) or (
@@ -360,8 +345,6 @@ def _plan_dataset_run(
     )
 
     return DatasetRunPlan(
-        eval_cfg=eval_cfg,
-        is_segmentation=False,
         metric_name="micro_mAP" if ds_cls.multilabel else "accuracy",
         knn_k=knn_k,
         seg_method=seg_method,
@@ -370,8 +353,6 @@ def _plan_dataset_run(
         skip_linear=skip_linear,
         skip_id=skip_id,
         skip_profile=skip_profile,
-        id_cfg=id_cfg,
-        profile_cfg=profile_cfg,
     )
 
 
@@ -1020,8 +1001,11 @@ def main(cfg: DictConfig) -> None:
     os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
 
     all_rows: list[dict] = []
-    eval_cfg_merged = _merged_eval_cfg(cfg)
-    c_start, c_stop, c_num = eval_cfg_merged.c_range
+    model_eval = cfg.model.get("eval", None) if "eval" in cfg.model else None
+    if model_eval is not None and model_eval.get("c_range", None) is not None:
+        c_start, c_stop, c_num = model_eval.c_range
+    else:
+        c_start, c_stop, c_num = cfg.eval.c_range
     c_values = 10 ** np.linspace(float(c_start), float(c_stop), int(c_num))
     c_values_list = [float(v) for v in c_values.tolist()]
 
@@ -1086,11 +1070,15 @@ def main(cfg: DictConfig) -> None:
                 bands_value,
             )
         )
+        eval_cfg_merged = OmegaConf.merge(cfg.eval, model_eval or {})
+        knn_k = int(getattr(eval_cfg_merged, "knn_k", 5))
+        seg_method = f"seg-{eval_cfg_merged.segmentation.head_type}"
         plan = _plan_dataset_run(
             cfg=cfg,
             ds_name=ds_name,
             ds_cls=ds_cls,
-            eval_cfg=eval_cfg_merged,
+            knn_k=knn_k,
+            seg_method=seg_method,
             config_tuple=config_tuple,
             completed_runs=completed_runs,
             completed_metrics=completed_metrics,
@@ -1169,8 +1157,8 @@ def main(cfg: DictConfig) -> None:
             "c_range_start": c_start,
             "c_range_stop": c_stop,
             "c_range_num": c_num,
-            "merge_val": eval_cfg_merged.merge_val,
-            "bootstrap": eval_cfg_merged.bootstrap,
+            "merge_val": cfg.eval.merge_val,
+            "bootstrap": cfg.eval.bootstrap,
         }
 
         if is_segmentation:
@@ -1248,20 +1236,20 @@ def main(cfg: DictConfig) -> None:
             x_test, y_test = embed_split(model, test_loader, device, verbose=cfg.verbose)
             feature_dim = x_train.shape[1]
 
-            cal_cfg = eval_cfg_merged.get("calibration", {}) or {}
+            cal_cfg = cfg.eval.get("calibration", {}) or {}
             cal_n_bins_knn = cal_cfg.get("n_bins_knn", None)
             cal_n_bins_linear = int(cal_cfg.get("n_bins_linear", 15))
             cal_temp_scale = bool(cal_cfg.get("temp_scale", True))
 
             if not plan.skip_knn:
-                knn_device = eval_cfg_merged.get("knn_device") or cfg.device
+                knn_device = cfg.eval.get("knn_device") or cfg.device
                 knn_score, knn_lo, knn_hi, knn_cal, knn_n_bins = evaluate_knn(
                     x_train,
                     y_train,
                     x_test,
                     y_test,
                     cfg.seed,
-                    eval_cfg_merged.bootstrap,
+                    cfg.eval.bootstrap,
                     verbose=cfg.verbose,
                     device=knn_device,
                     n_neighbors=plan.knn_k,
@@ -1299,8 +1287,8 @@ def main(cfg: DictConfig) -> None:
                     y_test,
                     c_values_list,
                     cfg.seed,
-                    eval_cfg_merged.bootstrap,
-                    eval_cfg_merged.merge_val,
+                    cfg.eval.bootstrap,
+                    cfg.eval.merge_val,
                     cfg.device,
                     cfg.verbose,
                     calibration_n_bins=cal_n_bins_linear,
@@ -1331,10 +1319,8 @@ def main(cfg: DictConfig) -> None:
                         calibration_n_bins=cal_n_bins_linear,
                     ).to_row()
                 )
-
             if not plan.skip_id:
-                id_cfg = plan.id_cfg
-                assert id_cfg is not None
+                id_cfg = cfg.eval.intrinsic_dim
                 id_rows = evaluate_intrinsic_dim(
                     splits={"train": x_train, "val": x_val, "test": x_test},
                     estimators=list(id_cfg.estimators),
@@ -1356,8 +1342,7 @@ def main(cfg: DictConfig) -> None:
                 all_rows.extend(id_rows)
 
             if not plan.skip_profile:
-                profile_cfg = plan.profile_cfg
-                assert profile_cfg is not None
+                profile_cfg = cfg.eval.profile
                 cpu_cfg = profile_cfg.get("cpu_throughput", {}) if profile_cfg else {}
                 profile_rows = evaluate_profile(
                     model=model,

--- a/src/torchgeo_bench/main.py
+++ b/src/torchgeo_bench/main.py
@@ -272,6 +272,109 @@ class EvaluationResult:
         return self.__dict__.copy()
 
 
+@dataclass(frozen=True)
+class DatasetRunPlan:
+    """Resume-aware execution plan for one dataset/config combination."""
+
+    eval_cfg: DictConfig
+    is_segmentation: bool
+    metric_name: str
+    knn_k: int
+    seg_method: str
+    skip_dataset: bool
+    skip_knn: bool
+    skip_linear: bool
+    skip_id: bool
+    skip_profile: bool
+    id_cfg: DictConfig | None = None
+    profile_cfg: DictConfig | None = None
+
+
+def _merged_eval_cfg(cfg: DictConfig) -> DictConfig:
+    """Return the global eval config with model-specific overrides applied."""
+    return OmegaConf.merge(
+        cfg.eval,
+        cfg.model.eval if "eval" in cfg.model and cfg.model.eval is not None else {},
+    )
+
+
+def _plan_dataset_run(
+    cfg: DictConfig,
+    ds_name: str,
+    ds_cls: type,
+    eval_cfg: DictConfig,
+    config_tuple: tuple[str, ...],
+    completed_runs: set[tuple[str, ...]],
+    completed_metrics: dict[str, set[tuple[str, ...]]],
+) -> DatasetRunPlan:
+    """Plan which work remains for a dataset before loading data or a model."""
+    knn_k = int(getattr(eval_cfg, "knn_k", 5))
+    seg_method = f"seg-{eval_cfg.segmentation.head_type}"
+    model_key = (cfg.model._target_, cfg.model.name, *config_tuple)
+
+    if ds_cls.task == "segmentation":
+        seg_key = (ds_name, seg_method, *model_key)
+        return DatasetRunPlan(
+            eval_cfg=eval_cfg,
+            is_segmentation=True,
+            metric_name="mIoU",
+            knn_k=knn_k,
+            seg_method=seg_method,
+            skip_dataset=bool(cfg.resume and seg_key in completed_runs),
+            skip_knn=True,
+            skip_linear=True,
+            skip_id=True,
+            skip_profile=True,
+        )
+
+    knn_key = (ds_name, f"knn{knn_k}", *model_key)
+    linear_key = (ds_name, "linear", *model_key)
+    id_key = (ds_name, "intrinsic_dim", *model_key)
+    profile_key = (ds_name, "profile", *model_key)
+
+    skip_knn = bool(cfg.resume and knn_key in completed_runs)
+    skip_linear = bool((cfg.resume and linear_key in completed_runs) or eval_cfg.get("skip_linear"))
+
+    id_cfg = getattr(eval_cfg, "intrinsic_dim", None)
+    id_enabled = bool(id_cfg and id_cfg.get("enabled", False))
+    id_metric_names = (
+        [f"id_{est}_{split}" for split in id_cfg.splits for est in id_cfg.estimators]
+        if id_enabled
+        else []
+    )
+    skip_id = (not id_enabled) or (
+        cfg.resume
+        and id_metric_names
+        and all(id_key in completed_metrics.get(metric, set()) for metric in id_metric_names)
+    )
+
+    profile_cfg = getattr(eval_cfg, "profile", None)
+    profile_enabled = bool(profile_cfg and profile_cfg.get("enabled", False))
+    profile_metric_names = _profile_metric_names(profile_cfg) if profile_enabled else []
+    skip_profile = (not profile_enabled) or (
+        cfg.resume
+        and profile_metric_names
+        and all(
+            profile_key in completed_metrics.get(metric, set()) for metric in profile_metric_names
+        )
+    )
+
+    return DatasetRunPlan(
+        eval_cfg=eval_cfg,
+        is_segmentation=False,
+        metric_name="micro_mAP" if ds_cls.multilabel else "accuracy",
+        knn_k=knn_k,
+        seg_method=seg_method,
+        skip_dataset=skip_knn and skip_linear and skip_id and skip_profile,
+        skip_knn=skip_knn,
+        skip_linear=skip_linear,
+        skip_id=skip_id,
+        skip_profile=skip_profile,
+        id_cfg=id_cfg,
+        profile_cfg=profile_cfg,
+    )
+
+
 def embed_split(
     model: BenchModel, dataloader: DataLoader, device: torch.device, verbose: bool
 ) -> tuple[np.ndarray, np.ndarray]:
@@ -917,11 +1020,8 @@ def main(cfg: DictConfig) -> None:
     os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
 
     all_rows: list[dict] = []
-    model_eval = cfg.model.get("eval", None) if "eval" in cfg.model else None
-    if model_eval is not None and model_eval.get("c_range", None) is not None:
-        c_start, c_stop, c_num = model_eval.c_range
-    else:
-        c_start, c_stop, c_num = cfg.eval.c_range
+    eval_cfg_merged = _merged_eval_cfg(cfg)
+    c_start, c_stop, c_num = eval_cfg_merged.c_range
     c_values = 10 ** np.linspace(float(c_start), float(c_stop), int(c_num))
     c_values_list = [float(v) for v in c_values.tolist()]
 
@@ -986,22 +1086,19 @@ def main(cfg: DictConfig) -> None:
                 bands_value,
             )
         )
-
-        # Merge model-specific eval config early so resume key and result rows
-        # reflect the actual head_type used, not the global default.
-        eval_cfg_merged = OmegaConf.merge(
-            cfg.eval,
-            cfg.model.eval if "eval" in cfg.model and cfg.model.eval is not None else {},
+        plan = _plan_dataset_run(
+            cfg=cfg,
+            ds_name=ds_name,
+            ds_cls=ds_cls,
+            eval_cfg=eval_cfg_merged,
+            config_tuple=config_tuple,
+            completed_runs=completed_runs,
+            completed_metrics=completed_metrics,
         )
-
-        knn_k = int(getattr(eval_cfg_merged, "knn_k", 5))
-        knn_key = (ds_name, f"knn{knn_k}", cfg.model._target_, cfg.model.name, *config_tuple)
-        linear_key = (ds_name, "linear", cfg.model._target_, cfg.model.name, *config_tuple)
-
-        seg_method = f"seg-{eval_cfg_merged.segmentation.head_type}"
-        seg_key = (ds_name, seg_method, cfg.model._target_, cfg.model.name, *config_tuple)
-        id_key = (ds_name, "intrinsic_dim", cfg.model._target_, cfg.model.name, *config_tuple)
-        profile_key = (ds_name, "profile", cfg.model._target_, cfg.model.name, *config_tuple)
+        if plan.skip_dataset:
+            if cfg.verbose:
+                logger.info(f"[{ds_name}] Resume preflight: all requested work already complete")
+            continue
 
         try:
             result = get_datasets(
@@ -1024,7 +1121,6 @@ def main(cfg: DictConfig) -> None:
 
         num_channels = train_dataset[0]["image"].shape[0]
         is_segmentation = ds_cls.task == "segmentation"
-        is_multilabel = ds_cls.multilabel
         num_classes = ds_cls.num_classes
 
         # Build the BandSpec list that matches the actual loaded channels.
@@ -1041,12 +1137,6 @@ def main(cfg: DictConfig) -> None:
             f"BandSpec count {len(bands_list)} != tensor channel count {num_channels} "
             f"for dataset {ds_name}; sample-level canonicalization may have changed shape."
         )
-
-        # Resume check for segmentation
-        if is_segmentation and cfg.resume and seg_key in completed_runs:
-            if cfg.verbose:
-                logger.info(f"[{ds_name}] Skipping segmentation (already computed)")
-            continue
 
         # Instantiate Backbone — pass `bands` post-hoc so Hydra never tries
         # to OmegaConf-ify the BandSpec list.  `_convert_="object"` keeps
@@ -1079,15 +1169,12 @@ def main(cfg: DictConfig) -> None:
             "c_range_start": c_start,
             "c_range_stop": c_stop,
             "c_range_num": c_num,
-            "merge_val": cfg.eval.merge_val,
-            "bootstrap": cfg.eval.bootstrap,
+            "merge_val": eval_cfg_merged.merge_val,
+            "bootstrap": eval_cfg_merged.bootstrap,
         }
 
         if is_segmentation:
-            seg_cfg_merged = OmegaConf.merge(
-                cfg.eval,
-                cfg.model.eval if "eval" in cfg.model and cfg.model.eval is not None else {},
-            ).segmentation
+            seg_cfg_merged = eval_cfg_merged.segmentation
             save_viz = seg_cfg_merged.get("save_viz", False)
             metrics, feat_dim, best_lr, best_bs, preds = evaluate_segmentation(
                 model,
@@ -1102,7 +1189,7 @@ def main(cfg: DictConfig) -> None:
             all_rows.append(
                 EvaluationResult(
                     **common_meta,
-                    method=seg_method,
+                    method=plan.seg_method,
                     metric_name="mIoU",
                     metric_value=metrics.get("mIoU", float("nan")),
                     ci_lower=0.0,
@@ -1155,69 +1242,35 @@ def main(cfg: DictConfig) -> None:
                 )
         else:
             # Classification (single-label or multi-label)
-            metric_name = "micro_mAP" if is_multilabel else "accuracy"
-
-            skip_knn = cfg.resume and knn_key in completed_runs
-            skip_linear = (cfg.resume and linear_key in completed_runs) or getattr(
-                cfg.eval, "skip_linear", False
-            )
-            id_cfg = getattr(cfg.eval, "intrinsic_dim", None)
-            id_enabled = bool(id_cfg and id_cfg.get("enabled", False))
-            id_metric_names = (
-                [f"id_{est}_{split}" for split in id_cfg.splits for est in id_cfg.estimators]
-                if id_enabled
-                else []
-            )
-            skip_id = (not id_enabled) or (
-                cfg.resume
-                and id_metric_names
-                and all(
-                    id_key in completed_metrics.get(metric, set()) for metric in id_metric_names
-                )
-            )
-            profile_cfg = getattr(cfg.eval, "profile", None)
-            profile_enabled = bool(profile_cfg and profile_cfg.get("enabled", False))
-            profile_metric_names = _profile_metric_names(profile_cfg) if profile_enabled else []
-            skip_profile = (not profile_enabled) or (
-                cfg.resume
-                and profile_metric_names
-                and all(
-                    profile_key in completed_metrics.get(metric, set())
-                    for metric in profile_metric_names
-                )
-            )
-
-            if skip_knn and skip_linear and skip_id and skip_profile:
-                continue
-
+            metric_name = plan.metric_name
             x_train, y_train = embed_split(model, train_loader, device, verbose=cfg.verbose)
             x_val, y_val = embed_split(model, val_loader, device, verbose=cfg.verbose)
             x_test, y_test = embed_split(model, test_loader, device, verbose=cfg.verbose)
             feature_dim = x_train.shape[1]
 
-            cal_cfg = cfg.eval.get("calibration", {}) or {}
+            cal_cfg = eval_cfg_merged.get("calibration", {}) or {}
             cal_n_bins_knn = cal_cfg.get("n_bins_knn", None)
             cal_n_bins_linear = int(cal_cfg.get("n_bins_linear", 15))
             cal_temp_scale = bool(cal_cfg.get("temp_scale", True))
 
-            if not skip_knn:
-                knn_device = cfg.eval.get("knn_device") or cfg.device
+            if not plan.skip_knn:
+                knn_device = eval_cfg_merged.get("knn_device") or cfg.device
                 knn_score, knn_lo, knn_hi, knn_cal, knn_n_bins = evaluate_knn(
                     x_train,
                     y_train,
                     x_test,
                     y_test,
                     cfg.seed,
-                    cfg.eval.bootstrap,
+                    eval_cfg_merged.bootstrap,
                     verbose=cfg.verbose,
                     device=knn_device,
-                    n_neighbors=knn_k,
+                    n_neighbors=plan.knn_k,
                     calibration_n_bins=cal_n_bins_knn,
                 )
                 all_rows.append(
                     EvaluationResult(
                         **common_meta,
-                        method=f"knn{knn_k}",
+                        method=f"knn{plan.knn_k}",
                         metric_name=metric_name,
                         metric_value=knn_score,
                         ci_lower=knn_lo,
@@ -1236,7 +1289,7 @@ def main(cfg: DictConfig) -> None:
                     ).to_row()
                 )
 
-            if not skip_linear:
+            if not plan.skip_linear:
                 lin_score, lin_lo, lin_hi, best_c, lin_cal, lin_cal_ts = evaluate_logistic(
                     x_train,
                     y_train,
@@ -1246,8 +1299,8 @@ def main(cfg: DictConfig) -> None:
                     y_test,
                     c_values_list,
                     cfg.seed,
-                    cfg.eval.bootstrap,
-                    cfg.eval.merge_val,
+                    eval_cfg_merged.bootstrap,
+                    eval_cfg_merged.merge_val,
                     cfg.device,
                     cfg.verbose,
                     calibration_n_bins=cal_n_bins_linear,
@@ -1279,7 +1332,9 @@ def main(cfg: DictConfig) -> None:
                     ).to_row()
                 )
 
-            if not skip_id:
+            if not plan.skip_id:
+                id_cfg = plan.id_cfg
+                assert id_cfg is not None
                 id_rows = evaluate_intrinsic_dim(
                     splits={"train": x_train, "val": x_val, "test": x_test},
                     estimators=list(id_cfg.estimators),
@@ -1300,7 +1355,9 @@ def main(cfg: DictConfig) -> None:
                     id_rows = _filter_completed_metric_rows(id_rows, completed_metrics, key_cols)
                 all_rows.extend(id_rows)
 
-            if not skip_profile:
+            if not plan.skip_profile:
+                profile_cfg = plan.profile_cfg
+                assert profile_cfg is not None
                 cpu_cfg = profile_cfg.get("cpu_throughput", {}) if profile_cfg else {}
                 profile_rows = evaluate_profile(
                     model=model,

--- a/tests/test_main_fast.py
+++ b/tests/test_main_fast.py
@@ -267,6 +267,66 @@ def test_non_resume_still_runs_even_with_matching_existing_rows(tmp_path: Path):
     assert int((pd.read_csv(out)["method"] == "knn5").sum()) == 2
 
 
+def test_model_eval_overrides_do_not_change_classification_resume_semantics(tmp_path: Path):
+    out = tmp_path / "out.csv"
+    cfg = _compose_cfg(
+        out,
+        overrides=[
+            "resume=true",
+            "model=timm/resnet50",
+            "eval.knn_device=cpu",
+            "eval.merge_val=false",
+            "eval.calibration.n_bins_linear=15",
+            "+model.eval.knn_k=7",
+            "+model.eval.skip_linear=true",
+            "+model.eval.bootstrap=99",
+            "+model.eval.merge_val=true",
+            "+model.eval.knn_device=meta-device",
+            "+model.eval.calibration.n_bins_linear=99",
+        ],
+    )
+    pd.DataFrame([_resume_row(cfg, method="knn7", metric_name="accuracy")]).to_csv(out, index=False)
+    model = _chainable_model_mock()
+
+    with (
+        mock.patch(
+            "torchgeo_bench.main.get_datasets", return_value=_synthetic_loaders()
+        ) as data_mock,
+        mock.patch("torchgeo_bench.main.instantiate", return_value=model) as instantiate_mock,
+        mock.patch("torchgeo_bench.main.embed_split", side_effect=_synthetic_embeddings()),
+        mock.patch("torchgeo_bench.main.evaluate_knn") as knn_mock,
+        mock.patch(
+            "torchgeo_bench.main.evaluate_logistic",
+            return_value=(
+                0.6,
+                0.52,
+                0.66,
+                0.1,
+                {"ece": 0.04, "rms_ce": 0.06, "mce": 0.09},
+                {"ece_ts": 0.04, "rms_ce_ts": 0.06, "mce_ts": 0.09, "temperature": 0.8},
+            ),
+        ) as linear_mock,
+    ):
+        main.__wrapped__(cfg)
+
+    data_mock.assert_called_once()
+    instantiate_mock.assert_called_once()
+    knn_mock.assert_not_called()
+    linear_mock.assert_called_once()
+
+    linear_call = linear_mock.call_args
+    assert linear_call.args[8] == cfg.eval.bootstrap
+    assert linear_call.args[9] is cfg.eval.merge_val
+    assert linear_call.kwargs["calibration_n_bins"] == cfg.eval.calibration.n_bins_linear
+
+    df = pd.read_csv(out)
+    linear_row = df[df["method"] == "linear"].iloc[0]
+    assert linear_row["bootstrap"] == cfg.eval.bootstrap
+    assert bool(linear_row["merge_val"]) is bool(cfg.eval.merge_val)
+    assert int((df["method"] == "knn7").sum()) == 1
+    assert int((df["method"] == "linear").sum()) == 1
+
+
 def test_resume_skips_when_image_size_read_as_float(tmp_path: Path):
     """Regression for the resume-key int/float mismatch (image_size).
 

--- a/tests/test_main_fast.py
+++ b/tests/test_main_fast.py
@@ -109,6 +109,14 @@ def _resume_row(cfg: DictConfig, *, method: str, metric_name: str) -> dict[str, 
     }
 
 
+def _chainable_model_mock() -> mock.Mock:
+    """Return a mock model whose ``to().eval()`` chain returns itself."""
+    model = mock.Mock()
+    model.to.return_value = model
+    model.eval.return_value = model
+    return model
+
+
 def test_knn_row_emitted(tmp_path: Path):
     out = tmp_path / "out.csv"
     cfg = _compose_cfg(out, overrides=["eval.skip_linear=true"])
@@ -175,6 +183,88 @@ def test_resume_skips_completed_knn_row(tmp_path: Path):
     knn_mock.assert_not_called()
     df = pd.read_csv(out)
     assert int((df["method"] == "knn5").sum()) == 1
+
+
+def test_resume_complete_preflight_skips_data_loading_and_model_init(tmp_path: Path):
+    out = tmp_path / "out.csv"
+    cfg = _compose_cfg(out, overrides=["resume=true"])
+    pd.DataFrame(
+        [
+            _resume_row(cfg, method="knn5", metric_name="accuracy"),
+            _resume_row(cfg, method="linear", metric_name="accuracy"),
+        ]
+    ).to_csv(out, index=False)
+
+    with (
+        mock.patch("torchgeo_bench.main.get_datasets") as get_datasets_mock,
+        mock.patch("torchgeo_bench.main.instantiate") as instantiate_mock,
+    ):
+        main.__wrapped__(cfg)
+
+    get_datasets_mock.assert_not_called()
+    instantiate_mock.assert_not_called()
+    assert len(pd.read_csv(out)) == 2
+
+
+def test_resume_partial_completion_still_runs_missing_work(tmp_path: Path):
+    out = tmp_path / "out.csv"
+    cfg = _compose_cfg(out, overrides=["resume=true"])
+    pd.DataFrame([_resume_row(cfg, method="knn5", metric_name="accuracy")]).to_csv(out, index=False)
+    model = _chainable_model_mock()
+
+    with (
+        mock.patch(
+            "torchgeo_bench.main.get_datasets", return_value=_synthetic_loaders()
+        ) as data_mock,
+        mock.patch("torchgeo_bench.main.instantiate", return_value=model) as instantiate_mock,
+        mock.patch("torchgeo_bench.main.embed_split", side_effect=_synthetic_embeddings()),
+        mock.patch("torchgeo_bench.main.evaluate_knn") as knn_mock,
+        mock.patch(
+            "torchgeo_bench.main.evaluate_logistic",
+            return_value=(
+                0.6,
+                0.52,
+                0.66,
+                0.1,
+                {"ece": 0.04, "rms_ce": 0.06, "mce": 0.09},
+                {"ece_ts": 0.04, "rms_ce_ts": 0.06, "mce_ts": 0.09, "temperature": 0.8},
+            ),
+        ) as linear_mock,
+    ):
+        main.__wrapped__(cfg)
+
+    data_mock.assert_called_once()
+    instantiate_mock.assert_called_once()
+    knn_mock.assert_not_called()
+    linear_mock.assert_called_once()
+    df = pd.read_csv(out)
+    assert int((df["method"] == "knn5").sum()) == 1
+    assert int((df["method"] == "linear").sum()) == 1
+
+
+def test_non_resume_still_runs_even_with_matching_existing_rows(tmp_path: Path):
+    out = tmp_path / "out.csv"
+    cfg = _compose_cfg(out, overrides=["eval.skip_linear=true"])
+    pd.DataFrame([_resume_row(cfg, method="knn5", metric_name="accuracy")]).to_csv(out, index=False)
+    model = _chainable_model_mock()
+
+    with (
+        mock.patch(
+            "torchgeo_bench.main.get_datasets", return_value=_synthetic_loaders()
+        ) as data_mock,
+        mock.patch("torchgeo_bench.main.instantiate", return_value=model) as instantiate_mock,
+        mock.patch("torchgeo_bench.main.embed_split", side_effect=_synthetic_embeddings()),
+        mock.patch(
+            "torchgeo_bench.main.evaluate_knn",
+            return_value=(0.5, 0.45, 0.55, {"ece": 0.05, "rms_ce": 0.07, "mce": 0.1}, 6),
+        ) as knn_mock,
+    ):
+        main.__wrapped__(cfg)
+
+    data_mock.assert_called_once()
+    instantiate_mock.assert_called_once()
+    knn_mock.assert_called_once()
+    assert int((pd.read_csv(out)["method"] == "knn5").sum()) == 2
 
 
 def test_resume_skips_when_image_size_read_as_float(tmp_path: Path):

--- a/tests/test_main_segmentation_fast.py
+++ b/tests/test_main_segmentation_fast.py
@@ -9,7 +9,7 @@ from torch.utils.data import DataLoader, Dataset
 
 from torchgeo_bench.main import main
 
-from .test_main_fast import _compose_cfg
+from .test_main_fast import _chainable_model_mock, _compose_cfg
 
 
 class _SegmentationDataset(Dataset):
@@ -140,15 +140,17 @@ def test_segmentation_resume_skips_complete_run(tmp_path: Path):
     out = tmp_path / "out.csv"
     cfg = _cfg_for_segmentation(out, overrides=["resume=true"])
     pd.DataFrame([_seg_resume_row(cfg)]).to_csv(out, index=False)
+    model = _chainable_model_mock()
 
     with (
-        mock.patch(
-            "torchgeo_bench.main.get_datasets", return_value=_synthetic_segmentation_loaders()
-        ),
+        mock.patch("torchgeo_bench.main.get_datasets") as data_mock,
+        mock.patch("torchgeo_bench.main.instantiate", return_value=model) as instantiate_mock,
         mock.patch("torchgeo_bench.main._build_seg_probe_and_solver") as build_mock,
     ):
         main.__wrapped__(cfg)
 
+    data_mock.assert_not_called()
+    instantiate_mock.assert_not_called()
     build_mock.assert_not_called()
     df = pd.read_csv(out)
     assert int((df["method"] == "seg-fpn").sum()) == 1


### PR DESCRIPTION
## Summary
- add a resume preflight that decides whether a dataset/config still has pending work before loading data or instantiating the backbone
- reuse the merged eval config for resume planning so method-specific overrides continue to match the executed methods
- add focused tests covering full resume preflight skips, partial resume execution, unchanged non-resume behavior, and segmentation resume preflight

## Testing
- `PYTHONPATH=$PWD/src /mnt/code/torchgeo-bench/.venv/bin/ruff check src/torchgeo_bench/main.py tests/test_main_fast.py tests/test_main_segmentation_fast.py`
- `PYTHONPATH=$PWD/src /mnt/code/torchgeo-bench/.venv/bin/pytest tests/test_main_fast.py tests/test_main_segmentation_fast.py tests/test_main_intrinsic_dim_fast.py tests/test_main_profile_fast.py tests/test_main_multilabel_fast.py tests/test_main_utils.py`