### PR TITLE
Reject colliding OlmoEarth sensor routes

### DIFF
--- a/src/torchgeo_bench/models/olmoearth.py
+++ b/src/torchgeo_bench/models/olmoearth.py
@@ -320,6 +320,16 @@ def _build_sensor_groups(bands: list[BandSpec]) -> list[dict]:
                 "src_stds": [b.std for b in group_bands],
             }
         )
+    fields: dict[str, str] = {}
+    for group in result:
+        field = group["sample_field"]
+        previous_sensor = fields.setdefault(field, group["sensor"])
+        if previous_sensor != group["sensor"]:
+            raise ValueError(
+                "OlmoEarth cannot route multiple input sensors to the same sample field: "
+                f"{previous_sensor!r} and {group['sensor']!r} both map to {field!r}. "
+                "Select one sensor or add an explicit fusion policy."
+            )
     return result
 
 

--- a/tests/test_olmoearth.py
+++ b/tests/test_olmoearth.py
@@ -53,6 +53,19 @@ def _s2_bands() -> list[BandSpec]:
     ]
 
 
+def test_rejects_sensor_groups_that_share_an_olmoearth_sample_field() -> None:
+    """Aerial and S2 data cannot both occupy ``sentinel2_l2a`` without fusion."""
+    from torchgeo_bench.models.olmoearth import _build_sensor_groups
+
+    bands = [
+        BandSpec("aerial", "red", "red", mean=120.0, std=30.0, min=0.0, max=255.0),
+        BandSpec("s2", "red", "B04", mean=1500.0, std=600.0, min=0.0, max=10000.0),
+    ]
+
+    with pytest.raises(ValueError, match="multiple input sensors"):
+        _build_sensor_groups(bands)
+
+
 # Map variant -> expected embedding dim (from the HF weights configs).
 EXPECTED_DIM = {"nano": 128, "tiny": 192, "small": 384, "base": 768, "large": 1024}
 


### PR DESCRIPTION
TreeSatAI all-band inputs contain aerial and Sentinel-2 groups. Both map to OlmoEarth's `sentinel2_l2a` field, so the later group silently overwrote the earlier one.

Reject that route collision before model loading. A real fusion policy can be added later without pretending both inputs were evaluated.