### PR TITLE
fix: bootstrap segmentation confidence intervals

### DIFF
--- a/docs/user/configuration.rst
+++ b/docs/user/configuration.rst
@@ -78,7 +78,7 @@ selection semantics.
 .. code-block:: yaml
 
    eval:
-     bootstrap: 200                # bootstrap resamples for KNN/linear CIs
+     bootstrap: 200                # bootstrap resamples for KNN/linear/segmentation CIs
      c_range: [-6, 4, 40]          # log10 sweep start, stop, num samples for linear probe
      merge_val: true               # merge train+val before training the final logistic head
      skip_linear: false            # skip the (slower) linear probe entirely

--- a/docs/user/methodology.rst
+++ b/docs/user/methodology.rst
@@ -237,6 +237,9 @@ Training & evaluation (all heads)
   ``torchmetrics.MulticlassJaccardIndex``.  Frequency-weighted IoU plus
   macro precision / recall / F1 are also reported in the result row
   (see :doc:`results-format`).
+* **Uncertainty:** 95% bootstrap confidence intervals resample held-out
+  images and recompute dataset-level mIoU from their aggregated confusion
+  matrices.
 
 Segmentation knobs
 ------------------

--- a/src/torchgeo_bench/main.py
+++ b/src/torchgeo_bench/main.py
@@ -34,6 +34,7 @@ from torchgeo_bench.results import (  # noqa: F401  (EvaluationResult re-exporte
     append_rows_atomic,
     bootstrap_accuracy,
     bootstrap_map,
+    bootstrap_miou,
     metric_row,
     model_results_path,
 )
@@ -462,6 +463,7 @@ def evaluate_segmentation(
     eval_cfg: DictConfig,
     num_classes: int,
     device: torch.device,
+    seed: int,
     collect_preds: bool = False,
     verbose: bool = False,
 ) -> "tuple[torchgeo_bench.segmentation_task.SegMetrics, int, float | None, int | None, torch.Tensor | None]":
@@ -480,6 +482,7 @@ def evaluate_segmentation(
             ``eval`` overrides.
         num_classes: Number of segmentation classes.
         device: Torch device.
+        seed: RNG seed for the mIoU bootstrap when ``eval_cfg.bootstrap`` > 0.
         collect_preds: If True, collect and return test predictions as (N, H, W) tensor.
         verbose: Show training progress.
 
@@ -498,6 +501,7 @@ def evaluate_segmentation(
     )
 
     probe, solver = build_seg_probe_and_solver(model, num_classes, eval_cfg, device, lr)
+    collect_confusions = int(eval_cfg.bootstrap) > 0
     if use_cache and probe.freeze_backbone:
         logger.info("Caching backbone features for train and val splits...")
         train_cache = probe.extract_segmentation_features(train_loader, cache_dtype=cache_dtype)
@@ -514,20 +518,38 @@ def evaluate_segmentation(
             test_cache,
             batch_size=probe_batch_size,
             collect_preds=collect_preds,
+            collect_confusions=collect_confusions,
         )
     else:
         solver.fit(train_loader=train_loader, val_loader=val_loader, epochs=epochs, verbose=verbose)
-        eval_result = solver.evaluate(test_loader, collect_preds=collect_preds)
+        eval_result = solver.evaluate(
+            test_loader,
+            collect_preds=collect_preds,
+            collect_confusions=collect_confusions,
+        )
     actual_batch_size = (
         probe_batch_size
         if use_cache and probe.freeze_backbone
         else int(train_loader.batch_size or 1)
     )
 
-    if collect_preds:
+    if collect_preds and collect_confusions:
+        metrics, preds, confusion_matrices = eval_result
+    elif collect_preds:
         metrics, preds = eval_result
+        confusion_matrices = None
+    elif collect_confusions:
+        metrics, confusion_matrices = eval_result
+        preds = None
     else:
         metrics, preds = eval_result, None
+        confusion_matrices = None
+    if confusion_matrices is not None:
+        metrics["ci_lower"], metrics["ci_upper"] = bootstrap_miou(
+            confusion_matrices,
+            n_boot=int(eval_cfg.bootstrap),
+            seed=seed,
+        )
     return metrics, sum(probe.channels_list), lr, actual_batch_size, preds
 
 
@@ -726,6 +748,7 @@ def main(cfg: DictConfig) -> None:
                 eval_cfg_merged,
                 num_classes,
                 device,
+                seed=cfg.seed,
                 collect_preds=save_viz,
                 verbose=cfg.verbose,
             )
@@ -735,6 +758,8 @@ def main(cfg: DictConfig) -> None:
                     method=seg_method,
                     metric_name="mIoU",
                     metric_value=metrics.get("mIoU", float("nan")),
+                    ci_lower=metrics.get("ci_lower", float("nan")),
+                    ci_upper=metrics.get("ci_upper", float("nan")),
                     feature_dim=feat_dim,
                     n_counts={
                         "train": len(train_dataset),

--- a/src/torchgeo_bench/results.py
+++ b/src/torchgeo_bench/results.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
+import torch
 
 logger = logging.getLogger(__name__)
 
@@ -119,6 +120,46 @@ def bootstrap_map(
     lower = float(np.percentile(maps, lo))
     upper = float(np.percentile(maps, hi))
     return map_mean, lower, upper
+
+
+def bootstrap_miou(
+    confusion_matrices: torch.Tensor,
+    n_boot: int = 1000,
+    ci: float = 95.0,
+    seed: int | None = None,
+) -> tuple[float, float]:
+    """Bootstrap interval for dataset-level mIoU from per-image confusion matrices.
+
+    ``confusion_matrices`` holds one ``(C, C)`` matrix per test image. Each
+    resample draws images with replacement, sums their confusion matrices,
+    and recomputes mIoU from the summed matrix -- mirroring how the metric is
+    computed over the whole test set rather than averaging a per-image score.
+    """
+    if n_boot < 1:
+        return float("nan"), float("nan")
+    if confusion_matrices.ndim != 3 or confusion_matrices.shape[0] == 0:
+        raise ValueError("Expected non-empty per-image confusion matrices with shape (N, C, C).")
+    if confusion_matrices.shape[1] != confusion_matrices.shape[2]:
+        raise ValueError("Confusion matrices must be square.")
+
+    confusions = confusion_matrices.to(dtype=torch.float64, device="cpu")
+    generator = torch.Generator().manual_seed(seed if seed is not None else 0)
+    n_samples = len(confusions)
+    scores = torch.empty(n_boot, dtype=torch.float64)
+    for index in range(n_boot):
+        sample = torch.randint(n_samples, (n_samples,), generator=generator)
+        confusion = confusions[sample].sum(dim=0)
+        intersection = confusion.diagonal()
+        union = confusion.sum(dim=0) + confusion.sum(dim=1) - intersection
+        present = union > 0
+        scores[index] = (
+            (intersection[present] / union[present]).mean() if present.any() else float("nan")
+        )
+
+    lower = (100.0 - ci) / 2.0
+    return float(torch.nanquantile(scores, lower / 100.0)), float(
+        torch.nanquantile(scores, 1 - lower / 100.0)
+    )
 
 
 @dataclass

--- a/src/torchgeo_bench/segmentation_task.py
+++ b/src/torchgeo_bench/segmentation_task.py
@@ -192,16 +192,17 @@ class SegmentationSolver:
         self,
         dataloader: DataLoader,
         collect_preds: bool = False,
-    ) -> "SegMetrics | tuple[SegMetrics, torch.Tensor]":
+        collect_confusions: bool = False,
+    ) -> "SegMetrics | tuple[SegMetrics, torch.Tensor] | tuple[SegMetrics, torch.Tensor, torch.Tensor]":
         """Evaluate the model on a dataloader and return segmentation metrics.
 
         Args:
             dataloader: Evaluation data loader.
             collect_preds: If True, also return predicted class maps (N, H, W) int64.
+            collect_confusions: If True, also return per-image confusion matrices.
 
         Returns:
-            Dict of metric name → value, or (metrics_dict, preds_tensor) when
-            collect_preds=True.
+            Metrics, optionally followed by predictions and/or per-image confusion matrices.
         """
         self.model.eval()
         for m in self._all_metrics:
@@ -209,6 +210,7 @@ class SegmentationSolver:
             m.to(self.device)
 
         pred_list: list[torch.Tensor] = []
+        confusion_list: list[torch.Tensor] = []
 
         for batch in dataloader:
             if isinstance(batch, dict):
@@ -228,13 +230,17 @@ class SegmentationSolver:
             for m in self._all_metrics:
                 m.update(logits, masks)
 
-            if collect_preds:
-                pred_list.append(logits.argmax(dim=1).cpu())
+            if collect_preds or collect_confusions:
+                predictions = logits.argmax(dim=1)
+                if collect_preds:
+                    pred_list.append(predictions.cpu())
+                if collect_confusions:
+                    confusion_list.append(self._per_image_confusions(predictions, masks).cpu())
 
         metrics = self._compute_metrics()
-        if collect_preds:
-            return metrics, torch.cat(pred_list, dim=0)
-        return metrics
+        return self._evaluation_result(
+            metrics, pred_list, confusion_list, collect_preds, collect_confusions
+        )
 
     def fit_cached(
         self,
@@ -326,7 +332,8 @@ class SegmentationSolver:
         cache: CachedFeaturesDataset,
         batch_size: int = 64,
         collect_preds: bool = False,
-    ) -> "SegMetrics | tuple[SegMetrics, torch.Tensor]":
+        collect_confusions: bool = False,
+    ) -> "SegMetrics | tuple[SegMetrics, torch.Tensor] | tuple[SegMetrics, torch.Tensor, torch.Tensor]":
         """Evaluate on a CachedFeaturesDataset.
 
         The cache is moved to GPU as a :class:`GPUTensorCache` for zero
@@ -337,13 +344,45 @@ class SegmentationSolver:
                 :meth:`SegmentationProbe.extract_segmentation_features`).
             batch_size: Batch size for iterating over the cache.
             collect_preds: If True, also return predicted class maps (N, H, W) int64.
+            collect_confusions: If True, also return per-image confusion matrices.
 
         Returns:
-            Dict of metric name → value, or (metrics_dict, preds_tensor) when
-            collect_preds=True.
+            Metrics, optionally followed by predictions and/or per-image confusion matrices.
         """
         gpu_cache = GPUTensorCache.from_cached(cache, self.device)
-        return self._evaluate_gpu_cache(gpu_cache, batch_size, collect_preds=collect_preds)
+        return self._evaluate_gpu_cache(
+            gpu_cache,
+            batch_size,
+            collect_preds=collect_preds,
+            collect_confusions=collect_confusions,
+        )
+
+    def _per_image_confusions(self, predictions: torch.Tensor, masks: torch.Tensor) -> torch.Tensor:
+        """Return one confusion matrix per image, excluding ignored labels."""
+        predictions = predictions.reshape(len(predictions), -1)
+        masks = masks.reshape(len(masks), -1)
+        valid = masks != self.ignore_index
+        offsets = torch.arange(len(masks), device=masks.device).unsqueeze(1)
+        indices = offsets * self.num_classes**2 + masks * self.num_classes + predictions
+        indices = indices[valid]
+        counts = torch.bincount(indices, minlength=len(masks) * self.num_classes**2)
+        return counts.reshape(len(masks), self.num_classes, self.num_classes)
+
+    @staticmethod
+    def _evaluation_result(
+        metrics: SegMetrics,
+        pred_list: list[torch.Tensor],
+        confusion_list: list[torch.Tensor],
+        collect_preds: bool,
+        collect_confusions: bool,
+    ) -> "SegMetrics | tuple[SegMetrics, torch.Tensor] | tuple[SegMetrics, torch.Tensor, torch.Tensor]":
+        if collect_preds and collect_confusions:
+            return metrics, torch.cat(pred_list, dim=0), torch.cat(confusion_list, dim=0)
+        if collect_preds:
+            return metrics, torch.cat(pred_list, dim=0)
+        if collect_confusions:
+            return metrics, torch.cat(confusion_list, dim=0)
+        return metrics
 
     def _compute_metrics(self) -> "SegMetrics":
         """Compute and return all metrics as a dict."""
@@ -361,7 +400,8 @@ class SegmentationSolver:
         gpu_cache: GPUTensorCache,
         batch_size: int,
         collect_preds: bool = False,
-    ) -> "SegMetrics | tuple[SegMetrics, torch.Tensor]":
+        collect_confusions: bool = False,
+    ) -> "SegMetrics | tuple[SegMetrics, torch.Tensor] | tuple[SegMetrics, torch.Tensor, torch.Tensor]":
         """Evaluate on a :class:`GPUTensorCache` and return segmentation metrics."""
         self.model.eval()
         for m in self._all_metrics:
@@ -369,6 +409,7 @@ class SegmentationSolver:
             m.to(self.device)
 
         pred_list: list[torch.Tensor] = []
+        confusion_list: list[torch.Tensor] = []
 
         input_hw = (gpu_cache.masks.shape[-2], gpu_cache.masks.shape[-1])
         for features, masks in gpu_cache.ordered_batches(batch_size):
@@ -376,13 +417,17 @@ class SegmentationSolver:
                 logits = self.model.head(features, *input_hw)
             for m in self._all_metrics:
                 m.update(logits, masks)
-            if collect_preds:
-                pred_list.append(logits.argmax(dim=1).cpu())
+            if collect_preds or collect_confusions:
+                predictions = logits.argmax(dim=1)
+                if collect_preds:
+                    pred_list.append(predictions.cpu())
+                if collect_confusions:
+                    confusion_list.append(self._per_image_confusions(predictions, masks).cpu())
 
         metrics = self._compute_metrics()
-        if collect_preds:
-            return metrics, torch.cat(pred_list, dim=0)
-        return metrics
+        return self._evaluation_result(
+            metrics, pred_list, confusion_list, collect_preds, collect_confusions
+        )
 
 
 def build_seg_probe_and_solver(

--- a/tests/test_main_segmentation_fast.py
+++ b/tests/test_main_segmentation_fast.py
@@ -88,13 +88,25 @@ def _mock_probe_and_solver():
     probe.channels_list = [16, 32]
     solver = mock.Mock()
     solver.fit.return_value = None
-    solver.evaluate.return_value = {
+    metrics = {
         "mIoU": 0.42,
         "fw_IoU": 0.55,
         "precision": 0.6,
         "recall": 0.7,
         "f1": 0.65,
     }
+    confusions = torch.tensor([[[0, 4], [0, 0]], [[0, 0], [0, 4]]])
+
+    def evaluate(*_args, collect_preds: bool = False, collect_confusions: bool = False, **_kwargs):
+        if collect_preds and collect_confusions:
+            return metrics, torch.zeros(2, 64, 64, dtype=torch.long), confusions
+        if collect_preds:
+            return metrics, torch.zeros(2, 64, 64, dtype=torch.long)
+        if collect_confusions:
+            return metrics, confusions
+        return metrics
+
+    solver.evaluate.side_effect = evaluate
     return probe, solver
 
 
@@ -119,6 +131,7 @@ def test_segmentation_row_emitted(tmp_path: Path):
     assert df.loc[0, "best_lr"] == 1e-3
     assert df.loc[0, "best_batch_size"] == 2
     assert not df.loc[0, "merge_val"]
+    assert df.loc[0, "ci_lower"] < df.loc[0, "ci_upper"]
 
 
 def test_cached_segmentation_records_probe_batch_size(tmp_path: Path):
@@ -209,6 +222,7 @@ def test_segmentation_viz_called_when_enabled(tmp_path: Path):
     )
     probe, solver = _mock_probe_and_solver()
     preds = torch.zeros(4, 64, 64, dtype=torch.long)
+    solver.evaluate.side_effect = None
     solver.evaluate.return_value = (
         {
             "mIoU": 0.42,
@@ -218,6 +232,7 @@ def test_segmentation_viz_called_when_enabled(tmp_path: Path):
             "f1": 0.65,
         },
         preds,
+        torch.tensor([[[0, 4], [0, 0]], [[0, 0], [0, 4]]]),
     )
 
     with (

--- a/tests/test_main_segmentation_fast.py
+++ b/tests/test_main_segmentation_fast.py
@@ -145,13 +145,16 @@ def test_cached_segmentation_records_probe_batch_size(tmp_path: Path):
     cache = mock.Mock()
     probe.freeze_backbone = True
     probe.extract_segmentation_features.return_value = cache
-    solver.evaluate_cached.return_value = {
-        "mIoU": 0.42,
-        "fw_IoU": 0.55,
-        "precision": 0.6,
-        "recall": 0.7,
-        "f1": 0.65,
-    }
+    solver.evaluate_cached.return_value = (
+        {
+            "mIoU": 0.42,
+            "fw_IoU": 0.55,
+            "precision": 0.6,
+            "recall": 0.7,
+            "f1": 0.65,
+        },
+        torch.tensor([[[0, 4], [0, 0]], [[0, 0], [0, 4]]]),
+    )
 
     with (
         mock.patch(

--- a/tests/test_segmentation.py
+++ b/tests/test_segmentation.py
@@ -4,6 +4,7 @@ import torch.nn as nn
 from omegaconf import OmegaConf
 from torch.utils.data import DataLoader, TensorDataset
 
+from torchgeo_bench.results import bootstrap_miou
 from torchgeo_bench.segmentation_probe import (
     CachedFeaturesDataset,
     GPUTensorCache,
@@ -13,6 +14,15 @@ from torchgeo_bench.segmentation_probe import (
 from torchgeo_bench.segmentation_task import SegmentationSolver, build_seg_probe_and_solver
 
 NUM_CLASSES = 5
+
+
+def test_bootstrap_miou_uses_per_image_resampling() -> None:
+    """Bootstrap intervals reflect variation across held-out images."""
+    confusions = torch.tensor([[[0, 4], [0, 0]], [[0, 0], [0, 4]]])
+
+    lower, upper = bootstrap_miou(confusions, n_boot=200, seed=7)
+
+    assert 0.0 <= lower < upper <= 1.0
 
 
 class MockBackbone(nn.Module):


### PR DESCRIPTION
Segmentation rows wrote `ci_lower=0` and `ci_upper=0` even though no interval was estimated.

Compute a 95% image-level bootstrap interval for dataset mIoU by resampling held-out per-image confusion matrices. This preserves pixel structure and avoids materializing bootstrap-sized masks. The documented `eval.bootstrap` setting now applies to segmentation too.