### PR TITLE
fix(seg): make DPTHead faithful to the reference DPT decoder

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,14 +14,14 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            extras: --extra dev --extra id --extra olmoearth
-            cache-tag: dev-id-olmoearth
+            extras: --extra dev --extra id --extra olmoearth --extra sam3
+            cache-tag: dev-id-olmoearth-sam3
           - os: macos-latest
-            extras: --extra dev
-            cache-tag: dev
+            extras: --extra dev --extra sam3
+            cache-tag: dev-sam3
           - os: windows-latest
-            extras: --extra dev
-            cache-tag: dev
+            extras: --extra dev --extra sam3
+            cache-tag: dev-sam3
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read

--- a/LICENSE-THIRDPARTY
+++ b/LICENSE-THIRDPARTY
@@ -33,36 +33,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
-================================================================================
-probe3d
---------------------------------------------------------------------------------
-Source:    https://github.com/mbanani/probe3d
-Used in:   src/torchgeo_bench/models/segmentation_heads.py (portions: the DPT
-           decoder heads ResidualConvUnit, FeatureFusionBlock, DPTHead)
-License:   MIT
-Note:      The DPT decoder architecture these classes implement originates
-           from https://github.com/isl-org/DPT, Copyright (c) 2021 Intel ISL
-           (Intel Intelligent Systems Lab), also MIT-licensed.
-
-MIT License
-
-Copyright (c) 2024 Mohamed El Banani
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -77,7 +77,7 @@ nitpick_ignore = [
     ("py:class", "GeoBenchv2"),
     ("py:class", "Single-label"),
     ("py:class", "auto_resize /"),
-    ("py:class", "FeatureFusionBlock"),
+    ("py:class", "DPTFeatureFusionLayer"),
     ("py:attr", "BenchModel.bands"),
     ("py:attr", "num_channels"),
     ("py:attr", "base.BenchDataset.supports_partitions"),

--- a/src/torchgeo_bench/models/segmentation_heads.py
+++ b/src/torchgeo_bench/models/segmentation_heads.py
@@ -1,6 +1,6 @@
-# The DPT decoder heads are adapted from probe3d (MIT); see LICENSE-THIRDPARTY.
-
 """Segmentation decoder heads for use with SegmentationProbe."""
+
+from types import SimpleNamespace
 
 import torch
 import torch.nn as nn
@@ -240,7 +240,12 @@ class FPNHead(nn.Module):
 
 
 # ---------------------------------------------------------------------------
-# DPT helper modules (adapted from probe3d — mbanani/probe3d)
+# DPT decoder
+#
+# The fusion cascade is the reference implementation from
+# ``transformers.models.dpt.modeling_dpt`` (Apache-2.0), itself a faithful port
+# of Intel-ISL DPT. It is imported rather than reimplemented so the residual
+# and upsampling arithmetic cannot silently drift from the paper.
 # ---------------------------------------------------------------------------
 
 
@@ -264,67 +269,63 @@ class ChannelLayerNorm(nn.Module):
         return self.norm(x.permute(0, 2, 3, 1)).permute(0, 3, 1, 2).contiguous()
 
 
-class ResidualConvUnit(nn.Module):
-    """Two conv+ReLU layers with a residual skip connection."""
+def _dpt_fusion_layer(hidden_dim: int) -> nn.Module:
+    """Construct a reference ``DPTFeatureFusionLayer`` at ``hidden_dim`` channels.
 
-    def __init__(self, features: int, kernel_size: int = 3) -> None:
-        super().__init__()
-        padding = kernel_size // 2
-        self.conv = nn.Sequential(
-            nn.Conv2d(features, features, kernel_size, padding=padding),
-            nn.ReLU(inplace=True),
-            nn.Conv2d(features, features, kernel_size, padding=padding),
-            nn.ReLU(inplace=True),
-        )
+    ``DPTFeatureFusionLayer`` and the ``DPTPreActResidualLayer`` s it owns are
+    plain ``nn.Module`` s that read exactly three scalars off ``config``; they
+    never touch the rest of ``DPTConfig``. A ``SimpleNamespace`` therefore lets
+    us reuse the reference implementation verbatim without pulling in
+    ``DPTConfig``, ``DPTNeck``, or the bundled ViT.
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """Apply residual conv block."""
-        return self.conv(x) + x
+    The two boolean settings reproduce the stock ViT-DPT defaults:
+    ``use_batch_norm_in_fusion_residual=False`` (the reference disables BN for
+    the ViT variants), which in turn makes the residual convs biased.
 
+    ``transformers`` is an optional dependency, so the import is deferred to
+    construction time — only the ``dpt`` head needs it.
+    """
+    try:
+        from transformers.models.dpt.modeling_dpt import DPTFeatureFusionLayer
+    except ImportError as e:  # pragma: no cover - exercised only without the extra
+        raise ImportError(
+            "DPTHead requires the 'transformers' package for its fusion cascade. "
+            "Install it with: pip install 'torchgeo-bench[sam3]' or pip install transformers"
+        ) from e
 
-class FeatureFusionBlock(nn.Module):
-    """Fuses a feature map with an optional skip connection via residual conv units."""
-
-    def __init__(self, features: int, kernel_size: int = 3, with_skip: bool = True) -> None:
-        super().__init__()
-        self.with_skip = with_skip
-        if with_skip:
-            self.resConfUnit1 = ResidualConvUnit(features, kernel_size)
-        self.resConfUnit2 = ResidualConvUnit(features, kernel_size)
-
-    def forward(self, x: torch.Tensor, skip_x: torch.Tensor | None = None) -> torch.Tensor:
-        """Fuse skip connection and refine features."""
-        if skip_x is not None:
-            if skip_x.shape[-2:] != x.shape[-2:]:
-                skip_x = F.interpolate(
-                    skip_x, size=x.shape[-2:], mode="bilinear", align_corners=False
-                )
-            x = self.resConfUnit1(x) + skip_x
-        return self.resConfUnit2(x)
+    config = SimpleNamespace(
+        fusion_hidden_size=hidden_dim,
+        use_batch_norm_in_fusion_residual=False,
+        use_bias_in_fusion_residual=None,  # → ``not use_batch_norm`` → True
+    )
+    return DPTFeatureFusionLayer(config)
 
 
 class DPTHead(nn.Module):
-    """DPT-style decoder head (adapted from probe3d at mbanani/probe3d, single-view).
+    """DPT decoder head using the reference ``transformers`` fusion cascade.
 
     Requires exactly **4** feature layers in **coarse-to-fine order** (same
     convention as FPN, e.g. ``["layer4", "layer3", "layer2", "layer1"]`` for
-    ResNet). The forward pass processes features from coarsest to finest
-    through a cascade of :class:`FeatureFusionBlock` modules.
+    ResNet). Features are normalised and projected to ``hidden_dim``, then run
+    through a top-down cascade of :class:`DPTFeatureFusionLayer`.
 
-    Upsampling chain (mirroring probe3d):
-      1. 1×1 project each map to ``hidden_dim``
-      2. 2× upsample all projected maps
-      3. Top-down fusion cascade (coarse → fine)
-      4. 4× upsample the fused result
-      5. 3×3 → ReLU → 3×3 output conv to ``num_classes``
-      6. Final resize to input resolution
+    The fusion layers are imported from ``transformers`` rather than
+    reimplemented, so the residual/fusion arithmetic matches Intel-ISL DPT
+    exactly: pre-activation residual units, refinement applied to the *skip*
+    (not the primary input), a post-fusion 1×1 projection, and a 2× upsample
+    inside every fusion layer. Four stacked layers therefore take a 14×14 ViT
+    token grid to 224×224 with no separate pre- or post-upsampling step.
+
+    Only the reassemble stage is ours: ``ChannelLayerNorm`` + a 1×1 projection
+    stands in for ``DPTReassembleStage``, because ``SegmentationProbe`` hands
+    the head backbone-agnostic ``(B, D, H, W)`` grids rather than the token
+    sequences plus patch geometry that the reference reassemble stage consumes.
 
     Args:
         channels_list: Channel count for each hooked feature layer (coarse-to-fine).
             Must have exactly 4 entries.
         num_classes: Number of segmentation output classes.
         hidden_dim: Hidden channel dimension (default 256).
-        kernel_size: Conv kernel size for residual units (default 3).
     """
 
     def __init__(
@@ -332,7 +333,6 @@ class DPTHead(nn.Module):
         channels_list: list[int],
         num_classes: int,
         hidden_dim: int = 256,
-        kernel_size: int = 3,
     ) -> None:
         super().__init__()
         if len(channels_list) != 4:
@@ -349,15 +349,9 @@ class DPTHead(nn.Module):
         self.convs = nn.ModuleList(
             [nn.Conv2d(c, hidden_dim, kernel_size=1, padding=0) for c in channels_list]
         )
-        # Fusion blocks: index 0 = coarsest (no skip), 1-3 receive skip from previous level
-        self.ref = nn.ModuleList(
-            [
-                FeatureFusionBlock(hidden_dim, kernel_size, with_skip=False),  # coarsest
-                FeatureFusionBlock(hidden_dim, kernel_size),
-                FeatureFusionBlock(hidden_dim, kernel_size),
-                FeatureFusionBlock(hidden_dim, kernel_size),  # finest
-            ]
-        )
+        # Fusion cascade: index 0 consumes the coarsest map alone, 1-3 each take
+        # the running fused state plus the next finer map as the skip.
+        self.ref = nn.ModuleList([_dpt_fusion_layer(hidden_dim) for _ in channels_list])
         self.out_conv = nn.Sequential(
             nn.Conv2d(hidden_dim, hidden_dim, kernel_size=3, padding=1),
             nn.ReLU(inplace=True),
@@ -372,20 +366,17 @@ class DPTHead(nn.Module):
             input_h: Target output height.
             input_w: Target output width.
         """
-        # Normalise → project → 2× upsample
-        projected = [
-            F.interpolate(conv(norm(f)), scale_factor=2, mode="bilinear", align_corners=True)
-            for norm, conv, f in zip(self.input_norms, self.convs, features)
-        ]
+        # Reassemble stand-in: normalise → 1×1 project to hidden_dim.
+        projected = [conv(norm(f)) for norm, conv, f in zip(self.input_norms, self.convs, features)]
 
-        # Top-down cascade: coarsest (0) → finest (3)
-        out = self.ref[0](projected[0], None)
-        out = self.ref[1](projected[1], out)
-        out = self.ref[2](projected[2], out)
-        out = self.ref[3](projected[3], out)
+        # Top-down cascade, coarsest (0) → finest (3). The running fused state is
+        # the primary input and the next feature map enters as the skip, matching
+        # ``DPTFeatureFusionStage``. Each layer upsamples 2×, so the cascade
+        # supplies all the upsampling (14×14 → 224×224 for a patch16 ViT).
+        out = self.ref[0](projected[0])
+        for layer, feat in zip(self.ref[1:], projected[1:]):
+            out = layer(out, feat)
 
-        # 4× upsample → output conv → resize to input resolution
-        out = F.interpolate(out, scale_factor=4, mode="bilinear", align_corners=True)
         out = self.out_conv(out)
         if out.shape[-2:] != (input_h, input_w):
             out = F.interpolate(out, size=(input_h, input_w), mode="bilinear", align_corners=False)

--- a/tests/test_segmentation.py
+++ b/tests/test_segmentation.py
@@ -512,6 +512,63 @@ def test_probe_dpt_wrong_num_layers():
         make_probe(backbone, layers=["layer1", "layer2"], head_type="dpt", hidden_dim=16)
 
 
+def test_dpt_fusion_layer_shim_matches_reference():
+    """The SimpleNamespace shim still satisfies the reference fusion layer's config API.
+
+    ``DPTFeatureFusionLayer`` is a private ``transformers`` API with no stability
+    guarantee. This asserts the four structural properties we depend on, so a
+    breaking upstream bump fails loudly here instead of silently changing the
+    decoder's arithmetic.
+    """
+    pytest.importorskip("transformers")
+    from transformers.models.dpt.modeling_dpt import DPTPreActResidualLayer
+
+    from torchgeo_bench.models.segmentation_heads import _dpt_fusion_layer
+
+    layer = _dpt_fusion_layer(16)
+
+    # 1. Post-fusion 1x1 projection is present (absent from the old implementation).
+    assert isinstance(layer.projection, nn.Conv2d)
+    assert layer.projection.kernel_size == (1, 1)
+
+    # 2. Both residual units are pre-activation (relu -> conv -> relu -> conv).
+    assert isinstance(layer.residual_layer1, DPTPreActResidualLayer)
+    assert isinstance(layer.residual_layer2, DPTPreActResidualLayer)
+
+    # 3. Each fusion layer upsamples 2x internally.
+    out = layer(torch.randn(1, 16, 7, 7))
+    assert out.shape == (1, 16, 14, 14)
+
+    # 4. A mismatched skip is resized to the primary input, not the reverse.
+    out = layer(torch.randn(1, 16, 7, 7), torch.randn(1, 16, 3, 3))
+    assert out.shape == (1, 16, 14, 14)
+
+
+def test_dpt_head_upsamples_purely_through_fusion_cascade():
+    """Four fusion layers take a 14x14 ViT token grid to 224x224 exactly.
+
+    The faithful cascade supplies all upsampling itself, so the head no longer
+    needs the pre-projection 2x and terminal 4x interpolations. With input_h/w
+    already at 224 the trailing resize is a no-op, which is what makes this a
+    regression test on the schedule rather than on the final ``F.interpolate``.
+    """
+    pytest.importorskip("transformers")
+    from torchgeo_bench.models.segmentation_heads import DPTHead
+
+    head = DPTHead([32, 32, 32, 32], num_classes=NUM_CLASSES, hidden_dim=16)
+    features = [torch.randn(1, 32, 14, 14) for _ in range(4)]
+
+    # Intercept the cascade output before out_conv / the final resize.
+    projected = [conv(norm(f)) for norm, conv, f in zip(head.input_norms, head.convs, features)]
+    fused = head.ref[0](projected[0])
+    for layer, feat in zip(head.ref[1:], projected[1:]):
+        fused = layer(fused, feat)
+    assert fused.shape[-2:] == (224, 224)
+
+    logits = head(features, 224, 224)
+    assert logits.shape == (1, NUM_CLASSES, 224, 224)
+
+
 # ---------------------------------------------------------------------------
 # Probe: PatchLinear head
 # ---------------------------------------------------------------------------

--- a/tests/test_segmentation.py
+++ b/tests/test_segmentation.py
@@ -482,6 +482,7 @@ class MockBackbone4Layer(nn.Module):
 
 def test_probe_dpt_head_forward():
     """DPT head with 4 coarse-to-fine layers produces correct output shape."""
+    pytest.importorskip("transformers")
     from torchgeo_bench.models.segmentation_heads import DPTHead
 
     backbone = MockBackbone4Layer()


### PR DESCRIPTION
Currently doing more segmentation experiments and these PRs are fixes of what I am finding during experimentation.

The DPT head was "adapted from probe3d" and diverged from Intel-ISL DPT in four ways, one of which is a genuine bug. Replace the hand-written fusion blocks with the reference implementation imported from `transformers.models.dpt.modeling_dpt`.

What was wrong:

1. Post- vs pre-activation residuals. `ResidualConvUnit` was conv->relu->conv->relu then `+x`; the reference `DPTPreActResidualLayer` is relu->conv->relu->conv then `+residual`. Ours ended on a ReLU, so the residual branch was non-negative and could only ever add magnitude.

2. Swapped fusion argument. Ours computed `resConfUnit1(x) + skip_x` — refining the primary input and adding the raw skip. The reference does `hidden_state + residual_layer1(residual)`, refining the *skip*. The two roles were inverted.

3. Missing post-fusion 1x1 `projection` conv, absent entirely.

4. Upsampling schedule. The reference upsamples 2x inside every fusion layer; ours did a pre-projection 2x and a single terminal 4x.

Approach: `DPTForSemanticSegmentation` cannot be used directly — it bundles its own ViT and `DPTConfig`, and `DPTNeck` consumes token sequences plus patch geometry, while `SegmentationProbe` is backbone-agnostic and hands the head `(B, D, H, W)` grids. But `DPTFeatureFusionLayer` and the `DPTPreActResidualLayer`s it owns are plain `nn.Module`s coupled to `config` only via three scalars, so they are driven with a `SimpleNamespace` shim. Four stacked fusion layers take a 14x14 ViT token grid to 224x224 exactly, so gaps 1-4 are all fixed at once and our extra pre/post upsampling is removed. `ChannelLayerNorm` + the 1x1 `convs` are kept as the backbone-agnostic stand-in for `DPTReassembleStage`.
