### PR TITLE
Clean up downloaded dataset archives

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,13 @@ same way (`torchgeo-bench download geobench_v2`, `torchgeo-bench download
 eurosat`). See the [documentation](https://torchgeo.org/torchgeo-bench/user/datasets.html)
 for all options.
 
+For GeoBench V1, the full download command writes the legacy HDF5 layout to
+`data/classification_v1.0/`. If you skip that command and request a single V1
+dataset at runtime, torchgeo-bench may instead auto-download a sharded
+WebDataset mirror under `data/classification_v1.0_wds/`. Those layouts are
+intentionally distinct; the runtime loader reuses `classification_v1.0/` when
+present and does not convert between formats automatically.
+
 ## Run a basic experiment
 
 ```bash

--- a/src/torchgeo_bench/download.py
+++ b/src/torchgeo_bench/download.py
@@ -81,11 +81,50 @@ def _decompress_zip_with_progress(zip_path: Path, extract_to: Path) -> None:
     _remove_download_artifact(zip_path, reason=f"successfully extracting {zip_path.name}")
 
 
-def _eurosat_is_ready(target: Path) -> bool:
-    """Return whether EuroSAT extraction and split setup are complete."""
-    image_dir = target / EUROSAT_BASE_DIR
-    split_files = [target / split_filename for split_filename in EUROSAT_SPLIT_FILENAMES]
-    return image_dir.is_dir() and all(split_file.is_file() for split_file in split_files)
+def _eurosat_archive_matches_extracted_data(target: Path, archive: Path) -> bool:
+    """Return whether the extracted EuroSAT tree fully matches ``archive``."""
+    missing_split_files = [
+        split_filename
+        for split_filename in EUROSAT_SPLIT_FILENAMES
+        if not (target / split_filename).is_file()
+    ]
+    if missing_split_files:
+        logger.info(
+            "Keeping %s because EuroSAT split setup is incomplete: missing %s",
+            archive,
+            ", ".join(missing_split_files),
+        )
+        return False
+
+    try:
+        with zipfile.ZipFile(archive, "r") as zf:
+            for member in zf.infolist():
+                if member.is_dir():
+                    continue
+                extracted_path = target / member.filename
+                if not extracted_path.is_file():
+                    logger.info(
+                        "Keeping %s because extracted EuroSAT member is missing: %s",
+                        archive,
+                        member.filename,
+                    )
+                    return False
+                extracted_size = extracted_path.stat().st_size
+                if extracted_size != member.file_size:
+                    logger.info(
+                        "Keeping %s because extracted EuroSAT member size mismatched for %s "
+                        "(expected %s, found %s)",
+                        archive,
+                        member.filename,
+                        member.file_size,
+                        extracted_size,
+                    )
+                    return False
+    except zipfile.BadZipFile as error:
+        logger.info("Keeping %s because EuroSAT archive verification failed: %s", archive, error)
+        return False
+
+    return True
 
 
 def _cleanup_eurosat_archive(target: Path) -> None:
@@ -93,8 +132,7 @@ def _cleanup_eurosat_archive(target: Path) -> None:
     archive = target / EUROSAT_ARCHIVE_NAME
     if not archive.exists():
         return
-    if not _eurosat_is_ready(target):
-        logger.info("Keeping %s because EuroSAT extraction or split setup is incomplete.", archive)
+    if not _eurosat_archive_matches_extracted_data(target, archive):
         return
     _remove_download_artifact(
         archive,

--- a/src/torchgeo_bench/download.py
+++ b/src/torchgeo_bench/download.py
@@ -23,6 +23,10 @@ logger = logging.getLogger(__name__)
 
 GEOBENCH_V1_REPO = "recursix/geo-bench-1.0"
 GEOBENCH_V2_REPO_PREFIX = "aialliance"
+EUROSAT_ARCHIVE_NAME = EuroSAT.filename
+EUROSAT_BASE_DIR = Path(EuroSAT.base_dir)
+EUROSAT_SPLITS = tuple(EuroSAT.splits)
+EUROSAT_SPLIT_FILENAMES = tuple(EuroSAT.split_filenames[split] for split in EUROSAT_SPLITS)
 
 # Default V2 datasets to download — only those the benchmark runner knows about.
 # Sourced from torchgeo_bench.datasets.geobench_v2._V2_REGISTRY at module load.
@@ -44,13 +48,58 @@ DEFAULT_V2_DATASETS: tuple[str, ...] = (
 )
 
 
+def _format_bytes(num_bytes: int) -> str:
+    """Return a human-readable file size."""
+    size = float(num_bytes)
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if size < 1024 or unit == "TB":
+            return f"{size:.2f} {unit}"
+        size /= 1024
+    return f"{num_bytes} B"
+
+
+def _remove_download_artifact(path: Path, *, reason: str) -> None:
+    """Delete a download artifact and log reclaimed disk space."""
+    try:
+        size_bytes = path.stat().st_size
+    except FileNotFoundError:
+        return
+
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        return
+
+    logger.info("Removed %s after %s (%s reclaimed)", path, reason, _format_bytes(size_bytes))
+
+
 def _decompress_zip_with_progress(zip_path: Path, extract_to: Path) -> None:
-    """Extract ``zip_path`` into ``extract_to`` with a progress bar; delete the zip."""
+    """Extract ``zip_path`` into ``extract_to`` with a progress bar."""
     with zipfile.ZipFile(zip_path, "r") as zf:
         for name in track(zf.namelist(), description=f"Extracting {zip_path.name}"):
             zf.extract(name, extract_to)
-    zip_path.unlink()
-    logger.info("Removed zip file: %s", zip_path)
+    _remove_download_artifact(zip_path, reason=f"successfully extracting {zip_path.name}")
+
+
+def _eurosat_is_ready(target: Path) -> bool:
+    """Return whether EuroSAT extraction and split setup are complete."""
+    image_dir = target / EUROSAT_BASE_DIR
+    split_files = [target / split_filename for split_filename in EUROSAT_SPLIT_FILENAMES]
+    return image_dir.is_dir() and all(split_file.is_file() for split_file in split_files)
+
+
+def _cleanup_eurosat_archive(target: Path) -> None:
+    """Remove the downloaded EuroSAT archive once extracted data is ready."""
+    archive = target / EUROSAT_ARCHIVE_NAME
+    if not archive.exists():
+        return
+    if not _eurosat_is_ready(target):
+        logger.info("Keeping %s because EuroSAT extraction or split setup is incomplete.", archive)
+        return
+    _remove_download_artifact(
+        archive,
+        reason="successful EuroSAT extraction and split setup",
+    )
 
 
 def download_geobench_v1(output_dir: Path) -> None:
@@ -107,6 +156,7 @@ def download_eurosat(output_dir: Path) -> None:
     target = Path(output_dir) / "eurosat"
     target.mkdir(parents=True, exist_ok=True)
     logger.info("Downloading torchgeo EuroSAT -> %s", target)
-    for split in ("train", "val", "test"):
+    for split in EUROSAT_SPLITS:
         EuroSAT(root=str(target), split=split, download=True)
+    _cleanup_eurosat_archive(target)
     logger.info("EuroSAT download complete.")

--- a/tests/test_dataset_units.py
+++ b/tests/test_dataset_units.py
@@ -1,7 +1,10 @@
 """Unit tests for dataset classes that don't require real data on disk."""
 
+from unittest import mock
+
 import torch
 
+from torchgeo_bench.datasets import get_bench_dataset_class
 from torchgeo_bench.datasets.eurosat import EuroSAT, EuroSATSpatial
 from torchgeo_bench.datasets.fotw import FieldsOfTheWorld as FOTW
 
@@ -105,3 +108,29 @@ class TestEuroSATSpatialMeta:
         ds_inst = EuroSATSpatial.__new__(EuroSATSpatial)
         ds_inst.get_dataset("test", bands=None)
         assert captured["split"] == "test"
+
+
+class TestGeoBenchV1BackendSelection:
+    def test_hdf5_layout_skips_sharded_auto_download(self, monkeypatch, tmp_path):
+        import torchgeo_bench.datasets._v1_webdataset as wds_mod
+        import torchgeo_bench.datasets.geobench_v1 as v1_mod
+
+        bench = get_bench_dataset_class("m-eurosat")()
+        hdf5_root = tmp_path / "classification_v1.0"
+        (hdf5_root / bench.name).mkdir(parents=True, exist_ok=True)
+        sharded_root = tmp_path / "classification_v1.0_wds"
+
+        sentinel = object()
+        geo_mock = mock.Mock(return_value=sentinel)
+        ensure_mock = mock.Mock()
+
+        monkeypatch.setattr(v1_mod, "V1_ROOT", hdf5_root)
+        monkeypatch.setattr(v1_mod, "V1_SHARDED_ROOT", sharded_root)
+        monkeypatch.setattr(v1_mod, "GeoBenchv1", geo_mock)
+        monkeypatch.setattr(wds_mod, "ensure_sharded_root", ensure_mock)
+
+        dataset = bench.get_dataset("train", bands=tuple(bench.rgb_bands))
+
+        assert dataset is sentinel
+        ensure_mock.assert_not_called()
+        geo_mock.assert_called_once()

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,14 +1,37 @@
 """Unit tests for dataset download helpers."""
 
+import logging
+import zipfile
 from pathlib import Path
 from unittest import mock
 
+import pytest
+
 from torchgeo_bench.download import (
     DEFAULT_V2_DATASETS,
+    EUROSAT_ARCHIVE_NAME,
+    EUROSAT_BASE_DIR,
+    EUROSAT_SPLIT_FILENAMES,
+    _decompress_zip_with_progress,
     download_eurosat,
     download_geobench_v1,
     download_geobench_v2,
 )
+
+
+def test_decompress_zip_with_progress_removes_archive_and_logs_cleanup(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    archive = tmp_path / "archive.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("classification_v1.0/sample.txt", "payload")
+
+    caplog.set_level(logging.INFO, logger="torchgeo_bench.download")
+    _decompress_zip_with_progress(archive, tmp_path)
+
+    assert not archive.exists()
+    assert (tmp_path / "classification_v1.0" / "sample.txt").read_text() == "payload"
+    assert any("archive.zip" in message and "reclaimed" in message for message in caplog.messages)
 
 
 def test_download_geobench_v1_creates_output_and_decompresses(tmp_path: Path) -> None:
@@ -49,11 +72,85 @@ def test_download_geobench_v2_defaults_to_registry_list(tmp_path: Path) -> None:
     assert dl_mock.call_count == len(DEFAULT_V2_DATASETS)
 
 
-def test_download_eurosat_creates_target_and_downloads_splits(tmp_path: Path) -> None:
+def test_download_eurosat_cleans_archive_after_success(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
     out = tmp_path / "data"
+    target = out / "eurosat"
+    target.mkdir(parents=True, exist_ok=True)
+    archive = target / EUROSAT_ARCHIVE_NAME
+    archive.write_bytes(b"archive-bytes")
+    called_splits: list[str] = []
+
+    def _fake_eurosat(*, root: str, split: str, download: bool) -> None:
+        assert download is True
+        called_splits.append(split)
+        dataset_root = Path(root)
+        (dataset_root / EUROSAT_BASE_DIR).mkdir(parents=True, exist_ok=True)
+        for split_filename in EUROSAT_SPLIT_FILENAMES:
+            (dataset_root / split_filename).write_text(split_filename)
+
+    caplog.set_level(logging.INFO, logger="torchgeo_bench.download")
+    with mock.patch("torchgeo_bench.download.EuroSAT", side_effect=_fake_eurosat):
+        download_eurosat(out)
+
+    assert target.exists()
+    assert called_splits == ["train", "val", "test"]
+    assert not archive.exists()
+    assert any(
+        EUROSAT_ARCHIVE_NAME in message and "reclaimed" in message for message in caplog.messages
+    )
+
+
+def test_download_eurosat_keeps_archive_when_split_setup_fails(tmp_path: Path) -> None:
+    out = tmp_path / "data"
+    target = out / "eurosat"
+    target.mkdir(parents=True, exist_ok=True)
+    archive = target / EUROSAT_ARCHIVE_NAME
+    archive.write_bytes(b"archive-bytes")
+
+    def _fake_eurosat(*, root: str, split: str, download: bool) -> None:
+        assert download is True
+        dataset_root = Path(root)
+        (dataset_root / EUROSAT_BASE_DIR).mkdir(parents=True, exist_ok=True)
+        (dataset_root / f"partial-{split}.txt").write_text(split)
+        if split == "val":
+            raise RuntimeError("split setup failed")
+
+    with (
+        mock.patch("torchgeo_bench.download.EuroSAT", side_effect=_fake_eurosat),
+        pytest.raises(RuntimeError, match="split setup failed"),
+    ):
+        download_eurosat(out)
+
+    assert archive.exists()
+
+
+def test_download_eurosat_is_idempotent_when_archive_is_missing(tmp_path: Path) -> None:
+    out = tmp_path / "data"
+    target = out / "eurosat"
+    (target / EUROSAT_BASE_DIR).mkdir(parents=True, exist_ok=True)
+    for split_filename in EUROSAT_SPLIT_FILENAMES:
+        (target / split_filename).write_text(split_filename)
+
     with mock.patch("torchgeo_bench.download.EuroSAT") as eurosat_mock:
         download_eurosat(out)
 
-    assert (out / "eurosat").exists()
+    assert not (target / EUROSAT_ARCHIVE_NAME).exists()
     called_splits = [kwargs["split"] for _, kwargs in eurosat_mock.call_args_list]
     assert called_splits == ["train", "val", "test"]
+
+
+def test_download_eurosat_cleans_stale_archive_when_already_extracted(tmp_path: Path) -> None:
+    out = tmp_path / "data"
+    target = out / "eurosat"
+    (target / EUROSAT_BASE_DIR).mkdir(parents=True, exist_ok=True)
+    for split_filename in EUROSAT_SPLIT_FILENAMES:
+        (target / split_filename).write_text(split_filename)
+    archive = target / EUROSAT_ARCHIVE_NAME
+    archive.write_bytes(b"archive-bytes")
+
+    with mock.patch("torchgeo_bench.download.EuroSAT"):
+        download_eurosat(out)
+
+    assert not archive.exists()

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -12,11 +12,47 @@ from torchgeo_bench.download import (
     EUROSAT_ARCHIVE_NAME,
     EUROSAT_BASE_DIR,
     EUROSAT_SPLIT_FILENAMES,
+    _cleanup_eurosat_archive,
     _decompress_zip_with_progress,
     download_eurosat,
     download_geobench_v1,
     download_geobench_v2,
 )
+
+
+def _eurosat_members() -> dict[str, bytes]:
+    return {
+        (EUROSAT_BASE_DIR / "AnnualCrop" / "sample-1.tif").as_posix(): b"abcd",
+        (EUROSAT_BASE_DIR / "Forest" / "sample-2.tif").as_posix(): b"efghij",
+    }
+
+
+def _create_eurosat_archive(target: Path, members: dict[str, bytes] | None = None) -> Path:
+    archive = target / EUROSAT_ARCHIVE_NAME
+    with zipfile.ZipFile(archive, "w") as zf:
+        for relative_path, payload in (members or _eurosat_members()).items():
+            zf.writestr(relative_path, payload)
+    return archive
+
+
+def _write_eurosat_split_files(target: Path) -> None:
+    for split_filename in EUROSAT_SPLIT_FILENAMES:
+        (target / split_filename).write_text(split_filename)
+
+
+def _write_extracted_members(
+    target: Path,
+    members: dict[str, bytes] | None = None,
+    *,
+    skip: set[str] | None = None,
+    overrides: dict[str, bytes] | None = None,
+) -> None:
+    for relative_path, payload in (members or _eurosat_members()).items():
+        if skip and relative_path in skip:
+            continue
+        output_path = target / relative_path
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(overrides.get(relative_path, payload) if overrides else payload)
 
 
 def test_decompress_zip_with_progress_removes_archive_and_logs_cleanup(
@@ -72,23 +108,113 @@ def test_download_geobench_v2_defaults_to_registry_list(tmp_path: Path) -> None:
     assert dl_mock.call_count == len(DEFAULT_V2_DATASETS)
 
 
+def test_cleanup_eurosat_archive_keeps_archive_for_empty_extraction(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    target = tmp_path / "eurosat"
+    target.mkdir(parents=True, exist_ok=True)
+    archive = _create_eurosat_archive(target)
+    (target / EUROSAT_BASE_DIR).mkdir(parents=True, exist_ok=True)
+    _write_eurosat_split_files(target)
+
+    caplog.set_level(logging.INFO, logger="torchgeo_bench.download")
+    _cleanup_eurosat_archive(target)
+
+    assert archive.exists()
+    assert any("member is missing" in message for message in caplog.messages)
+
+
+def test_cleanup_eurosat_archive_keeps_archive_for_partial_extraction(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    target = tmp_path / "eurosat"
+    target.mkdir(parents=True, exist_ok=True)
+    members = _eurosat_members()
+    archive = _create_eurosat_archive(target, members)
+    missing_member = next(reversed(members))
+    _write_extracted_members(target, members, skip={missing_member})
+    _write_eurosat_split_files(target)
+
+    caplog.set_level(logging.INFO, logger="torchgeo_bench.download")
+    _cleanup_eurosat_archive(target)
+
+    assert archive.exists()
+    assert any(missing_member in message for message in caplog.messages)
+
+
+def test_cleanup_eurosat_archive_keeps_archive_when_member_is_missing(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    target = tmp_path / "eurosat"
+    target.mkdir(parents=True, exist_ok=True)
+    members = _eurosat_members()
+    archive = _create_eurosat_archive(target, members)
+    _write_extracted_members(target, members)
+    missing_member = next(iter(members))
+    (target / missing_member).unlink()
+    _write_eurosat_split_files(target)
+
+    caplog.set_level(logging.INFO, logger="torchgeo_bench.download")
+    _cleanup_eurosat_archive(target)
+
+    assert archive.exists()
+    assert any(missing_member in message for message in caplog.messages)
+
+
+def test_cleanup_eurosat_archive_keeps_archive_when_member_size_mismatches(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    target = tmp_path / "eurosat"
+    target.mkdir(parents=True, exist_ok=True)
+    members = _eurosat_members()
+    archive = _create_eurosat_archive(target, members)
+    mismatch_member = next(iter(members))
+    _write_extracted_members(
+        target,
+        members,
+        overrides={mismatch_member: members[mismatch_member] + b"extra"},
+    )
+    _write_eurosat_split_files(target)
+
+    caplog.set_level(logging.INFO, logger="torchgeo_bench.download")
+    _cleanup_eurosat_archive(target)
+
+    assert archive.exists()
+    assert any("size mismatched" in message for message in caplog.messages)
+
+
+def test_cleanup_eurosat_archive_keeps_corrupt_archive(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    target = tmp_path / "eurosat"
+    target.mkdir(parents=True, exist_ok=True)
+    archive = target / EUROSAT_ARCHIVE_NAME
+    archive.write_bytes(b"not-a-zip")
+    _write_eurosat_split_files(target)
+
+    caplog.set_level(logging.INFO, logger="torchgeo_bench.download")
+    _cleanup_eurosat_archive(target)
+
+    assert archive.exists()
+    assert any("verification failed" in message for message in caplog.messages)
+
+
 def test_download_eurosat_cleans_archive_after_success(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
     out = tmp_path / "data"
     target = out / "eurosat"
     target.mkdir(parents=True, exist_ok=True)
-    archive = target / EUROSAT_ARCHIVE_NAME
-    archive.write_bytes(b"archive-bytes")
+    members = _eurosat_members()
+    archive = _create_eurosat_archive(target, members)
     called_splits: list[str] = []
 
     def _fake_eurosat(*, root: str, split: str, download: bool) -> None:
         assert download is True
         called_splits.append(split)
         dataset_root = Path(root)
-        (dataset_root / EUROSAT_BASE_DIR).mkdir(parents=True, exist_ok=True)
-        for split_filename in EUROSAT_SPLIT_FILENAMES:
-            (dataset_root / split_filename).write_text(split_filename)
+        _write_extracted_members(dataset_root, members)
+        _write_eurosat_split_files(dataset_root)
 
     caplog.set_level(logging.INFO, logger="torchgeo_bench.download")
     with mock.patch("torchgeo_bench.download.EuroSAT", side_effect=_fake_eurosat):
@@ -106,13 +232,14 @@ def test_download_eurosat_keeps_archive_when_split_setup_fails(tmp_path: Path) -
     out = tmp_path / "data"
     target = out / "eurosat"
     target.mkdir(parents=True, exist_ok=True)
-    archive = target / EUROSAT_ARCHIVE_NAME
-    archive.write_bytes(b"archive-bytes")
+    archive = _create_eurosat_archive(target)
+    members = _eurosat_members()
+    missing_member = next(iter(members))
 
     def _fake_eurosat(*, root: str, split: str, download: bool) -> None:
         assert download is True
         dataset_root = Path(root)
-        (dataset_root / EUROSAT_BASE_DIR).mkdir(parents=True, exist_ok=True)
+        _write_extracted_members(dataset_root, members, skip={missing_member})
         (dataset_root / f"partial-{split}.txt").write_text(split)
         if split == "val":
             raise RuntimeError("split setup failed")
@@ -129,9 +256,9 @@ def test_download_eurosat_keeps_archive_when_split_setup_fails(tmp_path: Path) -
 def test_download_eurosat_is_idempotent_when_archive_is_missing(tmp_path: Path) -> None:
     out = tmp_path / "data"
     target = out / "eurosat"
-    (target / EUROSAT_BASE_DIR).mkdir(parents=True, exist_ok=True)
-    for split_filename in EUROSAT_SPLIT_FILENAMES:
-        (target / split_filename).write_text(split_filename)
+    members = _eurosat_members()
+    _write_extracted_members(target, members)
+    _write_eurosat_split_files(target)
 
     with mock.patch("torchgeo_bench.download.EuroSAT") as eurosat_mock:
         download_eurosat(out)
@@ -144,11 +271,10 @@ def test_download_eurosat_is_idempotent_when_archive_is_missing(tmp_path: Path) 
 def test_download_eurosat_cleans_stale_archive_when_already_extracted(tmp_path: Path) -> None:
     out = tmp_path / "data"
     target = out / "eurosat"
-    (target / EUROSAT_BASE_DIR).mkdir(parents=True, exist_ok=True)
-    for split_filename in EUROSAT_SPLIT_FILENAMES:
-        (target / split_filename).write_text(split_filename)
-    archive = target / EUROSAT_ARCHIVE_NAME
-    archive.write_bytes(b"archive-bytes")
+    members = _eurosat_members()
+    _write_extracted_members(target, members)
+    _write_eurosat_split_files(target)
+    archive = _create_eurosat_archive(target, members)
 
     with mock.patch("torchgeo_bench.download.EuroSAT"):
         download_eurosat(out)


### PR DESCRIPTION
## Summary\n- remove downloaded EuroSAT and GeoBench V1 archives only after extraction/split setup succeeds, logging reclaimed space\n- keep EuroSAT archives on failures so retries can resume safely, and clean up stale archives on idempotent reruns\n- document why GeoBench V1 HDF5 and sharded auto-download paths remain distinct, and add focused regression tests\n\n## Testing\n- PYTHONPATH=$PWD/src /mnt/code/torchgeo-bench/.venv/bin/pytest tests/test_download.py tests/test_dataset_units.py -v\n- /mnt/code/torchgeo-bench/.venv/bin/ruff check src/torchgeo_bench/download.py tests/test_download.py tests/test_dataset_units.py