### PR TITLE
fix: report segmentation validation usage

### DIFF
--- a/src/torchgeo_bench/main.py
+++ b/src/torchgeo_bench/main.py
@@ -686,6 +686,7 @@ def main(cfg: DictConfig) -> None:
         if is_segmentation:
             seg_cfg_merged = eval_cfg_merged.segmentation
             save_viz = seg_cfg_merged.get("save_viz", False)
+            segmentation_meta = {**common_meta, "merge_val": False}
             metrics, feat_dim, best_lr, best_bs, preds = evaluate_segmentation(
                 model,
                 train_loader,
@@ -699,7 +700,7 @@ def main(cfg: DictConfig) -> None:
             )
             all_rows.append(
                 metric_row(
-                    common_meta,
+                    segmentation_meta,
                     method=seg_method,
                     metric_name="mIoU",
                     metric_value=metrics.get("mIoU", float("nan")),

--- a/tests/test_main_segmentation_fast.py
+++ b/tests/test_main_segmentation_fast.py
@@ -118,6 +118,7 @@ def test_segmentation_row_emitted(tmp_path: Path):
     assert "miou" in set(df["metric_name"].str.lower())
     assert df.loc[0, "best_lr"] == 1e-3
     assert df.loc[0, "best_batch_size"] == 2
+    assert not df.loc[0, "merge_val"]
 
 
 def test_segmentation_viz_not_called_when_disabled(tmp_path: Path):


### PR DESCRIPTION
Segmentation rows reported `merge_val=true` from the classification setting even though segmentation trains on train and evaluates validation separately.

Write `merge_val=false` for segmentation results and cover the CSV metadata.