### PR TITLE
Support downloading individual GeoBench V1 datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ The runner expects datasets under `./data/`. To grab GeoBench V1:
 torchgeo-bench download geobench_v1
 ```
 
+To download only the datasets needed for a run:
+
+```bash
+torchgeo-bench download geobench_v1 --datasets m-eurosat
+```
+
 V2 (classification + segmentation) and torchgeo's EuroSAT downloader work the
 same way (`torchgeo-bench download geobench_v2`, `torchgeo-bench download
 eurosat`). See the [documentation](https://torchgeo.org/torchgeo-bench/user/datasets.html)

--- a/docs/api/cli.rst
+++ b/docs/api/cli.rst
@@ -13,8 +13,8 @@ The ``torchgeo-bench`` console script exposes two subcommands:
 
 ``torchgeo-bench download {geobench_v1|geobench_v2|eurosat}``
     Downloads benchmark datasets into ``./data/`` (or a custom location with
-    ``--output-dir``). For GeoBench V2, individual datasets can be selected
-    with ``--datasets a,b,c``.
+    ``--output-dir``). For GeoBench V1 and V2, individual datasets can be
+    selected with ``--datasets a,b,c``.
 
 Hydra entry point
 -----------------

--- a/src/torchgeo_bench/cli.py
+++ b/src/torchgeo_bench/cli.py
@@ -61,7 +61,7 @@ def download(
     ] = Path("data"),
     datasets: Annotated[
         str | None,
-        typer.Option(help="(geobench_v2 only) Comma-separated dataset names."),
+        typer.Option(help="(GeoBench only) Comma-separated dataset names."),
     ] = None,
 ) -> None:
     """Download a benchmark dataset to disk."""
@@ -76,10 +76,10 @@ def download(
         typer.echo(f"Unknown target {target!r}. Choose from: {', '.join(sorted(valid))}", err=True)
         raise typer.Exit(1)
 
+    names = [n.strip() for n in datasets.split(",") if n.strip()] if datasets else None
     if target == "geobench_v1":
-        download_geobench_v1(output_dir)
+        download_geobench_v1(output_dir, datasets=names)
     elif target == "geobench_v2":
-        names = [n.strip() for n in datasets.split(",") if n.strip()] if datasets else None
         download_geobench_v2(output_dir, datasets=names)
     elif target == "eurosat":
         download_eurosat(output_dir)

--- a/src/torchgeo_bench/download.py
+++ b/src/torchgeo_bench/download.py
@@ -4,7 +4,8 @@ Three targets:
 
 - ``geobench_v1`` — full GeoBench V1 classification suite from
   ``recursix/geo-bench-1.0``. Downloads to ``<output>/`` (the HF repo already
-  contains a top-level ``classification_v1.0/`` directory).
+  contains a top-level ``classification_v1.0/`` directory). Selected datasets
+  use the sharded mirror under ``<output>/classification_v1.0_wds/``.
 - ``geobench_v2`` — selected GeoBench V2 datasets from ``aialliance/<name>``
   HF repos. Defaults to the benchmark-supported datasets; override with
   ``--datasets``. Each dataset goes to ``<output>/geobenchv2/<name>``.
@@ -22,6 +23,7 @@ from torchgeo.datasets import EuroSAT
 logger = logging.getLogger(__name__)
 
 GEOBENCH_V1_REPO = "recursix/geo-bench-1.0"
+GEOBENCH_V1_SHARDED_REPO = "isaaccorley/geobenchv1-webdataset"
 GEOBENCH_V2_REPO_PREFIX = "aialliance"
 
 # Default V2 datasets to download — only those the benchmark runner knows about.
@@ -53,10 +55,35 @@ def _decompress_zip_with_progress(zip_path: Path, extract_to: Path) -> None:
     logger.info("Removed zip file: %s", zip_path)
 
 
-def download_geobench_v1(output_dir: Path) -> None:
-    """Download GeoBench V1 to ``output_dir`` (creates ``classification_v1.0/`` inside)."""
+def download_geobench_v1(output_dir: Path, datasets: list[str] | None = None) -> None:
+    """Download GeoBench V1 datasets to ``output_dir``.
+
+    Args:
+        output_dir: Benchmark data root (typically ``data/``).
+        datasets: Specific dataset names to fetch from the sharded mirror.
+            ``None`` downloads the full legacy HDF5 collection.
+    """
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
+
+    if datasets:
+        sharded_root = output_dir / "classification_v1.0_wds"
+        sharded_root.mkdir(parents=True, exist_ok=True)
+        logger.info(
+            "Downloading %d GeoBench v1 dataset(s) from %s -> %s",
+            len(datasets),
+            GEOBENCH_V1_SHARDED_REPO,
+            sharded_root,
+        )
+        snapshot_download(
+            repo_id=GEOBENCH_V1_SHARDED_REPO,
+            repo_type="dataset",
+            local_dir=sharded_root,
+            allow_patterns=[f"{name}/*" for name in datasets],
+        )
+        logger.info("GeoBench v1 subset download complete.")
+        return
+
     logger.info("Downloading GeoBench v1 from %s -> %s", GEOBENCH_V1_REPO, output_dir)
 
     snapshot_download(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,15 +26,30 @@ def test_download_invalid_target() -> None:
 
 
 def test_download_geobench_v1(monkeypatch) -> None:
-    calls: list[str] = []
+    calls: list[tuple[str, list[str] | None]] = []
 
-    def _fake_download(path) -> None:
-        calls.append(str(path))
+    def _fake_download(path, datasets=None) -> None:
+        calls.append((str(path), datasets))
 
     monkeypatch.setattr("torchgeo_bench.download.download_geobench_v1", _fake_download)
     result = runner.invoke(app, ["download", "geobench_v1"])
     assert result.exit_code == 0
-    assert len(calls) == 1
+    assert calls == [("data", None)]
+
+
+def test_download_geobench_v1_with_datasets(monkeypatch) -> None:
+    calls: list[tuple[str, list[str] | None]] = []
+
+    def _fake_download(path, datasets=None) -> None:
+        calls.append((str(path), datasets))
+
+    monkeypatch.setattr("torchgeo_bench.download.download_geobench_v1", _fake_download)
+    result = runner.invoke(
+        app,
+        ["download", "geobench_v1", "--datasets", "m-eurosat,m-forestnet"],
+    )
+    assert result.exit_code == 0
+    assert calls == [("data", ["m-eurosat", "m-forestnet"])]
 
 
 def test_download_geobench_v2_with_datasets(monkeypatch) -> None:

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -32,6 +32,19 @@ def test_download_geobench_v1_creates_output_and_decompresses(tmp_path: Path) ->
     decompress_mock.assert_called_once()
 
 
+def test_download_geobench_v1_subset_uses_sharded_mirror(tmp_path: Path) -> None:
+    out = tmp_path / "data"
+    with mock.patch("torchgeo_bench.download.snapshot_download") as download_mock:
+        download_geobench_v1(out, datasets=["m-eurosat", "m-forestnet"])
+
+    download_mock.assert_called_once_with(
+        repo_id="isaaccorley/geobenchv1-webdataset",
+        repo_type="dataset",
+        local_dir=out / "classification_v1.0_wds",
+        allow_patterns=["m-eurosat/*", "m-forestnet/*"],
+    )
+
+
 def test_download_geobench_v2_subset(tmp_path: Path) -> None:
     out = tmp_path / "data"
     with mock.patch("torchgeo_bench.download.download_geobench_v2_dataset") as dl_mock:


### PR DESCRIPTION
## Summary
- allow `torchgeo-bench download geobench_v1 --datasets ...` to fetch only requested V1 datasets
- reuse the existing sharded WebDataset mirror and expected `classification_v1.0_wds` layout
- preserve the full legacy HDF5 download when `--datasets` is omitted
- document the new CLI path and add focused CLI/download tests

Fixes #167

## Validation
- `python -m pytest tests/test_download.py tests/test_cli.py -q` (11 passed)
- `ruff check src/torchgeo_bench/download.py src/torchgeo_bench/cli.py tests/test_download.py tests/test_cli.py`
- `ruff format --check src/torchgeo_bench/download.py src/torchgeo_bench/cli.py tests/test_download.py tests/test_cli.py`
- `git diff --check`