### PR TITLE
Fail fast on invalid segmentation probes

### DIFF
--- a/src/torchgeo_bench/main.py
+++ b/src/torchgeo_bench/main.py
@@ -1,6 +1,7 @@
 """Benchmark script for torchgeo-bench."""
 
 import logging
+import math
 import os
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
@@ -295,6 +296,37 @@ def evaluate_logistic(
     return metric, lo, hi, float(best_c), calibration, calibration_ts
 
 
+def _resolve_segmentation_runtime_config(
+    seg_cfg: DictConfig,
+) -> tuple[int, int, float, bool, torch.dtype]:
+    """Validate and normalize the segmentation settings used during a run.
+
+    Configuration mistakes should fail before feature extraction or training,
+    rather than being silently coerced or failing after an expensive GPU job
+    has started.
+    """
+    epochs = seg_cfg.get("epochs", 10)
+    batch_size = seg_cfg.get("batch_size", 64)
+    lr = seg_cfg.get("lr", 1e-3)
+    use_cache = seg_cfg.get("cache_features", True)
+    cache_dtype_name = seg_cfg.get("cache_dtype", "float16")
+
+    for name, value in (("epochs", epochs), ("batch_size", batch_size)):
+        if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+            raise ValueError(f"eval.segmentation.{name} must be a positive integer, got {value!r}.")
+    if isinstance(lr, bool) or not isinstance(lr, (int, float)) or not math.isfinite(lr) or lr <= 0:
+        raise ValueError(f"eval.segmentation.lr must be a finite positive number, got {lr!r}.")
+    if not isinstance(use_cache, bool):
+        raise ValueError(f"eval.segmentation.cache_features must be a boolean, got {use_cache!r}.")
+    cache_dtypes = {"float16": torch.float16, "float32": torch.float32}
+    if cache_dtype_name not in cache_dtypes:
+        raise ValueError(
+            "eval.segmentation.cache_dtype must be one of "
+            f"{tuple(cache_dtypes)}, got {cache_dtype_name!r}."
+        )
+    return epochs, batch_size, float(lr), use_cache, cache_dtypes[cache_dtype_name]
+
+
 def evaluate_intrinsic_dim(
     splits: dict[str, np.ndarray],
     estimators: Sequence[str],
@@ -461,13 +493,11 @@ def evaluate_segmentation(
         raise ValueError("Segmentation evaluation config missing for the model.")
 
     seg_cfg = eval_cfg.segmentation
-    epochs = seg_cfg.epochs
-    probe_batch_size = int(seg_cfg.get("batch_size", 64))
-    use_cache = seg_cfg.get("cache_features", True)
-    cache_dtype_str = seg_cfg.get("cache_dtype", "float16")
-    cache_dtype = torch.float16 if cache_dtype_str == "float16" else torch.float32
+    epochs, probe_batch_size, lr, use_cache, cache_dtype = _resolve_segmentation_runtime_config(
+        seg_cfg
+    )
 
-    probe, solver = build_seg_probe_and_solver(model, num_classes, eval_cfg, device, seg_cfg.lr)
+    probe, solver = build_seg_probe_and_solver(model, num_classes, eval_cfg, device, lr)
     if use_cache and probe.freeze_backbone:
         logger.info("Caching backbone features for train and val splits...")
         train_cache = probe.extract_segmentation_features(train_loader, cache_dtype=cache_dtype)
@@ -498,7 +528,7 @@ def evaluate_segmentation(
         metrics, preds = eval_result
     else:
         metrics, preds = eval_result, None
-    return metrics, sum(probe.channels_list), float(seg_cfg.lr), actual_batch_size, preds
+    return metrics, sum(probe.channels_list), lr, actual_batch_size, preds
 
 
 def _resolve_output_path(cfg: DictConfig) -> str:
@@ -644,10 +674,11 @@ def main(cfg: DictConfig) -> None:
             else tuple(cfg.dataset.bands)
         )
         bands_list = bench.select_band_specs(bands_resolved)
-        assert len(bands_list) == num_channels, (
-            f"BandSpec count {len(bands_list)} != tensor channel count {num_channels} "
-            f"for dataset {ds_name}; sample-level canonicalization may have changed shape."
-        )
+        if len(bands_list) != num_channels:
+            raise ValueError(
+                f"BandSpec count {len(bands_list)} != tensor channel count {num_channels} "
+                f"for dataset {ds_name}; sample-level canonicalization may have changed shape."
+            )
 
         # `bands` is passed as a kwarg (not via the config) so the BandSpec
         # dataclasses reach the constructor intact.

--- a/src/torchgeo_bench/segmentation_probe.py
+++ b/src/torchgeo_bench/segmentation_probe.py
@@ -190,6 +190,12 @@ class SegmentationProbe(nn.Module):
         self._features: dict[str, torch.Tensor] = {}
         self.hooks: list[Any] = []
 
+        duplicate_layers = {name for name in self.layer_names if self.layer_names.count(name) > 1}
+        if duplicate_layers:
+            raise ValueError(
+                f"Segmentation probe layers must be unique; duplicates: {sorted(duplicate_layers)}."
+            )
+
         found_layers = set()
         for name, module in self.backbone.named_modules():
             if name.startswith("backbone."):

--- a/tests/test_main_segmentation_fast.py
+++ b/tests/test_main_segmentation_fast.py
@@ -120,6 +120,47 @@ def test_segmentation_row_emitted(tmp_path: Path):
     assert df.loc[0, "best_batch_size"] == 2
 
 
+def test_cached_segmentation_records_probe_batch_size(tmp_path: Path):
+    """Cached probes use their own configured batch size, not loader batch size."""
+    out = tmp_path / "out.csv"
+    cfg = _cfg_for_segmentation(
+        out,
+        overrides=["eval.segmentation.cache_features=true", "eval.segmentation.batch_size=3"],
+    )
+    probe, solver = _mock_probe_and_solver()
+    cache = mock.Mock()
+    probe.freeze_backbone = True
+    probe.extract_segmentation_features.return_value = cache
+    solver.evaluate_cached.return_value = {
+        "mIoU": 0.42,
+        "fw_IoU": 0.55,
+        "precision": 0.6,
+        "recall": 0.7,
+        "f1": 0.65,
+    }
+
+    with (
+        mock.patch(
+            "torchgeo_bench.main.get_datasets", return_value=_synthetic_segmentation_loaders()
+        ),
+        mock.patch(
+            "torchgeo_bench.segmentation_task.build_seg_probe_and_solver",
+            return_value=(probe, solver),
+        ),
+    ):
+        main(cfg)
+
+    solver.fit_cached.assert_called_once_with(
+        train_cache=cache,
+        val_cache=cache,
+        batch_size=3,
+        epochs=cfg.eval.segmentation.epochs,
+        verbose=cfg.verbose,
+    )
+    df = pd.read_csv(out)
+    assert df.loc[0, "best_batch_size"] == 3
+
+
 def test_segmentation_viz_not_called_when_disabled(tmp_path: Path):
     out = tmp_path / "out.csv"
     cfg = _cfg_for_segmentation(out, overrides=["eval.segmentation.save_viz=false"])

--- a/tests/test_main_utils.py
+++ b/tests/test_main_utils.py
@@ -13,6 +13,7 @@ from torchgeo_bench.main import (
     _expand_dataset_list,
     _filter_completed_metric_rows,
     _normalize_bands_value,
+    _resolve_segmentation_runtime_config,
     evaluate_profile,
 )
 from torchgeo_bench.model_profile import measure_cpu_throughput
@@ -72,6 +73,34 @@ def test_build_seg_probe_and_solver_rejects_empty_layers() -> None:
             device=torch.device("cpu"),
             lr=1e-3,
         )
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("epochs", 0, "positive integer"),
+        ("batch_size", 0, "positive integer"),
+        ("lr", 0.0, "finite positive number"),
+        ("cache_features", "true", "must be a boolean"),
+        ("cache_dtype", "bfloat16", "must be one of"),
+    ],
+)
+def test_segmentation_runtime_config_rejects_invalid_values(
+    field: str, value: object, message: str
+) -> None:
+    cfg = OmegaConf.create(
+        {
+            "epochs": 1,
+            "batch_size": 2,
+            "lr": 1e-3,
+            "cache_features": True,
+            "cache_dtype": "float16",
+            field: value,
+        }
+    )
+
+    with pytest.raises(ValueError, match=message):
+        _resolve_segmentation_runtime_config(cfg)
 
 
 def test_measure_cpu_throughput_budget_exceeded_returns_none_metrics() -> None:

--- a/tests/test_segmentation.py
+++ b/tests/test_segmentation.py
@@ -118,6 +118,22 @@ def test_probe_unknown_head_type(mock_backbone):
         )
 
 
+def test_probe_rejects_missing_or_duplicate_layers(mock_backbone):
+    """Layer typos must fail before a benchmark starts extracting features."""
+    with pytest.raises(ValueError, match="not found"):
+        SegmentationProbe(
+            backbone=mock_backbone,
+            layer_names=["not_a_layer"],
+            num_classes=NUM_CLASSES,
+        )
+    with pytest.raises(ValueError, match="must be unique"):
+        SegmentationProbe(
+            backbone=mock_backbone,
+            layer_names=["layer1", "layer1"],
+            num_classes=NUM_CLASSES,
+        )
+
+
 def test_build_seg_probe_requires_spatial_layers(mock_backbone):
     """Segmentation evaluation refuses the global-output fallback."""
     eval_cfg = OmegaConf.create(


### PR DESCRIPTION
This is a small guardrail pass around the segmentation path.

- reject bad probe settings before feature extraction starts
- reject missing or duplicate hook layers instead of failing later in the run
- keep the cached probe batch size in the result row, with regression coverage
- turn the BandSpec/channel mismatch assertion into a normal runtime error

The config checks are deliberately narrow: invalid cache dtypes used to quietly become float32, and bad batch sizes tended to fail only after a job was underway.