### PR TITLE
Add train budget functionality

### DIFF
--- a/src/torchgeo_bench/conf/config.yaml
+++ b/src/torchgeo_bench/conf/config.yaml
@@ -42,7 +42,18 @@ eval:
   bootstrap: 200          # number of bootstrap resamples
   c_range: [-6, 4, 40]      # log10 [start, stop, num_points]; per-model overrides allowed
   merge_val: true          # merge train+val for final logistic training
+                           # NOTE: ignored by the label-budget linear path below —
+                           # every fraction (including 1.0) is fit train-only so the
+                           # data-scaling curve is internally consistent. Linear rows
+                           # therefore record merge_val=false.
   skip_linear: false       # if true, skip LogisticRegression evaluation
+
+  # Label-budget axis (data-scaling curves). The linear probe is refit on
+  # stratified, nested, floor-1-per-class subsets of the cached train (and val)
+  # embeddings at each fraction; test stays full. Defaults reproduce today's
+  # single full-data point exactly.
+  label_fractions: [1.0]    # e.g. [0.01, 0.05, 0.1, 0.25, 1.0]
+  n_subsample_repeats: 1    # independent nested draws per f<1.0 (seed = cfg.seed + i)
   knn_k: 5                 # number of neighbours for KNN evaluation
   knn_device: null         # null = inherit device, falling back to CPU if FAISS lacks GPU support
 

--- a/src/torchgeo_bench/datasets/loading.py
+++ b/src/torchgeo_bench/datasets/loading.py
@@ -231,8 +231,13 @@ def get_datasets(
     val_ds = bench.get_dataset("val", partition="default", **common)
     test_ds = bench.get_dataset("test", partition="default", **common)
 
+    # Train loader is consumed only for frozen-backbone feature extraction, so
+    # it iterates in fixed dataset order (shuffle=False). This makes positional
+    # indices into the cached ``x_train`` deterministic and identical across
+    # models, which the label-budget subsampling relies on. Result-neutral for
+    # the full-data probe (order-invariant full-batch LBFGS).
     train_loader = _make_loader(
-        train_ds, batch_size=batch_size, shuffle=True, num_workers=num_workers
+        train_ds, batch_size=batch_size, shuffle=False, num_workers=num_workers
     )
     val_loader = _make_loader(val_ds, batch_size=batch_size, shuffle=False, num_workers=num_workers)
     test_loader = _make_loader(

--- a/src/torchgeo_bench/main.py
+++ b/src/torchgeo_bench/main.py
@@ -40,7 +40,7 @@ from torchgeo_bench.segmentation_probe import (
 )
 from torchgeo_bench.segmentation_task import SegmentationSolver, SegMetrics
 from torchgeo_bench.segmentation_viz import save_segmentation_viz
-from torchgeo_bench.utils import extract_features
+from torchgeo_bench.utils import extract_features, stratified_subsample_indices
 
 logger = logging.getLogger(__name__)
 
@@ -159,6 +159,51 @@ def _filter_completed_metric_rows(
     return filtered
 
 
+# Resume-key columns. ``train_fraction`` and ``subsample_seed`` carry the
+# label-budget axis; legacy rows lacking them normalize to the full-data point
+# (see ``_normalize_resume_fraction_columns``). ``seed`` is intentionally absent.
+_RESUME_KEY_COLS = (
+    "dataset",
+    "method",
+    "model",
+    "name",
+    "normalization",
+    "image_size",
+    "interpolation",
+    "partition",
+    "bands",
+    "train_fraction",
+    "subsample_seed",
+)
+
+
+def _normalize_resume_fraction_columns(df: pd.DataFrame, base_seed: int) -> pd.DataFrame:
+    """Backfill the label-budget key columns for legacy/partial result rows.
+
+    A pre-existing ``method="linear"`` row predates the label-budget axis, so it
+    has no ``train_fraction``/``subsample_seed`` columns (or empty cells). Such a
+    row is the full-data, base-seed point: ``train_fraction`` normalizes to
+    ``1.0`` and ``subsample_seed`` to ``base_seed`` so it matches a fresh
+    ``f=1.0`` resume key and is never recomputed.
+
+    Args:
+        df: The results DataFrame read back for resume.
+        base_seed: The run's ``cfg.seed``, used as the legacy subsample seed.
+
+    Returns:
+        A copy of ``df`` with both columns present and filled.
+    """
+    df = df.copy()
+    for col, default in (("train_fraction", 1.0), ("subsample_seed", base_seed)):
+        if col not in df.columns:
+            df[col] = default
+            continue
+        values = df[col]
+        is_empty = values.isna() | (values.astype(str).str.strip() == "")
+        df[col] = np.where(is_empty.to_numpy(), default, values.to_numpy())
+    return df
+
+
 def _profile_metric_names(profile_cfg: DictConfig | None) -> list[str]:
     """Return the required profile metrics for resume completeness checks."""
     names = [
@@ -266,6 +311,16 @@ class EvaluationResult:
     mce_ts: float | None = None
     temperature: float | None = None
     calibration_n_bins: int | None = None
+    # Label-budget axis (data-scaling curves). Defaults reproduce the full-data
+    # probe exactly: ``train_fraction=1.0`` and ``subsample_seed`` falling back
+    # to the row's ``seed``. ``n_train`` records the actual post-subsample count.
+    train_fraction: float = 1.0
+    subsample_seed: int | None = None
+
+    def __post_init__(self) -> None:
+        """Default ``subsample_seed`` to the run ``seed`` when unspecified."""
+        if self.subsample_seed is None:
+            self.subsample_seed = self.seed
 
     def to_row(self) -> dict:
         """Convert to a flat dictionary suitable for CSV/DataFrame export."""
@@ -284,6 +339,29 @@ class DatasetRunPlan:
     skip_linear: bool
     skip_id: bool
     skip_profile: bool
+    # Linear-probe (fraction, subsample_seed) pairs still to run for this
+    # dataset. Empty when the linear probe is skipped or every requested pair is
+    # already present in the results CSV.
+    linear_pairs_to_run: tuple[tuple[float, int], ...] = ()
+
+
+def _expand_fraction_seed_pairs(
+    label_fractions: Sequence[float], n_subsample_repeats: int, base_seed: int
+) -> list[tuple[float, int]]:
+    """Expand the label-budget config into concrete ``(fraction, seed)`` pairs.
+
+    ``f == 1.0`` is the full-data point: a single entry at ``base_seed``
+    regardless of ``n_subsample_repeats``. Each ``f < 1.0`` expands to
+    ``n_subsample_repeats`` independent nested draws seeded ``base_seed + i``.
+    """
+    pairs: list[tuple[float, int]] = []
+    for raw in label_fractions:
+        fraction = float(raw)
+        if fraction == 1.0:
+            pairs.append((1.0, int(base_seed)))
+        else:
+            pairs.extend((fraction, int(base_seed) + i) for i in range(int(n_subsample_repeats)))
+    return pairs
 
 
 def _plan_dataset_run(
@@ -313,12 +391,37 @@ def _plan_dataset_run(
         )
 
     knn_key = (ds_name, f"knn{knn_k}", *model_key)
-    linear_key = (ds_name, "linear", *model_key)
     id_key = (ds_name, "intrinsic_dim", *model_key)
     profile_key = (ds_name, "profile", *model_key)
 
     skip_knn = bool(cfg.resume and knn_key in completed_runs)
-    skip_linear = bool((cfg.resume and linear_key in completed_runs) or cfg.eval.skip_linear)
+
+    # The linear probe is swept over label-budget (fraction, subsample_seed)
+    # pairs. Its per-pair resume key reuses the shared config cells but replaces
+    # the base (train_fraction, subsample_seed) tail with the pair's own values.
+    base_model_key = (cfg.model._target_, cfg.model.name, *config_tuple[:-2])
+    requested_pairs = _expand_fraction_seed_pairs(
+        cfg.eval.label_fractions, cfg.eval.n_subsample_repeats, cfg.seed
+    )
+
+    def _linear_key(fraction: float, subsample_seed: int) -> tuple[str, ...]:
+        return (
+            ds_name,
+            "linear",
+            *base_model_key,
+            _canonical_key_cell(fraction),
+            _canonical_key_cell(subsample_seed),
+        )
+
+    if cfg.eval.skip_linear:
+        linear_pairs_to_run: list[tuple[float, int]] = []
+    elif cfg.resume:
+        linear_pairs_to_run = [
+            (f, s) for (f, s) in requested_pairs if _linear_key(f, s) not in completed_runs
+        ]
+    else:
+        linear_pairs_to_run = list(requested_pairs)
+    skip_linear = len(linear_pairs_to_run) == 0
 
     id_cfg = getattr(cfg.eval, "intrinsic_dim", None)
     id_enabled = bool(id_cfg and id_cfg.get("enabled", False))
@@ -353,6 +456,7 @@ def _plan_dataset_run(
         skip_linear=skip_linear,
         skip_id=skip_id,
         skip_profile=skip_profile,
+        linear_pairs_to_run=tuple(linear_pairs_to_run),
     )
 
 
@@ -569,6 +673,87 @@ def evaluate_logistic(
                 f"MCE={calibration_ts['mce_ts']:.4f}"
             )
     return metric, lo, hi, float(best_c), calibration, calibration_ts
+
+
+def _run_linear_fractions(
+    *,
+    pairs: Sequence[tuple[float, int]],
+    x_train: np.ndarray,
+    y_train: np.ndarray,
+    x_val: np.ndarray,
+    y_val: np.ndarray,
+    x_test: np.ndarray,
+    y_test: np.ndarray,
+    c_values: Sequence[float],
+    common_meta: dict,
+    metric_name: str,
+    feature_dim: int,
+    seed: int,
+    n_bootstrap: int,
+    device: str,
+    verbose: bool,
+    calibration_n_bins: int,
+    temp_scale: bool,
+) -> list[dict]:
+    """Fit the linear probe over label-budget ``(fraction, subsample_seed)`` pairs.
+
+    Train and val are subsampled by the *same* nested stratified draw at each
+    fraction (test stays full), the fit is forced train-only (``merge_val=False``)
+    so hyperparameter selection also degrades under scarcity, and one linear row
+    per pair is emitted carrying ``train_fraction``, ``subsample_seed``, and the
+    actual post-subsample ``n_train``.
+    """
+    # The final probe never merges a full val set into a tiny train subset in
+    # this mode; record that on the row rather than the config value.
+    meta = {**common_meta, "merge_val": False}
+    rows: list[dict] = []
+    for fraction, subsample_seed in pairs:
+        train_idx = stratified_subsample_indices(y_train, fraction, subsample_seed)
+        val_idx = stratified_subsample_indices(y_val, fraction, subsample_seed)
+        lin_score, lin_lo, lin_hi, best_c, lin_cal, lin_cal_ts = evaluate_logistic(
+            x_train[train_idx],
+            y_train[train_idx],
+            x_val[val_idx],
+            y_val[val_idx],
+            x_test,
+            y_test,
+            c_values,
+            seed,
+            n_bootstrap,
+            merge_val=False,
+            device=device,
+            verbose=verbose,
+            calibration_n_bins=calibration_n_bins,
+            temp_scale=temp_scale,
+        )
+        rows.append(
+            EvaluationResult(
+                **meta,
+                method="linear",
+                metric_name=metric_name,
+                metric_value=lin_score,
+                ci_lower=lin_lo,
+                ci_upper=lin_hi,
+                feature_dim=feature_dim,
+                best_c=best_c,
+                best_lr=None,
+                best_batch_size=None,
+                n_train=len(train_idx),
+                n_val=len(val_idx),
+                n_test=len(x_test),
+                ece=lin_cal["ece"],
+                rms_ce=lin_cal["rms_ce"],
+                mce=lin_cal["mce"],
+                ece_ts=lin_cal_ts["ece_ts"],
+                rms_ce_ts=lin_cal_ts["rms_ce_ts"],
+                mce_ts=lin_cal_ts["mce_ts"],
+                temperature=lin_cal_ts["temperature"],
+                calibration_n_bins=calibration_n_bins,
+                train_fraction=fraction,
+                subsample_seed=subsample_seed,
+            ).to_row()
+        )
+    return rows
 
 
 def _make_seg_dataloaders(
@@ -1024,21 +1209,14 @@ def main(cfg: DictConfig) -> None:
     c_values = 10 ** np.linspace(float(c_start), float(c_stop), int(c_num))
     c_values_list = [float(v) for v in c_values.tolist()]
 
-    key_cols = (
-        "dataset",
-        "method",
-        "model",
-        "name",
-        "normalization",
-        "image_size",
-        "interpolation",
-        "partition",
-        "bands",
-    )
+    key_cols = _RESUME_KEY_COLS
     completed_runs: set[tuple[str, ...]] = set()
     completed_metrics: dict[str, set[tuple[str, ...]]] = {}
     if cfg.resume and os.path.exists(output_path):
         existing_df = pd.read_csv(cfg.output)
+        # Legacy rows predate the label-budget axis; treat them as the
+        # full-data, base-seed point so they are recognized and not recomputed.
+        existing_df = _normalize_resume_fraction_columns(existing_df, cfg.seed)
         for col in key_cols:
             if col not in existing_df.columns:
                 existing_df[col] = ""
@@ -1083,6 +1261,11 @@ def main(cfg: DictConfig) -> None:
                 getattr(cfg.dataset, "interpolation", "bilinear"),
                 cfg.dataset.partition,
                 bands_value,
+                # Base label-budget key cells shared by knn/id/profile (and the
+                # default full-data linear point). Per-pair linear keys override
+                # these two cells in ``_plan_dataset_run``.
+                1.0,
+                cfg.seed,
             )
         )
         eval_cfg_merged = OmegaConf.merge(cfg.eval, model_eval or {})
@@ -1297,46 +1480,29 @@ def main(cfg: DictConfig) -> None:
                 )
 
             if not plan.skip_linear:
-                lin_score, lin_lo, lin_hi, best_c, lin_cal, lin_cal_ts = evaluate_logistic(
-                    x_train,
-                    y_train,
-                    x_val,
-                    y_val,
-                    x_test,
-                    y_test,
-                    c_values_list,
-                    cfg.seed,
-                    cfg.eval.bootstrap,
-                    cfg.eval.merge_val,
-                    cfg.device,
-                    cfg.verbose,
-                    calibration_n_bins=cal_n_bins_linear,
-                    temp_scale=cal_temp_scale,
-                )
-                all_rows.append(
-                    EvaluationResult(
-                        **common_meta,
-                        method="linear",
+                # Sweep the linear probe over label-budget (fraction, seed) pairs.
+                # knn/intrinsic_dim/profile stay outside this loop and run once at
+                # full data, since they characterize the embedding, not the labels.
+                all_rows.extend(
+                    _run_linear_fractions(
+                        pairs=plan.linear_pairs_to_run,
+                        x_train=x_train,
+                        y_train=y_train,
+                        x_val=x_val,
+                        y_val=y_val,
+                        x_test=x_test,
+                        y_test=y_test,
+                        c_values=c_values_list,
+                        common_meta=common_meta,
                         metric_name=metric_name,
-                        metric_value=lin_score,
-                        ci_lower=lin_lo,
-                        ci_upper=lin_hi,
                         feature_dim=feature_dim,
-                        best_c=best_c,
-                        best_lr=None,
-                        best_batch_size=None,
-                        n_train=len(x_train),
-                        n_val=len(x_val),
-                        n_test=len(x_test),
-                        ece=lin_cal["ece"],
-                        rms_ce=lin_cal["rms_ce"],
-                        mce=lin_cal["mce"],
-                        ece_ts=lin_cal_ts["ece_ts"],
-                        rms_ce_ts=lin_cal_ts["rms_ce_ts"],
-                        mce_ts=lin_cal_ts["mce_ts"],
-                        temperature=lin_cal_ts["temperature"],
+                        seed=cfg.seed,
+                        n_bootstrap=cfg.eval.bootstrap,
+                        device=cfg.device,
+                        verbose=cfg.verbose,
                         calibration_n_bins=cal_n_bins_linear,
-                    ).to_row()
+                        temp_scale=cal_temp_scale,
+                    )
                 )
             if not plan.skip_id:
                 id_cfg = cfg.eval.intrinsic_dim

--- a/src/torchgeo_bench/utils.py
+++ b/src/torchgeo_bench/utils.py
@@ -76,3 +76,49 @@ def extract_features(
     y_all = np.concatenate(y_all, axis=0)
 
     return x_all, y_all
+
+
+def stratified_subsample_indices(
+    y: np.ndarray,
+    fraction: float,
+    seed: int,
+    min_per_class: int = 1,
+) -> np.ndarray:
+    """Return sorted positions of a stratified, nested subsample of ``y``.
+
+    For each class, one permutation of that class's positions is drawn from an
+    RNG seeded only by ``seed`` (never by the model or the fraction), and the
+    first ``min(n_c, max(min_per_class, round(fraction * n_c)))`` positions are
+    kept. Because every fraction reads a prefix of the same per-class
+    permutation, subsamples are automatically **nested**
+    (``f=0.05 ⊂ f=0.1 ⊂ … ⊂ f=1.0``) and **identical across models**. The
+    floor guarantees every class survives at every fraction.
+
+    Args:
+        y: 1D integer label array in fixed dataset order.
+        fraction: Label budget in ``(0, 1]``.
+        seed: Per-repeat seed (e.g. ``cfg.seed + repeat_index``).
+        min_per_class: Minimum kept examples per class.
+
+    Returns:
+        A sorted 1D ``int64`` array of positions into ``y``.
+
+    Raises:
+        ValueError: If ``fraction`` is outside ``(0, 1]``.
+    """
+    if not 0.0 < fraction <= 1.0:
+        raise ValueError(f"fraction must be in (0, 1], got {fraction}.")
+    n = len(y)
+    if fraction == 1.0:
+        return np.arange(n, dtype=np.int64)
+
+    y = np.asarray(y)
+    rng = np.random.default_rng(seed)
+    selected: list[np.ndarray] = []
+    for cls in np.unique(y):
+        positions = np.flatnonzero(y == cls)
+        n_c = len(positions)
+        keep = min(n_c, max(min_per_class, round(fraction * n_c)))
+        perm = rng.permutation(positions)
+        selected.append(perm[:keep])
+    return np.sort(np.concatenate(selected)).astype(np.int64)

--- a/tests/test_geobench_dataset.py
+++ b/tests/test_geobench_dataset.py
@@ -10,10 +10,11 @@ methods. They access band data via the per-dataset wrapper's
 
 import pytest
 import torch
-from torch.utils.data import DataLoader
+from torch.utils.data import DataLoader, Dataset, RandomSampler, SequentialSampler
 
 from torchgeo_bench.datasets import get_bench_dataset_class
 from torchgeo_bench.datasets.geobench_v1 import GeoBenchv1
+from torchgeo_bench.datasets.loading import get_datasets
 
 # Source names recognized by m-eurosat HDF5 files (used by tests that need to
 # bypass the wrapper and instantiate ``GeoBenchv1`` directly).
@@ -275,3 +276,53 @@ class TestErrorHandling:
         bench = get_bench_dataset_class("m-eurosat")()
         with pytest.raises(ValueError, match="unknown band"):
             bench.get_dataset("train", partition=small_partition, bands=("nonexistent_band",))
+
+
+class _FixedOrderDataset(Dataset):
+    """Tiny synthetic classification dataset whose label equals its index."""
+
+    def __init__(self, n: int = 12) -> None:
+        self._n = n
+
+    def __len__(self) -> int:
+        return self._n
+
+    def __getitem__(self, idx: int) -> dict[str, torch.Tensor]:
+        return {"image": torch.zeros(3, 4, 4), "label": torch.tensor(idx)}
+
+
+class _FakeBench:
+    """Fake BenchDataset stand-in for exercising ``get_datasets`` without data."""
+
+    supports_partitions = False
+    rgb_bands = ("red", "green", "blue")
+
+    def get_dataset(self, split, partition, bands, transform):
+        del split, partition, bands, transform
+        return _FixedOrderDataset()
+
+
+def test_train_loader_fixed_order_for_embedding(monkeypatch):
+    """The embedding train loader must iterate in stable, non-shuffled order."""
+    monkeypatch.setattr(
+        "torchgeo_bench.datasets.loading.get_bench_dataset_class",
+        lambda name: _FakeBench,
+    )
+    result = get_datasets(dataset_name="fake", return_val=True, num_workers=0, batch_size=4)
+    train_ds, train_loader, val_loader, test_loader = result
+
+    # Train loader used for embedding is sequential, not random.
+    assert isinstance(train_loader.sampler, SequentialSampler)
+    assert not isinstance(train_loader.sampler, RandomSampler)
+    # Val/test loaders remain sequential (unchanged behavior).
+    assert isinstance(val_loader.sampler, SequentialSampler)
+    assert isinstance(test_loader.sampler, SequentialSampler)
+
+    def _labels() -> list[int]:
+        return [int(v) for batch in train_loader for v in batch["label"].tolist()]
+
+    assert _labels() == _labels() == list(range(12))
+
+    # Tuple shape unchanged: return_val=False yields a 3-tuple.
+    three = get_datasets(dataset_name="fake", num_workers=0, batch_size=4)
+    assert len(three) == 3

--- a/tests/test_main_fast.py
+++ b/tests/test_main_fast.py
@@ -361,7 +361,10 @@ def test_model_eval_overrides_do_not_change_classification_resume_semantics(tmp_
 
     linear_call = linear_mock.call_args
     assert linear_call.args[8] == cfg.eval.bootstrap
-    assert linear_call.args[9] is cfg.eval.merge_val
+    # The label-budget linear path always fits train-only, so merge_val is a
+    # forced keyword False regardless of config or the +model.eval.merge_val
+    # override — which confirms the override does not leak into the probe fit.
+    assert linear_call.kwargs["merge_val"] is False
     assert linear_call.kwargs["calibration_n_bins"] == cfg.eval.calibration.n_bins_linear
 
     df = pd.read_csv(out)

--- a/tests/test_main_utils.py
+++ b/tests/test_main_utils.py
@@ -1,22 +1,193 @@
 """Unit tests for utility helpers in ``torchgeo_bench.main``."""
 
+from pathlib import Path
 from unittest import mock
 
+import numpy as np
 import pandas as pd
 import pytest
 import torch
 from omegaconf import OmegaConf
 from torch.utils.data import DataLoader, Dataset
 
+import torchgeo_bench
 from torchgeo_bench.main import (
+    _RESUME_KEY_COLS,
+    EvaluationResult,
     _build_seg_probe_and_solver,
+    _canonical_key_cell,
     _completed_run_keys,
     _expand_dataset_list,
     _filter_completed_metric_rows,
     _measure_cpu_throughput,
     _normalize_bands_value,
+    _normalize_resume_fraction_columns,
+    _plan_dataset_run,
+    _row_key,
+    _run_linear_fractions,
     evaluate_profile,
 )
+from torchgeo_bench.utils import stratified_subsample_indices
+
+
+def _cached(n: int, d: int = 8, n_classes: int = 3, seed: int = 0):
+    """Synthetic cached embedding/label matrices with every class present."""
+    rng = np.random.default_rng(seed)
+    x = rng.standard_normal((n, d)).astype(np.float32)
+    # Guarantee each class appears at least once, then fill randomly.
+    y = np.concatenate(
+        [np.arange(n_classes), rng.integers(0, n_classes, size=n - n_classes)]
+    ).astype(np.int64)
+    return x, y
+
+
+def _fraction_common_meta() -> dict:
+    return {
+        "dataset": "m-eurosat",
+        "seed": 0,
+        "model": "mock.Model",
+        "name": "mock",
+        "normalization": "identity",
+        "image_size": 8,
+        "interpolation": "bilinear",
+        "partition": "default",
+        "bands": "rgb",
+        "c_range_start": -2,
+        "c_range_stop": 2,
+        "c_range_num": 3,
+        "merge_val": True,
+        "bootstrap": 10,
+    }
+
+
+def _fake_logistic(*args, **kwargs):
+    cal = {"ece": 0.1, "rms_ce": 0.1, "mce": 0.2}
+    cal_ts = {"ece_ts": 0.05, "rms_ce_ts": 0.05, "mce_ts": 0.1, "temperature": 1.2}
+    return 0.9, 0.85, 0.95, 1.0, cal, cal_ts
+
+
+def _call_run_linear_fractions(pairs, x_train, y_train, x_val, y_val, x_test, y_test):
+    return _run_linear_fractions(
+        pairs=pairs,
+        x_train=x_train,
+        y_train=y_train,
+        x_val=x_val,
+        y_val=y_val,
+        x_test=x_test,
+        y_test=y_test,
+        c_values=[0.1, 1.0, 10.0],
+        common_meta=_fraction_common_meta(),
+        metric_name="accuracy",
+        feature_dim=x_train.shape[1],
+        seed=0,
+        n_bootstrap=10,
+        device="cpu",
+        verbose=False,
+        calibration_n_bins=15,
+        temp_scale=True,
+    )
+
+
+class _FakeClsDataset:
+    """Minimal single-label classification dataset class for planning tests."""
+
+    task = "classification"
+    multilabel = False
+    num_classes = 5
+
+
+def _plan_config(
+    label_fractions, n_subsample_repeats, *, seed=0, resume=False, skip_linear=False
+) -> OmegaConf:
+    return OmegaConf.create(
+        {
+            "seed": seed,
+            "resume": resume,
+            "model": {"_target_": "mock.Model", "name": "mock"},
+            "eval": {
+                "skip_linear": skip_linear,
+                "knn_k": 5,
+                "label_fractions": list(label_fractions),
+                "n_subsample_repeats": n_subsample_repeats,
+                "segmentation": {"head_type": "fpn"},
+            },
+        }
+    )
+
+
+def _plan_config_tuple(seed=0) -> tuple[str, ...]:
+    """Config tuple as assembled in ``main()`` (base 1.0/seed cells appended)."""
+    return tuple(
+        _canonical_key_cell(v) for v in ("identity", 8, "bilinear", "default", "rgb", 1.0, seed)
+    )
+
+
+def _plan_linear_key(ds, fraction, subsample_seed, *, cfg_seed=0) -> tuple[str, ...]:
+    ct = _plan_config_tuple(cfg_seed)
+    base = ("mock.Model", "mock", *ct[:-2])
+    return (
+        ds,
+        "linear",
+        *base,
+        _canonical_key_cell(fraction),
+        _canonical_key_cell(subsample_seed),
+    )
+
+
+def _plan_knn_key(ds, *, cfg_seed=0) -> tuple[str, ...]:
+    ct = _plan_config_tuple(cfg_seed)
+    return (ds, "knn5", "mock.Model", "mock", *ct)
+
+
+def _linear_row(**overrides) -> dict:
+    """A minimal resume-key-bearing linear result row."""
+    row = {
+        "dataset": "m-eurosat",
+        "method": "linear",
+        "model": "mock.Model",
+        "name": "mock",
+        "normalization": "identity",
+        "image_size": 8,
+        "interpolation": "bilinear",
+        "partition": "default",
+        "bands": "rgb",
+    }
+    row.update(overrides)
+    return row
+
+
+def _min_result(**overrides) -> EvaluationResult:
+    """Build an EvaluationResult with all required fields, overriding as needed."""
+    kwargs = {
+        "dataset": "m-eurosat",
+        "method": "linear",
+        "metric_name": "accuracy",
+        "metric_value": 0.9,
+        "ci_lower": 0.85,
+        "ci_upper": 0.95,
+        "feature_dim": 8,
+        "best_c": 1.0,
+        "best_lr": None,
+        "best_batch_size": None,
+        "n_train": 100,
+        "n_val": 20,
+        "n_test": 30,
+        "seed": 0,
+        "model": "mock.Model",
+        "name": "mock",
+        "normalization": "identity",
+        "image_size": 8,
+        "interpolation": "bilinear",
+        "partition": "default",
+        "bands": "rgb",
+        "c_range_start": -2,
+        "c_range_stop": 2,
+        "c_range_num": 3,
+        "merge_val": False,
+        "bootstrap": 10,
+    }
+    kwargs.update(overrides)
+    return EvaluationResult(**kwargs)
 
 
 class _ImageOnlyDataset(Dataset):
@@ -26,6 +197,193 @@ class _ImageOnlyDataset(Dataset):
     def __getitem__(self, idx: int) -> dict[str, torch.Tensor]:
         del idx
         return {"image": torch.ones(3, 8, 8)}
+
+
+def test_evaluation_result_row_has_fraction_columns() -> None:
+    row = _min_result(train_fraction=0.1, subsample_seed=7, n_train=13).to_row()
+    assert row["train_fraction"] == 0.1
+    assert row["subsample_seed"] == 7
+    assert row["n_train"] == 13
+
+
+def test_evaluation_result_fraction_defaults() -> None:
+    r = _min_result(seed=42)
+    assert r.train_fraction == 1.0
+    assert r.subsample_seed == 42  # defaults to the row's seed
+    row = r.to_row()
+    assert row["train_fraction"] == 1.0
+    assert row["subsample_seed"] == 42
+
+
+def test_config_defaults_label_fractions() -> None:
+    cfg_path = Path(torchgeo_bench.__file__).parent / "conf" / "config.yaml"
+    cfg = OmegaConf.load(cfg_path)
+    assert list(cfg.eval.label_fractions) == [1.0]
+    assert cfg.eval.n_subsample_repeats == 1
+
+
+def test_legacy_linear_row_canonicalizes_to_full_fraction() -> None:
+    # A legacy CSV with no train_fraction / subsample_seed columns at all.
+    legacy = pd.DataFrame([_linear_row()])
+    legacy = _normalize_resume_fraction_columns(legacy, base_seed=0)
+    completed = _completed_run_keys(legacy, _RESUME_KEY_COLS)
+    fresh_key = _row_key(_linear_row(train_fraction=1.0, subsample_seed=0), _RESUME_KEY_COLS)
+    assert fresh_key in completed  # legacy row is recognized -> skipped on resume
+
+
+def test_legacy_empty_cells_canonicalize_to_full_fraction() -> None:
+    # Columns present but with empty/NaN cells (partial CSV).
+    legacy = pd.DataFrame([_linear_row(train_fraction="", subsample_seed="")])
+    legacy = _normalize_resume_fraction_columns(legacy, base_seed=3)
+    completed = _completed_run_keys(legacy, _RESUME_KEY_COLS)
+    fresh_key = _row_key(_linear_row(train_fraction=1.0, subsample_seed=3), _RESUME_KEY_COLS)
+    assert fresh_key in completed
+
+
+def test_distinct_fractions_distinct_keys() -> None:
+    completed = _completed_run_keys(
+        pd.DataFrame([_linear_row(train_fraction=1.0, subsample_seed=0)]),
+        _RESUME_KEY_COLS,
+    )
+    key_01 = _row_key(_linear_row(train_fraction=0.1, subsample_seed=0), _RESUME_KEY_COLS)
+    assert key_01 not in completed
+
+
+def test_distinct_subsample_seeds_distinct_keys() -> None:
+    r0 = _row_key(_linear_row(train_fraction=0.1, subsample_seed=0), _RESUME_KEY_COLS)
+    r1 = _row_key(_linear_row(train_fraction=0.1, subsample_seed=1), _RESUME_KEY_COLS)
+    assert r0 != r1
+    completed = _completed_run_keys(
+        pd.DataFrame([_linear_row(train_fraction=0.1, subsample_seed=0)]),
+        _RESUME_KEY_COLS,
+    )
+    assert r0 in completed
+    assert r1 not in completed  # neither draw skips the other
+
+
+def test_canonical_fraction_string_form() -> None:
+    # Whole fractions/seeds collapse identically across config-side and CSV-side forms.
+    assert _canonical_key_cell(1.0) == _canonical_key_cell("1.0") == "1"
+    assert _canonical_key_cell(0) == _canonical_key_cell("0.0") == "0"
+    assert _canonical_key_cell(7) == _canonical_key_cell("7.0") == "7"
+    # Non-integer fractions pass through unchanged from both sides.
+    assert _canonical_key_cell(0.1) == _canonical_key_cell("0.1") == "0.1"
+    assert _canonical_key_cell(0.05) == _canonical_key_cell("0.05") == "0.05"
+
+
+def test_plan_expands_requested_fraction_seed_pairs() -> None:
+    cfg = _plan_config([0.01, 1.0], n_subsample_repeats=2, seed=0)
+    plan = _plan_dataset_run(
+        cfg=cfg,
+        ds_name="m-eurosat",
+        ds_cls=_FakeClsDataset,
+        knn_k=5,
+        seg_method="seg-fpn",
+        config_tuple=_plan_config_tuple(0),
+        completed_runs=set(),
+        completed_metrics={},
+    )
+    assert set(plan.linear_pairs_to_run) == {(0.01, 0), (0.01, 1), (1.0, 0)}
+
+
+def test_plan_skip_dataset_only_when_all_pairs_present() -> None:
+    cfg = _plan_config([0.01, 1.0], n_subsample_repeats=2, seed=0, resume=True)
+    all_linear = {
+        _plan_linear_key("m-eurosat", f, s) for (f, s) in [(0.01, 0), (0.01, 1), (1.0, 0)]
+    }
+    completed = all_linear | {_plan_knn_key("m-eurosat")}
+
+    def _plan(completed_runs):
+        return _plan_dataset_run(
+            cfg=cfg,
+            ds_name="m-eurosat",
+            ds_cls=_FakeClsDataset,
+            knn_k=5,
+            seg_method="seg-fpn",
+            config_tuple=_plan_config_tuple(0),
+            completed_runs=completed_runs,
+            completed_metrics={},
+        )
+
+    # All linear pairs + knn present (id/profile disabled) -> whole dataset skipped.
+    assert _plan(completed).skip_dataset is True
+
+    # Drop one low-fraction pair -> dataset stays scheduled.
+    missing_one = completed - {_plan_linear_key("m-eurosat", 0.01, 1)}
+    plan = _plan(missing_one)
+    assert plan.skip_dataset is False
+    assert (0.01, 1) in plan.linear_pairs_to_run
+
+
+def test_plan_linear_pairs_filtered_by_resume() -> None:
+    cfg = _plan_config([0.01], n_subsample_repeats=2, seed=0, resume=True)
+    completed = {_plan_linear_key("m-eurosat", 0.01, 0)}
+    plan = _plan_dataset_run(
+        cfg=cfg,
+        ds_name="m-eurosat",
+        ds_cls=_FakeClsDataset,
+        knn_k=5,
+        seg_method="seg-fpn",
+        config_tuple=_plan_config_tuple(0),
+        completed_runs=completed,
+        completed_metrics={},
+    )
+    assert list(plan.linear_pairs_to_run) == [(0.01, 1)]
+
+
+def test_fraction_loop_emits_row_per_pair() -> None:
+    x_train, y_train = _cached(60, seed=0)
+    x_val, y_val = _cached(30, seed=1)
+    x_test, y_test = _cached(20, seed=2)
+    pairs = [(0.1, 0), (0.1, 1), (1.0, 0)]
+    with mock.patch("torchgeo_bench.main.evaluate_logistic", side_effect=_fake_logistic):
+        rows = _call_run_linear_fractions(pairs, x_train, y_train, x_val, y_val, x_test, y_test)
+    assert len(rows) == 3
+    for (f, s), row in zip(pairs, rows):
+        assert row["method"] == "linear"
+        assert row["train_fraction"] == f
+        assert row["subsample_seed"] == s
+        expected_n = len(stratified_subsample_indices(y_train, f, s))
+        assert row["n_train"] == expected_n
+
+
+def test_fraction_loop_forces_merge_val_false() -> None:
+    x_train, y_train = _cached(60, seed=0)
+    x_val, y_val = _cached(30, seed=1)
+    x_test, y_test = _cached(20, seed=2)
+    pairs = [(0.1, 0), (1.0, 0)]
+    with mock.patch("torchgeo_bench.main.evaluate_logistic", side_effect=_fake_logistic) as m:
+        _call_run_linear_fractions(pairs, x_train, y_train, x_val, y_val, x_test, y_test)
+    assert m.call_count == 2
+    for call in m.call_args_list:
+        assert call.kwargs["merge_val"] is False
+
+
+def test_fraction_loop_slices_val_too() -> None:
+    x_train, y_train = _cached(60, seed=0)
+    x_val, y_val = _cached(30, seed=1)
+    x_test, y_test = _cached(20, seed=2)
+    with mock.patch("torchgeo_bench.main.evaluate_logistic", side_effect=_fake_logistic) as m:
+        _call_run_linear_fractions([(0.1, 0)], x_train, y_train, x_val, y_val, x_test, y_test)
+    # evaluate_logistic(x_train, y_train, x_val, y_val, x_test, y_test, ...)
+    passed_x_val = m.call_args_list[0].args[2]
+    expected_val_idx = stratified_subsample_indices(y_val, 0.1, 0)
+    assert passed_x_val.shape[0] == len(expected_val_idx)
+    assert passed_x_val.shape[0] < len(x_val)  # val is actually subsampled
+
+
+def test_knn_id_profile_only_at_full_fraction() -> None:
+    # The linear-fraction loop emits ONLY linear rows; knn/id/profile are not
+    # swept per fraction (they run once, outside this helper).
+    x_train, y_train = _cached(60, seed=0)
+    x_val, y_val = _cached(30, seed=1)
+    x_test, y_test = _cached(20, seed=2)
+    pairs = [(0.1, 0), (0.1, 1), (1.0, 0)]
+    with mock.patch("torchgeo_bench.main.evaluate_logistic", side_effect=_fake_logistic):
+        rows = _call_run_linear_fractions(pairs, x_train, y_train, x_val, y_val, x_test, y_test)
+    methods = {row["method"] for row in rows}
+    assert methods == {"linear"}
+    assert not any(row["method"] in {"knn5", "intrinsic_dim", "profile"} for row in rows)
 
 
 def test_expand_dataset_list_all(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_subsample.py
+++ b/tests/test_subsample.py
@@ -1,0 +1,85 @@
+"""Tests for stratified_subsample_indices (utils.py) — the label-budget selector."""
+
+import numpy as np
+import pytest
+
+from torchgeo_bench.utils import stratified_subsample_indices
+
+FRACTIONS = [0.01, 0.05, 0.1, 0.25, 1.0]
+
+
+def _make_y(counts: dict[int, int]) -> np.ndarray:
+    """Build a fixed-order label vector with the given per-class counts."""
+    parts = [np.full(n, cls, dtype=np.int64) for cls, n in counts.items()]
+    return np.concatenate(parts)
+
+
+def test_stratification_per_class_counts():
+    counts = {0: 100, 1: 40, 2: 7}
+    y = _make_y(counts)
+    f = 0.1
+    idx = stratified_subsample_indices(y, f, seed=0)
+    assert idx.dtype == np.int64
+    assert np.array_equal(idx, np.sort(idx))
+    assert np.all(np.diff(idx) > 0)  # sorted and unique
+    sel = y[idx]
+    for cls, n in counts.items():
+        expected = min(n, max(1, round(f * n)))
+        assert (sel == cls).sum() == expected
+    assert set(np.unique(sel).tolist()) == set(counts)
+
+
+def test_tiny_class_floor():
+    # A class where f * n_c < 1 must still yield >= 1 example.
+    y = _make_y({0: 100, 1: 3})
+    idx = stratified_subsample_indices(y, 0.1, seed=0)
+    assert (y[idx] == 1).sum() >= 1
+
+    # A singleton class must appear at every fraction.
+    y_single = _make_y({0: 200, 1: 1})
+    for f in FRACTIONS:
+        idx_f = stratified_subsample_indices(y_single, f, seed=1)
+        assert (y_single[idx_f] == 1).sum() == 1
+
+
+def test_nesting():
+    y = _make_y({0: 100, 1: 40, 2: 7})
+    seed = 3
+    a = set(stratified_subsample_indices(y, 0.05, seed).tolist())
+    b = set(stratified_subsample_indices(y, 0.1, seed).tolist())
+    c = set(stratified_subsample_indices(y, 1.0, seed).tolist())
+    assert a < b < c  # proper nested subsets
+
+
+def test_determinism_and_model_independence():
+    y = _make_y({0: 50, 1: 30, 2: 20})
+    for f in (0.1, 0.25):
+        i1 = stratified_subsample_indices(y, f, seed=7)
+        i2 = stratified_subsample_indices(y, f, seed=7)
+        assert np.array_equal(i1, i2)
+
+
+def test_seed_changes_membership_not_sizes():
+    y = _make_y({0: 100, 1: 60})
+    f = 0.2
+    i1 = stratified_subsample_indices(y, f, seed=0)
+    i2 = stratified_subsample_indices(y, f, seed=1)
+    for cls in (0, 1):
+        assert (y[i1] == cls).sum() == (y[i2] == cls).sum()
+    assert not np.array_equal(i1, i2)
+
+
+def test_fraction_one_is_seed_independent():
+    y = _make_y({0: 10, 1: 5, 2: 3})
+    expected = np.arange(len(y))
+    for seed in (0, 1, 99):
+        idx = stratified_subsample_indices(y, 1.0, seed)
+        assert np.array_equal(idx, expected)
+        assert idx.dtype == np.int64
+
+
+def test_fraction_out_of_range_raises():
+    y = _make_y({0: 10, 1: 10})
+    for bad in (0.0, -0.1, 1.5, 2.0):
+        with pytest.raises(ValueError):
+            stratified_subsample_indices(y, bad, seed=0)


### PR DESCRIPTION
Closes #171 

Adds a label-budget axis to the frozen-backbone linear probe: the logistic probe is refit on stratified, nested, reproducible subsets of the cached training embeddings at fractions {0.01, 0.05, 0.1, 0.25, 1.0}, recording accuracy/calibration per fraction so backbones can be compared by their accuracy-vs-train_fraction curve rather than a single full-data point.


 - Subsampling is stratified, nested, and floor-1-per-class. Each class draws one seeded permutation
  of its positions; fraction f keeps the first min(n_c, max(1, round(f·n_c))). Prefixes of a shared
  per-class permutation are automatically stratified and nested (0.01 ⊂ 0.05 ⊂ … ⊂ 1.0); the floor
  guarantees every class survives at every fraction, so the probe is always a valid classifier over
  all classes.
  - Model-independent by construction. The subset is a pure function of (dataset order, fraction, 
  seed) with no model input. To make positional indices deterministic, the embedding train loader was
  flipped to shuffle=False. This is result-neutral for the existing full-data probe because the
  final fit is order-invariant full-batch L-BFGS.
  - Train and val are both subsampled; test is always full. C is selected on the f-scaled validation
  set, so hyperparameter selection honestly degrades under scarcity too. The fixed full test split
  keeps metrics comparable across fractions.
  - merge_val is disabled in this mode — at every fraction, including f=1.0. The label-budget path
  always fits train-only so the data-scaling curve is internally consistent end-to-end.  Behavioral
  change: the default probe previously merged train+val for the final full-data fit; a fresh default
  f=1.0 number is now train-only and may differ slightly from legacy merged numbers. Linear rows
  record merge_val=false.
  - Only the linear probe varies with fraction. knn5, intrinsic_dim, and profile characterize the
  embedding space, not the label budget, so they run once at full data.
  - Resume treats (train_fraction, subsample_seed) as part of the key, with legacy backfill.
  Pre-existing method="linear" rows lacking the new columns canonicalize to the 1.0/base-seed point,
  so they're recognized and never recomputed or overwritten. Skip decisions moved from
  once-per-dataset to per-(fraction, seed) pair, so a partial sweep resumes only the missing points.
  - Repeats for variance. n_subsample_repeats (default 1) controls independent nested draws per
  f<1.0, each seeded cfg.seed + i, emitting one row per draw. f=1.0 is special-cased to a single
  base-seed row regardless of repeats.
  - Defaults preserve current behavior exactly (structurally): label_fractions: [1.0],
  n_subsample_repeats: 1 → one linear row per (model, dataset), as before.
