### PR TITLE
Normalize fMoW ResNet inputs as reflectance

### DIFF
--- a/src/torchgeo_bench/conf/model/torchgeo/resnet50_fmow_gassl.yaml
+++ b/src/torchgeo_bench/conf/model/torchgeo/resnet50_fmow_gassl.yaml
@@ -5,6 +5,9 @@ _target_: torchgeo_bench.models.TorchGeoResNetBench
 factory: resnet50
 weights_class: ResNet50_Weights
 weights_member: FMOW_RGB_GASSL
+# Convert raw S2 / TCI inputs to [0, 1] ourselves, then retain only ImageNet z-score.
+normalization_input_unit: reflectance_0_1
+skip_weight_normalize: 1
 auto_resize: false
 target_size: 224
 name: tgeo_resnet50_fmow_gassl

--- a/src/torchgeo_bench/models/torchgeo_models.py
+++ b/src/torchgeo_bench/models/torchgeo_models.py
@@ -221,6 +221,8 @@ class _TorchGeoBackboneBench(BenchModel):
         weights_member: str,
         auto_resize: bool,
         target_size: int | None,
+        normalization_input_unit: str | None = None,
+        skip_weight_normalize: int = 0,
         input_unit_check: str = "warn",
         factory_kwargs: dict[str, Any] | None = None,
         **kwargs: Any,
@@ -233,18 +235,50 @@ class _TorchGeoBackboneBench(BenchModel):
             if derived is not None:
                 type(self).expected_input_unit = derived
         super().__init__(bands=bands, **kwargs)
+        if normalization_input_unit is not None:
+            if normalization_input_unit not in _UNIT_EXPECTED_SOURCE:
+                raise ValueError(
+                    "normalization_input_unit must be one of "
+                    f"{tuple(_UNIT_EXPECTED_SOURCE)}, got {normalization_input_unit!r}."
+                )
+            self.normalization_input_unit = normalization_input_unit
+        else:
+            self.normalization_input_unit = self.weights_input_unit
+        if (
+            isinstance(skip_weight_normalize, bool)
+            or not isinstance(skip_weight_normalize, int)
+            or skip_weight_normalize < 0
+        ):
+            raise ValueError(
+                "skip_weight_normalize must be a non-negative integer, "
+                f"got {skip_weight_normalize!r}."
+            )
         weights = _resolve_torchgeo_weights(weights_class, weights_member)
         self.weights = weights
         model_factory = _resolve_torchgeo_factory(factory)
         self.backbone = model_factory(weights=weights, **(factory_kwargs or {}))
         self.auto_resize = auto_resize
         self.target_size = target_size
-        self._weights_normalize = _extract_normalize_transforms(weights)
+        weights_normalize = _extract_normalize_transforms(weights)
+        if weights_normalize is not None:
+            if skip_weight_normalize > len(weights_normalize):
+                raise ValueError(
+                    f"skip_weight_normalize={skip_weight_normalize} exceeds the "
+                    f"{len(weights_normalize)} Normalize layers supplied by {weights_member}."
+                )
+            self._weights_normalize = nn.Sequential(
+                *list(weights_normalize)[skip_weight_normalize:]
+            )
+        else:
+            self._weights_normalize = None
         if input_unit_check not in ("warn", "ignore", "error"):
             raise ValueError(
                 f"input_unit_check must be one of warn|ignore|error, got {input_unit_check!r}."
             )
-        _warn_unit_mismatch(type(self).__name__, self.weights_input_unit, bands, input_unit_check)
+        if normalization_input_unit is None:
+            _warn_unit_mismatch(
+                type(self).__name__, self.weights_input_unit, bands, input_unit_check
+            )
 
         # Pre-compute the unit conversion needed to bring dataset inputs
         # into the scale the weights' Normalize was calibrated for.  No-op
@@ -255,7 +289,7 @@ class _TorchGeoBackboneBench(BenchModel):
         # values, producing near-zero inputs.
         self._dataset_input_unit = detect_input_unit(self.bands)
         self._weights_target_unit: InputUnit | None = _UNIT_EXPECTED_SOURCE.get(
-            self.weights_input_unit or ""
+            self.normalization_input_unit or ""
         )
 
     def _tiled_normalize(self, in_chans: int) -> nn.Sequential | None:
@@ -401,6 +435,8 @@ class TorchGeoResNetBench(_TorchGeoBackboneBench):
         weights_member: str = "SENTINEL2_RGB_MOCO",
         auto_resize: bool = False,
         target_size: int | None = 224,
+        normalization_input_unit: str | None = None,
+        skip_weight_normalize: int = 0,
         input_unit_check: str = "warn",
         **_kwargs: Any,
     ) -> None:
@@ -411,6 +447,8 @@ class TorchGeoResNetBench(_TorchGeoBackboneBench):
             weights_member=weights_member,
             auto_resize=auto_resize,
             target_size=target_size,
+            normalization_input_unit=normalization_input_unit,
+            skip_weight_normalize=skip_weight_normalize,
             input_unit_check=input_unit_check,
             **_kwargs,
         )

--- a/tests/test_torchgeo_models.py
+++ b/tests/test_torchgeo_models.py
@@ -411,6 +411,46 @@ def test_channel_mismatch_preserves_tiled_normalize_chain(
     assert torch.allclose(normalized[:, 3:], expected.expand(1, 3, 8, 8))
 
 
+def test_resnet_can_convert_to_reflectance_before_skipping_weight_scale(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Raw S2 should skip a checkpoint's uint8 scale before ImageNet z-score."""
+    import torchgeo_bench.models.torchgeo_models as tg_models
+
+    class _TinyResNet(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.conv1 = nn.Conv2d(3, 4, 1)
+            self.fc = nn.Identity()
+
+    class _FakeWeights:
+        transforms = nn.Sequential(
+            Normalize(mean=[0.0], std=[255.0]),
+            Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
+        )
+
+    monkeypatch.setattr(
+        tg_models, "_resolve_torchgeo_factory", lambda _name: lambda weights: _TinyResNet()
+    )
+    monkeypatch.setattr(
+        tg_models,
+        "_resolve_torchgeo_weights",
+        lambda _weights_class, _weights_member: _FakeWeights(),
+    )
+
+    model = TorchGeoResNetBench(
+        bands=_rgb_bands(),
+        normalization="model_native",
+        normalization_input_unit="reflectance_0_1",
+        skip_weight_normalize=1,
+        input_unit_check="error",
+    )
+
+    normalized = model.normalize_inputs(torch.full((1, 3, 2, 2), 10000.0))
+    expected = torch.tensor([(1.0 - 0.485) / 0.229, (1.0 - 0.456) / 0.224, (1.0 - 0.406) / 0.225])
+    assert torch.allclose(normalized[0, :, 0, 0], expected)
+
+
 # ---------------------------------------------------------------------------
 # _warn_unit_mismatch
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
fMoW GASSL's TorchGeo transform starts with a TCI `/255` step, then ImageNet normalization. That first step is wrong for raw benchmark tensors.

This config now converts input to reflectance first (`/10000` for raw Sentinel-2, `/255` for TCI), skips TorchGeo's leading scale-only Normalize, and keeps the ImageNet mean/std stage. The wrapper accepts this as explicit model config rather than a class-wide assumption.

Checks: `uv run pytest tests/test_torchgeo_models.py tests/test_torchgeo_unit_check.py --no-cov -q`.