### PR TITLE
Suppress duplicated HF Hub unauthenticated warning

### DIFF
--- a/src/torchgeo_bench/models/timm.py
+++ b/src/torchgeo_bench/models/timm.py
@@ -1,6 +1,8 @@
 """Timm backbone wrapper for patch-level feature extraction."""
 
 import logging
+from collections.abc import Iterator
+from contextlib import contextmanager
 
 import timm
 import torch
@@ -14,6 +16,54 @@ from .interface import BenchModel
 logger = logging.getLogger(__name__)
 
 _VALID_INPUT_NORMALIZATIONS = ("bands_zscore", "imagenet", "timm_default", "none")
+_HF_HUB_UNAUTHENTICATED_WARNING_FRAGMENTS = (
+    "unauthenticated requests to the hf hub",
+    "hf_token",
+    "higher rate limits",
+    "faster downloads",
+)
+
+
+def _is_hf_hub_unauthenticated_warning(message: str) -> bool:
+    """Return whether a log message matches HF Hub's unauthenticated-download warning."""
+    normalized = " ".join(message.lower().split())
+    if normalized.startswith("warning: "):
+        normalized = normalized.removeprefix("warning: ")
+    return all(fragment in normalized for fragment in _HF_HUB_UNAUTHENTICATED_WARNING_FRAGMENTS)
+
+
+class _HfHubUnauthenticatedWarningFilter(logging.Filter):
+    """Drop only the noisy HF Hub warning about missing ``HF_TOKEN``."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        """Return ``False`` only for the specific unauthenticated-download warning."""
+        return not _is_hf_hub_unauthenticated_warning(record.getMessage())
+
+
+@contextmanager
+def _suppress_hf_hub_unauthenticated_warning() -> Iterator[None]:
+    """Suppress only the duplicated HF Hub unauthenticated-download warning."""
+    warning_filter = _HfHubUnauthenticatedWarningFilter()
+    source_logger = logging.getLogger("huggingface_hub.utils._http")
+    source_logger.addFilter(warning_filter)
+
+    filtered_handlers: list[logging.Handler] = []
+    seen_handler_ids: set[int] = set()
+    for logger_name in ("", "huggingface_hub"):
+        for handler in logging.getLogger(logger_name).handlers:
+            handler_id = id(handler)
+            if handler_id in seen_handler_ids:
+                continue
+            handler.addFilter(warning_filter)
+            filtered_handlers.append(handler)
+            seen_handler_ids.add(handler_id)
+
+    try:
+        yield
+    finally:
+        source_logger.removeFilter(warning_filter)
+        for handler in filtered_handlers:
+            handler.removeFilter(warning_filter)
 
 
 class TimmPatchBenchModel(BenchModel):
@@ -103,13 +153,23 @@ class TimmPatchBenchModel(BenchModel):
         if self.use_cls_token and global_pool != "":
             global_pool = ""
 
-        self.backbone = timm.create_model(
-            model_name,
-            pretrained=pretrained,
-            in_chans=self.num_channels,
-            num_classes=0,
-            global_pool=global_pool,
-        )
+        if pretrained:
+            with _suppress_hf_hub_unauthenticated_warning():
+                self.backbone = timm.create_model(
+                    model_name,
+                    pretrained=pretrained,
+                    in_chans=self.num_channels,
+                    num_classes=0,
+                    global_pool=global_pool,
+                )
+        else:
+            self.backbone = timm.create_model(
+                model_name,
+                pretrained=pretrained,
+                in_chans=self.num_channels,
+                num_classes=0,
+                global_pool=global_pool,
+            )
 
         # Determine default input size from timm config; store square size.
         default_cfg = getattr(self.backbone, "default_cfg", {}) or {}

--- a/tests/test_timm_hf_warning.py
+++ b/tests/test_timm_hf_warning.py
@@ -84,7 +84,9 @@ def test_hf_warning_matcher_is_specific():
     assert not _is_hf_hub_unauthenticated_warning(HF_HTTP_WARNING)
 
 
-def test_pretrained_timm_suppresses_only_unauthenticated_hf_warning(monkeypatch: pytest.MonkeyPatch):
+def test_pretrained_timm_suppresses_only_unauthenticated_hf_warning(
+    monkeypatch: pytest.MonkeyPatch,
+):
     import timm
 
     from torchgeo_bench.models.timm import TimmPatchBenchModel

--- a/tests/test_timm_hf_warning.py
+++ b/tests/test_timm_hf_warning.py
@@ -1,0 +1,117 @@
+import io
+import logging
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+import pytest
+import torch
+import torch.nn as nn
+
+from torchgeo_bench.datasets.base import BandSpec
+
+HF_UNAUTHENTICATED_WARNING = (
+    "Warning: You are sending unauthenticated requests to the HF Hub. "
+    "Please set a HF_TOKEN to enable higher rate limits and faster downloads."
+)
+HF_AUTH_FAILURE_WARNING = "The token from HF_TOKEN environment variable is invalid."
+HF_HTTP_WARNING = "HTTP Error 401 thrown while requesting GET https://huggingface.co/timm/example"
+
+
+def _rgb_bands() -> list[BandSpec]:
+    return [
+        BandSpec(
+            sensor="s2",
+            name=name,
+            source_name=name.upper(),
+            mean=1500.0,
+            std=600.0,
+            min=0.0,
+            max=10000.0,
+        )
+        for name in ("red", "green", "blue")
+    ]
+
+
+@contextmanager
+def _captured_hf_logging() -> Iterator[tuple[io.StringIO, io.StringIO]]:
+    root_logger = logging.getLogger()
+    hf_logger = logging.getLogger("huggingface_hub")
+
+    old_root_handlers = root_logger.handlers[:]
+    old_root_level = root_logger.level
+    old_hf_handlers = hf_logger.handlers[:]
+    old_hf_level = hf_logger.level
+    old_hf_propagate = hf_logger.propagate
+
+    root_stream = io.StringIO()
+    hf_stream = io.StringIO()
+    root_handler = logging.StreamHandler(root_stream)
+    hf_handler = logging.StreamHandler(hf_stream)
+    root_handler.setFormatter(logging.Formatter("%(levelname)s:%(name)s:%(message)s"))
+    hf_handler.setFormatter(logging.Formatter("%(message)s"))
+
+    root_logger.handlers = [root_handler]
+    root_logger.setLevel(logging.WARNING)
+    hf_logger.handlers = [hf_handler]
+    hf_logger.setLevel(logging.WARNING)
+    hf_logger.propagate = True
+
+    try:
+        yield root_stream, hf_stream
+    finally:
+        root_logger.handlers = old_root_handlers
+        root_logger.setLevel(old_root_level)
+        hf_logger.handlers = old_hf_handlers
+        hf_logger.setLevel(old_hf_level)
+        hf_logger.propagate = old_hf_propagate
+
+
+class _TinyBackbone(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.default_cfg: dict[str, object] = {}
+
+    def forward(self, images: torch.Tensor) -> torch.Tensor:
+        return images.mean(dim=(-2, -1))
+
+
+def test_hf_warning_matcher_is_specific():
+    from torchgeo_bench.models.timm import _is_hf_hub_unauthenticated_warning
+
+    assert _is_hf_hub_unauthenticated_warning(HF_UNAUTHENTICATED_WARNING)
+    assert _is_hf_hub_unauthenticated_warning(HF_UNAUTHENTICATED_WARNING.removeprefix("Warning: "))
+    assert not _is_hf_hub_unauthenticated_warning(HF_AUTH_FAILURE_WARNING)
+    assert not _is_hf_hub_unauthenticated_warning(HF_HTTP_WARNING)
+
+
+def test_pretrained_timm_suppresses_only_unauthenticated_hf_warning(monkeypatch: pytest.MonkeyPatch):
+    import timm
+
+    from torchgeo_bench.models.timm import TimmPatchBenchModel
+
+    def _fake_create_model(*args, **kwargs):
+        del args, kwargs
+        logger = logging.getLogger("huggingface_hub.utils._http")
+        logger.warning(HF_UNAUTHENTICATED_WARNING)
+        logger.warning(HF_AUTH_FAILURE_WARNING)
+        logger.warning(HF_HTTP_WARNING)
+        return _TinyBackbone()
+
+    monkeypatch.setattr(timm, "create_model", _fake_create_model)
+
+    with _captured_hf_logging() as (root_stream, hf_stream):
+        TimmPatchBenchModel(
+            bands=_rgb_bands(),
+            model_name="resnet18",
+            pretrained=True,
+        )
+
+    root_output = root_stream.getvalue()
+    hf_output = hf_stream.getvalue()
+    combined_output = root_output + hf_output
+
+    assert "unauthenticated requests to the HF Hub" not in combined_output
+    assert HF_AUTH_FAILURE_WARNING in root_output
+    assert HF_AUTH_FAILURE_WARNING in hf_output
+    assert HF_HTTP_WARNING in root_output
+    assert HF_HTTP_WARNING in hf_output


### PR DESCRIPTION
## Summary
- wrap pretrained timm model creation in a targeted HF Hub warning filter
- suppress only the unauthenticated HF_TOKEN rate-limit warning while keeping other Hub warnings visible
- add focused tests covering suppression and retention of unrelated/auth warnings

## Testing
- PYTHONPATH=$PWD/src /mnt/code/torchgeo-bench/.venv/bin/ruff check src/torchgeo_bench/models/timm.py tests/test_timm_hf_warning.py
- PYTHONPATH=$PWD/src /mnt/code/torchgeo-bench/.venv/bin/pytest tests/test_timm_hf_warning.py tests/test_timm_normalization.py -v