### PR TITLE
fix: make segmentation sweeps reproducible

### DIFF
--- a/scripts/run_segmentation_protocol_study.py
+++ b/scripts/run_segmentation_protocol_study.py
@@ -110,7 +110,7 @@ def _source_hash(root: Path) -> str:
     return hasher.hexdigest()
 
 
-def study_metadata(root: Path) -> dict[str, object]:
+def study_metadata(root: Path, seed: int) -> dict[str, object]:
     """Return the result-affecting study configuration."""
     return {
         "schema_version": 1,
@@ -122,7 +122,7 @@ def study_metadata(root: Path) -> dict[str, object]:
         "image_size": 224,
         "normalization": "bandspec_zscore",
         "partition": "default",
-        "seed": 0,
+        "seed": seed,
         "cache_features": True,
         "cache_dtype": "float16",
     }
@@ -134,6 +134,7 @@ class StudyConfig(RunnerConfig):
 
     raw_dir: Path
     combined_output: Path
+    seed: int
 
 
 class StudyRunner(BaseGpuRunner):
@@ -149,7 +150,7 @@ class StudyRunner(BaseGpuRunner):
         return self.config.raw_dir / f"{job.job_id}.csv"
 
     def _validate_metadata(self) -> None:
-        expected = study_metadata(self.config.root)
+        expected = study_metadata(self.config.root, self.config.seed)
         if self.metadata_path.exists():
             if json.loads(self.metadata_path.read_text()) != expected:
                 raise RuntimeError(f"Incompatible study metadata at {self.metadata_path}.")
@@ -219,6 +220,7 @@ class StudyRunner(BaseGpuRunner):
             "dataset.image_size=224",
             f"dataset.batch_size={loader_batch}",
             f"dataset.num_workers={self.config.num_workers}",
+            f"seed={self.config.seed}",
             f"device=cuda:{gpu}",
             "eval.segmentation.head_type=fpn",
             f"eval.segmentation.epochs={job.variant.epochs}",
@@ -284,6 +286,7 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--gpus", default="0,1")
     parser.add_argument("--num-workers", type=int, default=0)
     parser.add_argument("--max-attempts", type=int, default=2)
+    parser.add_argument("--seed", type=int, default=0)
     parser.add_argument("--raw-dir", type=Path, default=Path("results/segmentation_protocol/raw"))
     parser.add_argument(
         "--state-dir", type=Path, default=Path("results/segmentation_protocol/state")
@@ -309,6 +312,7 @@ def main() -> None:
         gpus=parse_gpus(args.gpus),
         num_workers=args.num_workers,
         max_attempts=args.max_attempts,
+        seed=args.seed,
     )
     logger.info(
         "Study: %d models x %d datasets x %d variants = %d jobs",

--- a/scripts/run_segmentation_representative_sweep.py
+++ b/scripts/run_segmentation_representative_sweep.py
@@ -3,6 +3,7 @@
 
 import argparse
 import csv
+import hashlib
 import json
 import logging
 import random
@@ -101,13 +102,25 @@ def build_jobs() -> list[Job]:
     return jobs
 
 
-def sweep_metadata(image_size: int) -> dict[str, object]:
+def _source_hash(root: Path) -> str:
+    """Fingerprint benchmark code and packaged configuration."""
+    hasher = hashlib.sha256()
+    paths = sorted((root / "src/torchgeo_bench").rglob("*.py"))
+    paths.extend(sorted((root / "src/torchgeo_bench/conf").rglob("*.yaml")))
+    for path in paths:
+        hasher.update(str(path.relative_to(root)).encode())
+        hasher.update(path.read_bytes())
+    return hasher.hexdigest()
+
+
+def sweep_metadata(root: Path, image_size: int, seed: int) -> dict[str, object]:
     """Return the result-affecting configuration fingerprint."""
     return {
-        "schema_version": 1,
+        "schema_version": 2,
+        "source_hash": _source_hash(root),
         "epochs": EPOCHS,
         "image_size": image_size,
-        "seed": 0,
+        "seed": seed,
         "normalization": "bandspec_zscore",
         "interpolation": "bilinear",
         "partition": "default",
@@ -175,7 +188,7 @@ class SweepRunner(BaseGpuRunner):
         )
 
     def _validate_metadata(self) -> None:
-        expected = sweep_metadata(self.config.image_size)
+        expected = sweep_metadata(self.config.root, self.config.image_size, self.config.seed)
         if self.config.output.exists() and self.config.output.stat().st_size > 0:
             if not self.metadata_path.exists():
                 raise RuntimeError(
@@ -196,6 +209,7 @@ class SweepRunner(BaseGpuRunner):
             "failed_jobs": str(self.failed_path),
             "epochs": EPOCHS,
             "image_size": self.config.image_size,
+            "seed": self.config.seed,
         }
 
     def _failed_record(self, job: Job, gpu: int) -> dict:
@@ -214,6 +228,7 @@ class SweepRunner(BaseGpuRunner):
             f"dataset.image_size={self.config.image_size}",
             f"dataset.batch_size={loader_batch}",
             f"dataset.num_workers={self.config.num_workers}",
+            f"seed={self.config.seed}",
             f"device=cuda:{gpu}",
             f"eval.segmentation.head_type={job.head}",
             f"eval.segmentation.epochs={EPOCHS}",

--- a/tests/test_segmentation_sweep_scripts.py
+++ b/tests/test_segmentation_sweep_scripts.py
@@ -1,0 +1,72 @@
+"""Regression tests for standalone segmentation sweep runners."""
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+ROOT = Path(__file__).parents[1]
+
+
+def _load_script(filename: str) -> ModuleType:
+    """Load a script module without requiring ``scripts`` to be a package.
+
+    The sweep and study scripts both import ``_seg_sweep_common`` as a
+    top-level module, so ``scripts/`` must be on ``sys.path`` before exec.
+    """
+    scripts_dir = str(ROOT / "scripts")
+    if scripts_dir not in sys.path:
+        sys.path.insert(0, scripts_dir)
+    path = ROOT / "scripts" / filename
+    module_name = f"test_{path.stem}"
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_representative_sweep_passes_seed_and_rejects_unknown_metadata(tmp_path: Path) -> None:
+    sweep = _load_script("run_segmentation_representative_sweep.py")
+    config = sweep.SweepConfig(
+        root=ROOT,
+        cli=tmp_path / "torchgeo-bench",
+        output=tmp_path / "results.csv",
+        state_dir=tmp_path / "state",
+        gpus=[0],
+        image_size=224,
+        num_workers=2,
+        max_attempts=2,
+        seed=17,
+    )
+    runner = sweep.SweepRunner(config)
+
+    assert "seed=17" in runner._command(runner.jobs[0], gpu=0, attempt=1)
+    assert sweep.sweep_metadata(ROOT, image_size=224, seed=17)["seed"] == 17
+
+    config.output.write_text("dataset\n")
+    runner.metadata_path.write_text('{"schema_version": 1}\n')
+    with pytest.raises(RuntimeError, match="incompatible sweep configuration"):
+        runner._validate_metadata()
+
+
+def test_protocol_study_passes_configured_seed(tmp_path: Path) -> None:
+    study = _load_script("run_segmentation_protocol_study.py")
+    config = study.StudyConfig(
+        root=ROOT,
+        cli=tmp_path / "torchgeo-bench",
+        raw_dir=tmp_path / "raw",
+        state_dir=tmp_path / "state",
+        combined_output=tmp_path / "combined.csv",
+        gpus=[0],
+        num_workers=2,
+        max_attempts=2,
+        seed=23,
+    )
+    runner = study.StudyRunner(config)
+
+    assert "seed=23" in runner._command(runner.jobs[0], gpu=0, attempt=1)
+    assert study.study_metadata(ROOT, seed=23)["seed"] == 23


### PR DESCRIPTION
The segmentation sweep scripts recorded a seed but did not pass it to torchgeo-bench. The representative sweep could also resume rows after benchmark code or config had changed.

Pass the configured seed through both runners, and fingerprint representative sweep metadata with benchmark source/config. Existing results with unknown or incompatible metadata now stop instead of being silently reused.

Checks: uv run pytest tests/test_segmentation_sweep_scripts.py --no-cov -q; uv run ruff check ...; uv run ruff format --check ...