### PR TITLE
fix(datasets): drop dead background class in SpaceNet2/SpaceNet7

### DIFF
--- a/docs/user/datasets.rst
+++ b/docs/user/datasets.rst
@@ -165,8 +165,8 @@ CLI name             #cls   bands notes                                        C
 ``fotw``             4      4     Fields of the World                          :class:`~torchgeo_bench.datasets.FieldsOfTheWorld`
 ``kuro_siwo``        4      3     SAR ``vv`` / ``vh`` + DEM (no RGB triplet)   :class:`~torchgeo_bench.datasets.KuroSiwo`
 ``pastis``           20     16    Sentinel-2 + Sentinel-1 (multi-modal)        :class:`~torchgeo_bench.datasets.PASTIS`
-``spacenet2``        3      9     WorldView 8-band + pan                       :class:`~torchgeo_bench.datasets.SpaceNet2`
-``spacenet7``        3      3                                                  :class:`~torchgeo_bench.datasets.SpaceNet7`
+``spacenet2``        2      9     WorldView 8-band + pan                       :class:`~torchgeo_bench.datasets.SpaceNet2`
+``spacenet7``        2      3                                                  :class:`~torchgeo_bench.datasets.SpaceNet7`
 ==================== ====== ===== ============================================ ==============================================================
 
 Other

--- a/src/torchgeo_bench/datasets/spacenet2.py
+++ b/src/torchgeo_bench/datasets/spacenet2.py
@@ -1,20 +1,35 @@
 """SpaceNet2 (GeoBench V2) benchmark dataset."""
 
+import torch
+
 from .base import BandSpec
 from .geobench_v2 import _V2Dataset
 
 
 class SpaceNet2(_V2Dataset):
-    """WorldView building footprint segmentation (3 classes).
+    """WorldView building footprint segmentation (2 classes).
 
     8 multispectral + 1 panchromatic band from WorldView satellite.
+
+    The task is natively 2-class ``{0: background/no-building, 1: building}``.
+    Upstream GeoBench applies ``mask = mask + 1`` (*"to have a true background
+    class"*), declaring 3 classes ``('background', 'no-building', 'building')``
+    and shipping masks valued ``{1, 2}`` — the added ``background`` class 0 never
+    actually occurs. That vestigial class 0 gave segmentation heads a
+    never-correct label to escape to on low-signal tiles (it dominated the
+    label-quality audit's "most suspect" ranking). We reverse the upstream
+    offset in :meth:`canonicalize_sample` (``mask - 1``), recovering the native
+    2-class labels ``{0: no-building, 1: building}``.
+
+    See https://github.com/The-AI-Alliance/GEO-Bench-2 (geobench_v2/datasets/
+    spacenet2.py: ``sample["mask"] = ... + 1``).
     """
 
     band_order_strategy = "by_sensor"
 
     name = "spacenet2"
     task = "segmentation"
-    num_classes = 3
+    num_classes = 2
     multilabel = False
     rgb_bands = ["red", "green", "blue"]
     split_sizes = {"train": 5186, "val": 1461, "test": 2961}
@@ -32,3 +47,20 @@ class SpaceNet2(_V2Dataset):
         BandSpec("pan", "pan", "pan", mean=469.092, std=266.975, min=0, max=2047),
     ]
     # fmt: on
+
+    def canonicalize_sample(self, sample: dict) -> dict:
+        """Reverse GeoBench's ``+1`` offset: mask ``1 -> 0``, ``2 -> 1``.
+
+        Upstream ships masks valued ``{1: no-building, 2: building}`` after
+        adding 1 to the native ``{0, 1}`` labels. Subtracting one recovers the
+        native 2-class labels and drops the never-used ``background`` (0). The
+        ``clamp(min=0)`` is defensive: if GeoBench ever emitted its reserved
+        class 0, it folds into ``no-building`` (the correct default for a pixel
+        with no building) rather than wrapping to ``-1``. Runs before any resize
+        transform; masks are integer class ids so the shift is exact.
+        """
+        mask = sample.get("mask")
+        if mask is not None:
+            mask = torch.as_tensor(mask)
+            sample["mask"] = (mask - 1).clamp_(min=0)
+        return sample

--- a/src/torchgeo_bench/datasets/spacenet7.py
+++ b/src/torchgeo_bench/datasets/spacenet7.py
@@ -1,18 +1,40 @@
 """SpaceNet7 (GeoBench V2) benchmark dataset."""
 
+import torch
+
 from .base import BandSpec
 from .geobench_v2 import _V2Dataset
 
 
 class SpaceNet7(_V2Dataset):
-    """Planet building change segmentation (3 classes).
+    """Planet building footprint segmentation (2 classes).
 
     RGB imagery from Planet satellites.
+
+    The task is natively 2-class ``{0: no-building, 1: building}``. Upstream
+    GeoBench applies ``mask = mask + 1`` (*"to have a true background class"*),
+    declaring 3 classes ``('background', 'no-building', 'building')`` and
+    shipping masks valued ``{1, 2}`` — the added ``background`` class 0 never
+    actually occurs. This is the same defect corrected in
+    :class:`~torchgeo_bench.datasets.spacenet2.SpaceNet2`: the vestigial class 0
+    gives segmentation heads a never-correct label to escape to on low-signal
+    tiles. We reverse the upstream offset in :meth:`canonicalize_sample`
+    (``mask - 1``), recovering the native 2-class labels.
+
+    Verified against the shipped tortilla: every mask in all three splits
+    (3500 train / 652 val / 1152 test) contains only raw values ``{0, 1}``.
+
+    Despite upstream's "multi-temporal" framing, the benchmark ships one image
+    and one mask per sample, so this is single-image segmentation rather than
+    change detection.
+
+    See https://github.com/The-AI-Alliance/GEO-Bench-2 (geobench_v2/datasets/
+    spacenet7.py: ``mask = torch.from_numpy(mask).long().squeeze(0) + 1``).
     """
 
     name = "spacenet7"
     task = "segmentation"
-    num_classes = 3
+    num_classes = 2
     multilabel = False
     rgb_bands = ["red", "green", "blue"]
     split_sizes = {"train": 3500, "val": 652, "test": 1152}
@@ -24,3 +46,20 @@ class SpaceNet7(_V2Dataset):
         BandSpec("planet", "blue", "blue", mean=77.561, std=46.01, min=0, max=255),
     ]
     # fmt: on
+
+    def canonicalize_sample(self, sample: dict) -> dict:
+        """Reverse GeoBench's ``+1`` offset: mask ``1 -> 0``, ``2 -> 1``.
+
+        Upstream ships masks valued ``{1: no-building, 2: building}`` after
+        adding 1 to the native ``{0, 1}`` labels. Subtracting one recovers the
+        native 2-class labels and drops the never-used ``background`` (0). The
+        ``clamp(min=0)`` is defensive: if GeoBench ever emitted its reserved
+        class 0, it folds into ``no-building`` (the correct default for a pixel
+        with no building) rather than wrapping to ``-1``. Runs before any resize
+        transform; masks are integer class ids so the shift is exact.
+        """
+        mask = sample.get("mask")
+        if mask is not None:
+            mask = torch.as_tensor(mask)
+            sample["mask"] = (mask - 1).clamp_(min=0)
+        return sample

--- a/tests/test_dataset_units.py
+++ b/tests/test_dataset_units.py
@@ -4,6 +4,8 @@ import torch
 
 from torchgeo_bench.datasets.eurosat import EuroSAT, EuroSATSpatial
 from torchgeo_bench.datasets.fotw import FieldsOfTheWorld as FOTW
+from torchgeo_bench.datasets.spacenet2 import SpaceNet2
+from torchgeo_bench.datasets.spacenet7 import SpaceNet7
 
 # ---------------------------------------------------------------------------
 # FOTW.canonicalize_sample
@@ -36,6 +38,70 @@ class TestFOTWCanonicalize:
         sample = {"image_b": img_b, "label": 2}
         result = ds.canonicalize_sample(sample)
         assert torch.equal(result["image"], img_b)
+
+
+# ---------------------------------------------------------------------------
+# SpaceNet2.canonicalize_sample — reverse GeoBench's +1 mask offset
+# ---------------------------------------------------------------------------
+
+
+class TestSpaceNet2Canonicalize:
+    def test_declares_two_classes(self):
+        """The dead background class is dropped: 2 classes, not GeoBench's 3."""
+        assert SpaceNet2.num_classes == 2
+
+    def test_mask_offset_reversed(self):
+        """Upstream ``{1: no-building, 2: building}`` maps to native ``{0, 1}``."""
+        ds = SpaceNet2.__new__(SpaceNet2)
+        mask = torch.tensor([[1, 2], [2, 1]])
+        result = ds.canonicalize_sample({"image": torch.zeros(3, 2, 2), "mask": mask})
+        assert torch.equal(result["mask"], torch.tensor([[0, 1], [1, 0]]))
+        assert int(result["mask"].max()) < SpaceNet2.num_classes
+
+    def test_reserved_zero_folds_into_no_building(self):
+        """A stray reserved class 0 clamps to 0 (no-building), never wraps to -1."""
+        ds = SpaceNet2.__new__(SpaceNet2)
+        mask = torch.tensor([[0, 1, 2]])
+        result = ds.canonicalize_sample({"image": torch.zeros(3, 1, 3), "mask": mask})
+        assert torch.equal(result["mask"], torch.tensor([[0, 0, 1]]))
+
+    def test_missing_mask_is_noop(self):
+        """No mask key (e.g. inference) leaves the sample untouched."""
+        ds = SpaceNet2.__new__(SpaceNet2)
+        sample = {"image": torch.zeros(3, 4, 4)}
+        assert ds.canonicalize_sample(sample) == sample
+
+
+# ---------------------------------------------------------------------------
+# SpaceNet7.canonicalize_sample — same +1 offset defect as SpaceNet2
+# ---------------------------------------------------------------------------
+
+
+class TestSpaceNet7Canonicalize:
+    def test_declares_two_classes(self):
+        """The dead background class is dropped: 2 classes, not GeoBench's 3."""
+        assert SpaceNet7.num_classes == 2
+
+    def test_mask_offset_reversed(self):
+        """Upstream ``{1: no-building, 2: building}`` maps to native ``{0, 1}``."""
+        ds = SpaceNet7.__new__(SpaceNet7)
+        mask = torch.tensor([[1, 2], [2, 1]])
+        result = ds.canonicalize_sample({"image": torch.zeros(3, 2, 2), "mask": mask})
+        assert torch.equal(result["mask"], torch.tensor([[0, 1], [1, 0]]))
+        assert int(result["mask"].max()) < SpaceNet7.num_classes
+
+    def test_reserved_zero_folds_into_no_building(self):
+        """A stray reserved class 0 clamps to 0 (no-building), never wraps to -1."""
+        ds = SpaceNet7.__new__(SpaceNet7)
+        mask = torch.tensor([[0, 1, 2]])
+        result = ds.canonicalize_sample({"image": torch.zeros(3, 1, 3), "mask": mask})
+        assert torch.equal(result["mask"], torch.tensor([[0, 0, 1]]))
+
+    def test_missing_mask_is_noop(self):
+        """No mask key (e.g. inference) leaves the sample untouched."""
+        ds = SpaceNet7.__new__(SpaceNet7)
+        sample = {"image": torch.zeros(3, 4, 4)}
+        assert ds.canonicalize_sample(sample) == sample
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Both datasets are natively 2-class building-footprint segmentation ({0: no-building, 1: building}), but upstream GeoBench applies `mask = mask + 1` ("to have a true background class"), declaring 3 classes ('background', 'no-building', 'building') and shipping masks valued {1, 2}. The added class 0 never actually occurs.

That vestigial class gives segmentation heads a never-correct label to escape to on low-signal tiles; on SpaceNet2 it dominated the label-quality audit's "most suspect" ranking, with the predicted class being the dead class 0.

Verified against the shipped tortillas: an exhaustive scan of all 5304 SpaceNet7 tiles (3500 train / 652 val / 1152 test) found only raw values {0, 1}, with zero tiles containing anything else. SpaceNet2 shows the same pattern.

Both datasets now declare num_classes = 2 and override canonicalize_sample to reverse the offset with (mask - 1).clamp(min=0). 

In the torchgeo main implementation https://github.com/torchgeo/torchgeo/blob/3209f08c3b59b150fcf62f66a20874de45d4c761/torchgeo/datamodules/spacenet.py#L84 there are still variable sized patches, but actually GeoBenchV2 datasets have been patched to common sizes already so this label trick is not necessary and this pure 2 class problem is cleaner