### PR TITLE
fix: fingerprint resumable evaluations

### DIFF
--- a/src/torchgeo_bench/main.py
+++ b/src/torchgeo_bench/main.py
@@ -44,6 +44,7 @@ from torchgeo_bench.resume import (  # noqa: F401  (re-exported for back-compat)
     _normalize_bands_value,
     _plan_dataset_run,
     _profile_metric_names,
+    _resume_config_hash,
     _row_key,
     load_completed,
 )
@@ -562,6 +563,7 @@ def main(cfg: DictConfig) -> None:
     # ablations across strategies are distinguishable.
     normalization = str(getattr(cfg.dataset, "normalization", "bandspec_zscore"))
     bands_value = _normalize_bands_value(getattr(cfg.dataset, "bands", "rgb"))
+    config_hash = _resume_config_hash(cfg)
 
     for ds_name in track(dataset_names, description="Datasets"):
         try:
@@ -590,6 +592,7 @@ def main(cfg: DictConfig) -> None:
                 ds_cls.num_classes,
                 model_res,
                 model_pool,
+                config_hash,
             )
         )
         eval_cfg_merged = OmegaConf.merge(cfg.eval, model_eval or {})
@@ -674,6 +677,7 @@ def main(cfg: DictConfig) -> None:
             "partition": cfg.dataset.partition,
             "bands": bands_value,
             "num_classes": num_classes,
+            "config_hash": config_hash,
             "c_range_start": c_start,
             "c_range_stop": c_stop,
             "c_range_num": c_num,

--- a/src/torchgeo_bench/results.py
+++ b/src/torchgeo_bench/results.py
@@ -147,6 +147,9 @@ class EvaluationResult:
     partition: str
     bands: str
     num_classes: int
+    # Fingerprint of the full config (seed, device, dataset, eval, model); see
+    # ``resume._resume_config_hash``.  Part of the resume key.
+    config_hash: str
     c_range_start: float
     c_range_stop: float
     c_range_num: int

--- a/src/torchgeo_bench/resume.py
+++ b/src/torchgeo_bench/resume.py
@@ -5,12 +5,14 @@ Resume keys are assembled from two sources that format values differently
 :func:`_canonical_key_cell` before comparison.
 """
 
+import hashlib
+import json
 import logging
 from collections.abc import Sequence
 from dataclasses import dataclass
 
 import pandas as pd
-from omegaconf import DictConfig
+from omegaconf import DictConfig, OmegaConf
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +32,10 @@ KEY_COLS = (
     # silently skipped.
     "res",
     "pool",
+    # Fingerprint of the full config (seed, device, dataset, eval, model) so a
+    # changed setting that doesn't show up in the other key columns can't be
+    # mistaken for an already-completed run.
+    "config_hash",
 )
 
 
@@ -50,6 +56,27 @@ def _normalize_bands_value(bands: object) -> str:
     except TypeError:
         return str(bands)
     return ",".join(items)
+
+
+def _resume_config_hash(cfg: DictConfig) -> str:
+    """Return a stable fingerprint of settings that can change a result row.
+
+    Resume must not treat a row from a different model/evaluation setup as
+    complete merely because its display metadata happens to match.
+    """
+    dataset_cfg = OmegaConf.to_container(cfg.dataset, resolve=True)
+    assert isinstance(dataset_cfg, dict)
+    dataset_cfg.pop("names", None)
+    payload = {
+        "version": 1,
+        "seed": cfg.seed,
+        "device": cfg.device,
+        "dataset": dataset_cfg,
+        "eval": OmegaConf.to_container(cfg.eval, resolve=True),
+        "model": OmegaConf.to_container(cfg.model, resolve=True),
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(encoded.encode()).hexdigest()[:16]
 
 
 def _canonical_key_cell(value: object) -> str:

--- a/tests/test_main_fast.py
+++ b/tests/test_main_fast.py
@@ -14,6 +14,7 @@ from torchgeo.datasets import DatasetNotFoundError
 
 from torchgeo_bench.config import compose_config
 from torchgeo_bench.main import main, resolve_model_config
+from torchgeo_bench.resume import _resume_config_hash
 
 
 class _DictTensorDataset(Dataset):
@@ -104,6 +105,7 @@ def _resume_row(cfg: DictConfig, *, method: str, metric_name: str) -> dict[str, 
         "partition": cfg.dataset.partition,
         "bands": cfg.dataset.bands,
         "num_classes": 10,
+        "config_hash": _resume_config_hash(cfg),
         "metric_name": metric_name,
         "metric_value": 0.1,
     }
@@ -520,6 +522,28 @@ def test_resume_recomputes_legacy_row_without_num_classes(tmp_path: Path):
     assert len(df) == 2
     assert pd.isna(df.iloc[0]["num_classes"])
     assert int(df.iloc[1]["num_classes"]) == 10
+
+
+def test_resume_reruns_when_evaluation_config_changes(tmp_path: Path):
+    """A stale row must not suppress a run with a different random seed."""
+    out = tmp_path / "out.csv"
+    old_cfg = _compose_cfg(out, overrides=["eval.skip_linear=true"])
+    cfg = _compose_cfg(out, overrides=["resume=true", "seed=7", "eval.skip_linear=true"])
+    pd.DataFrame([_resume_row(old_cfg, method="knn5", metric_name="accuracy")]).to_csv(
+        out, index=False
+    )
+
+    with (
+        mock.patch("torchgeo_bench.main.get_datasets", return_value=_synthetic_loaders()),
+        mock.patch("torchgeo_bench.main.embed_split", side_effect=_synthetic_embeddings()),
+        mock.patch(
+            "torchgeo_bench.main.evaluate_knn",
+            return_value=(0.5, 0.45, 0.55, {"ece": 0.05, "rms_ce": 0.07, "mce": 0.1}, 6),
+        ) as knn_mock,
+    ):
+        main(cfg)
+
+    knn_mock.assert_called_once()
 
 
 def test_dataset_not_found_skips(tmp_path: Path):

--- a/tests/test_main_multilabel_fast.py
+++ b/tests/test_main_multilabel_fast.py
@@ -9,6 +9,7 @@ import torch
 from torch.utils.data import DataLoader
 
 from torchgeo_bench.main import main
+from torchgeo_bench.resume import _resume_config_hash
 
 from .test_main_fast import _compose_cfg, _DictTensorDataset
 
@@ -66,6 +67,7 @@ def _multilabel_resume_row(cfg) -> dict[str, object]:
         "partition": cfg.dataset.partition,
         "bands": cfg.dataset.bands,
         "num_classes": 43,
+        "config_hash": _resume_config_hash(cfg),
         "metric_name": "micro_mAP",
         "metric_value": 0.2,
     }

--- a/tests/test_main_segmentation_fast.py
+++ b/tests/test_main_segmentation_fast.py
@@ -8,6 +8,7 @@ import torch
 from torch.utils.data import DataLoader, Dataset
 
 from torchgeo_bench.main import main
+from torchgeo_bench.resume import _resume_config_hash
 
 from .test_main_fast import _chainable_model_mock, _compose_cfg
 
@@ -65,6 +66,7 @@ def _seg_resume_row(cfg, *, metric_name: str = "mIoU") -> dict[str, object]:
         "partition": cfg.dataset.partition,
         "bands": cfg.dataset.bands,
         "num_classes": 3,
+        "config_hash": _resume_config_hash(cfg),
         "metric_name": metric_name,
         "metric_value": 0.42,
     }

--- a/tests/test_main_utils.py
+++ b/tests/test_main_utils.py
@@ -104,6 +104,7 @@ def test_evaluate_profile_adds_cpu_metrics_branch() -> None:
         "partition": "default",
         "bands": "rgb",
         "num_classes": 10,
+        "config_hash": "test-config-hash",
         "c_range_start": -2,
         "c_range_stop": 2,
         "c_range_num": 3,


### PR DESCRIPTION
Resume matching only considered a subset of the inputs that affect a score. A changed seed, evaluation sweep, or model setting could therefore reuse an incompatible CSV row.

Add a stable config fingerprint to result rows and resume keys. Existing rows without it are rerun safely.

Checks: uv run pytest tests/test_main_fast.py tests/test_main_multilabel_fast.py tests/test_main_segmentation_fast.py tests/test_main_intrinsic_dim_fast.py tests/test_main_profile_fast.py tests/test_main_utils.py --no-cov -q; uv run ruff check ...; uv run ruff format --check ...