### PR TITLE
Clamp KNN neighbors before GPU search

### DIFF
--- a/src/torchgeo_bench/knn.py
+++ b/src/torchgeo_bench/knn.py
@@ -71,7 +71,7 @@ class KNNClassifier:
 
     Args:
         n_neighbors: Number of neighbours (k). Clamped to ``min(k, n_train)``
-            on the CPU path; faissknn does not clamp internally.
+            before either backend is constructed.
         device: ``"cpu"`` (default) → the FAISS CPU index. Anything else
             (``"cuda"``, ``"cuda:0"``) requires ``faissknn`` with a GPU FAISS
             backend (installed automatically on Linux x86_64); raises an
@@ -90,7 +90,10 @@ class KNNClassifier:
         metric: Literal["l2", "ip", "cosine"] = "l2",
         use_fp16: bool = False,
     ) -> None:
-        self.n_neighbors = int(n_neighbors)
+        if isinstance(n_neighbors, bool) or not isinstance(n_neighbors, int) or n_neighbors < 1:
+            raise ValueError(f"n_neighbors must be a positive integer, got {n_neighbors!r}.")
+        self.n_neighbors = n_neighbors
+        self._effective_n_neighbors: int | None = None
         self.device = device
         self.metric = metric
         self.use_fp16 = use_fp16
@@ -113,7 +116,12 @@ class KNNClassifier:
                ``(n_samples, n_classes)`` multi-hot multi-label.
         """
         X = np.ascontiguousarray(np.atleast_2d(X).astype(np.float32))
+        if len(X) == 0:
+            raise ValueError("KNNClassifier.fit requires at least one training sample.")
+        if len(y) != len(X):
+            raise ValueError(f"X has {len(X)} samples but y has {len(y)} labels.")
         self._multi_label = y.ndim == 2
+        self._effective_n_neighbors = min(self.n_neighbors, len(X))
 
         if _is_cpu_device(self.device):
             self._fit_cpu(X, y)
@@ -136,8 +144,8 @@ class KNNClassifier:
     def _search_cpu(self, X: np.ndarray) -> np.ndarray:
         assert self._index is not None
         X = np.ascontiguousarray(np.atleast_2d(X).astype(np.float32))
-        k_eff = min(self.n_neighbors, self._index.ntotal)
-        _, indices = self._index.search(X, k_eff)
+        assert self._effective_n_neighbors is not None
+        _, indices = self._index.search(X, self._effective_n_neighbors)
         return indices
 
     def _neighbour_counts(self, indices: np.ndarray) -> np.ndarray:
@@ -185,7 +193,7 @@ class KNNClassifier:
             )
 
         kwargs = {
-            "n_neighbors": self.n_neighbors,
+            "n_neighbors": self._effective_n_neighbors,
             "device": self.device,
             "metric": self.metric,
             "use_fp16": self.use_fp16,

--- a/tests/test_multilabel.py
+++ b/tests/test_multilabel.py
@@ -2,6 +2,8 @@
 
 import builtins
 import logging
+import sys
+from types import SimpleNamespace
 
 import numpy as np
 import pytest
@@ -91,6 +93,40 @@ class TestKNNClassifierSingleLabel:
         clf.fit(X, y)
         preds = clf.predict(X)
         assert preds.shape == (3,)
+
+    def test_gpu_k_is_clamped_before_faissknn_construction(self, monkeypatch: pytest.MonkeyPatch):
+        """FAISS GPU uses -1 neighbor IDs when asked for k > n_train."""
+        constructed: list[object] = []
+
+        class FakeFaissKNNClassifier:
+            def __init__(self, **kwargs) -> None:
+                self.kwargs = kwargs
+                constructed.append(self)
+
+            def fit(self, X, y) -> None:
+                del X, y
+
+        monkeypatch.setattr(knn, "gpu_faiss_available", lambda: True)
+        monkeypatch.setitem(
+            sys.modules,
+            "faissknn",
+            SimpleNamespace(
+                FaissKNNClassifier=FakeFaissKNNClassifier,
+                FaissKNNMultilabelClassifier=FakeFaissKNNClassifier,
+            ),
+        )
+        X = np.zeros((3, 2), dtype=np.float32)
+        y = np.array([0, 1, 2], dtype=np.int64)
+
+        KNNClassifier(n_neighbors=10, device="cuda").fit(X, y)
+
+        assert len(constructed) == 1
+        assert constructed[0].kwargs["n_neighbors"] == 3
+
+    @pytest.mark.parametrize("n_neighbors", [0, -1, True, 1.5])
+    def test_rejects_invalid_neighbor_count(self, n_neighbors):
+        with pytest.raises(ValueError, match="positive integer"):
+            KNNClassifier(n_neighbors=n_neighbors)
 
 
 class TestKNNClassifierMultiLabel:


### PR DESCRIPTION
faissknn does not clamp `k` to the training-set size. When `k > n_train`, FAISS can return `-1` neighbor IDs; those then index the last label and skew predictions.

Clamp `k` once during fit before either backend is built. Also reject invalid neighbor counts, empty training sets, and X/y length mismatches.