### PR TITLE
Support GeoBench V1 subset downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ The runner expects datasets under `./data/`. To grab GeoBench V1:
 torchgeo-bench download geobench_v1
 ```
 
+To download only the datasets needed for a run:
+
+```bash
+torchgeo-bench download geobench_v1 --datasets m-eurosat
+```
+
 V2 (classification + segmentation) and torchgeo's EuroSAT downloader work the
 same way (`torchgeo-bench download geobench_v2`, `torchgeo-bench download eurosat`). See the [documentation](https://torchgeo.org/torchgeo-bench/user/datasets.html)
 for all options.

--- a/docs/api/cli.rst
+++ b/docs/api/cli.rst
@@ -13,8 +13,8 @@ The ``torchgeo-bench`` console script exposes two subcommands:
 
 ``torchgeo-bench download {geobench_v1|geobench_v2|eurosat}``
     Downloads benchmark datasets into ``./data/`` (or a custom location with
-    ``--output-dir``). For GeoBench V2, individual datasets can be selected
-    with ``--datasets a,b,c``.
+    ``--output-dir``). For GeoBench V1 and V2, individual datasets can be
+    selected with ``--datasets a,b,c``.
 
 Hydra entry point
 -----------------

--- a/docs/user/datasets.rst
+++ b/docs/user/datasets.rst
@@ -40,6 +40,7 @@ The bundled :doc:`/api/cli` provides one subcommand per family:
 .. code-block:: console
 
    $ torchgeo-bench download geobench_v1                              # full V1 bundle
+   $ torchgeo-bench download geobench_v1 --datasets m-eurosat         # V1 subset
    $ torchgeo-bench download geobench_v2                              # default V2 set
    $ torchgeo-bench download geobench_v2 --datasets benv2,burn_scars  # V2 subset
    $ torchgeo-bench download eurosat                                  # torchgeo EuroSAT

--- a/src/torchgeo_bench/cli.py
+++ b/src/torchgeo_bench/cli.py
@@ -79,7 +79,7 @@ def download(
     ] = Path("data"),
     datasets: Annotated[
         str | None,
-        typer.Option(help="(geobench_v2 only) Comma-separated dataset names."),
+        typer.Option(help="(GeoBench only) Comma-separated dataset names."),
     ] = None,
 ) -> None:
     """Download a benchmark dataset to disk."""
@@ -94,12 +94,25 @@ def download(
         typer.echo(f"Unknown target {target!r}. Choose from: {', '.join(sorted(valid))}", err=True)
         raise typer.Exit(1)
 
+    names = None
+    if datasets is not None:
+        names = [name.strip() for name in datasets.split(",") if name.strip()]
+        if not names:
+            raise typer.BadParameter(
+                "must contain at least one dataset name",
+                param_hint="--datasets",
+            )
+
     if target == "geobench_v1":
-        download_geobench_v1(output_dir)
+        download_geobench_v1(output_dir, datasets=names)
     elif target == "geobench_v2":
-        names = [n.strip() for n in datasets.split(",") if n.strip()] if datasets else None
         download_geobench_v2(output_dir, datasets=names)
     elif target == "eurosat":
+        if names is not None:
+            raise typer.BadParameter(
+                "is only supported for GeoBench downloads",
+                param_hint="--datasets",
+            )
         download_eurosat(output_dir)
 
 

--- a/src/torchgeo_bench/download.py
+++ b/src/torchgeo_bench/download.py
@@ -4,7 +4,8 @@ Three targets:
 
 - ``geobench_v1`` — full GeoBench V1 classification suite from
   ``recursix/geo-bench-1.0``. Downloads to ``<output>/`` (the HF repo already
-  contains a top-level ``classification_v1.0/`` directory).
+  contains a top-level ``classification_v1.0/`` directory). Selected datasets
+  use the sharded mirror under ``<output>/classification_v1.0_wds/``.
 - ``geobench_v2`` — selected GeoBench V2 datasets from ``aialliance/<name>``
   HF repos. Defaults to the benchmark-supported datasets; override with
   ``--datasets``. Each dataset goes to ``<output>/geobenchv2/<name>``.
@@ -22,6 +23,7 @@ from torchgeo.datasets import EuroSAT
 logger = logging.getLogger(__name__)
 
 GEOBENCH_V1_REPO = "recursix/geo-bench-1.0"
+GEOBENCH_V1_SHARDED_REPO = "isaaccorley/geobenchv1-webdataset"
 GEOBENCH_V2_REPO_PREFIX = "aialliance"
 
 # Default V2 datasets to download — only those the benchmark runner knows about.
@@ -53,10 +55,40 @@ def _decompress_zip_with_progress(zip_path: Path, extract_to: Path) -> None:
     logger.info("Removed zip file: %s", zip_path)
 
 
-def download_geobench_v1(output_dir: Path) -> None:
-    """Download GeoBench V1 to ``output_dir`` (creates ``classification_v1.0/`` inside)."""
+def download_geobench_v1(output_dir: Path, datasets: list[str] | None = None) -> None:
+    """Download GeoBench V1 datasets to ``output_dir``.
+
+    Args:
+        output_dir: Benchmark data root (typically ``data/``).
+        datasets: Specific dataset names to fetch from the sharded mirror.
+            ``None`` downloads the full legacy HDF5 collection.
+
+    Raises:
+        ValueError: If ``datasets`` is empty.
+    """
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
+
+    if datasets is not None:
+        if not datasets:
+            raise ValueError("datasets must contain at least one GeoBench V1 dataset name")
+        sharded_root = output_dir / "classification_v1.0_wds"
+        sharded_root.mkdir(parents=True, exist_ok=True)
+        logger.info(
+            "Downloading %d GeoBench v1 dataset(s) from %s -> %s",
+            len(datasets),
+            GEOBENCH_V1_SHARDED_REPO,
+            sharded_root,
+        )
+        snapshot_download(
+            repo_id=GEOBENCH_V1_SHARDED_REPO,
+            repo_type="dataset",
+            local_dir=sharded_root,
+            allow_patterns=[f"{name}/*" for name in datasets],
+        )
+        logger.info("GeoBench v1 subset download complete.")
+        return
+
     logger.info("Downloading GeoBench v1 from %s -> %s", GEOBENCH_V1_REPO, output_dir)
 
     snapshot_download(
@@ -95,7 +127,9 @@ def download_geobench_v2(output_dir: Path, datasets: list[str] | None = None) ->
     """
     v2_root = Path(output_dir) / "geobenchv2"
     v2_root.mkdir(parents=True, exist_ok=True)
-    names = datasets or list(DEFAULT_V2_DATASETS)
+    if datasets is not None and not datasets:
+        raise ValueError("datasets must contain at least one GeoBench V2 dataset name")
+    names = list(DEFAULT_V2_DATASETS) if datasets is None else datasets
     logger.info("Downloading %d GeoBench v2 dataset(s) to %s", len(names), v2_root)
     for name in names:
         download_geobench_v2_dataset(name, v2_root)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,15 +26,30 @@ def test_download_invalid_target() -> None:
 
 
 def test_download_geobench_v1(monkeypatch) -> None:
-    calls: list[str] = []
+    calls: list[tuple[str, list[str] | None]] = []
 
-    def _fake_download(path) -> None:
-        calls.append(str(path))
+    def _fake_download(path, datasets=None) -> None:
+        calls.append((str(path), datasets))
 
     monkeypatch.setattr("torchgeo_bench.download.download_geobench_v1", _fake_download)
     result = runner.invoke(app, ["download", "geobench_v1"])
     assert result.exit_code == 0
-    assert len(calls) == 1
+    assert calls == [("data", None)]
+
+
+def test_download_geobench_v1_with_datasets(monkeypatch) -> None:
+    calls: list[tuple[str, list[str] | None]] = []
+
+    def _fake_download(path, datasets=None) -> None:
+        calls.append((str(path), datasets))
+
+    monkeypatch.setattr("torchgeo_bench.download.download_geobench_v1", _fake_download)
+    result = runner.invoke(
+        app,
+        ["download", "geobench_v1", "--datasets", "m-eurosat,m-forestnet"],
+    )
+    assert result.exit_code == 0
+    assert calls == [("data", ["m-eurosat", "m-forestnet"])]
 
 
 def test_download_geobench_v2_with_datasets(monkeypatch) -> None:
@@ -62,3 +77,15 @@ def test_download_eurosat(monkeypatch) -> None:
     result = runner.invoke(app, ["download", "eurosat"])
     assert result.exit_code == 0
     assert len(calls) == 1
+
+
+def test_download_rejects_empty_dataset_list() -> None:
+    result = runner.invoke(app, ["download", "geobench_v1", "--datasets", ","])
+    assert result.exit_code == 2
+    assert "must contain at least one dataset name" in result.stderr
+
+
+def test_download_rejects_datasets_for_eurosat() -> None:
+    result = runner.invoke(app, ["download", "eurosat", "--datasets", "m-eurosat"])
+    assert result.exit_code == 2
+    assert "only supported for GeoBench downloads" in result.stderr

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -3,6 +3,8 @@
 from pathlib import Path
 from unittest import mock
 
+import pytest
+
 from torchgeo_bench.download import (
     DEFAULT_V2_DATASETS,
     download_eurosat,
@@ -32,6 +34,24 @@ def test_download_geobench_v1_creates_output_and_decompresses(tmp_path: Path) ->
     decompress_mock.assert_called_once()
 
 
+def test_download_geobench_v1_subset_uses_sharded_mirror(tmp_path: Path) -> None:
+    out = tmp_path / "data"
+    with mock.patch("torchgeo_bench.download.snapshot_download") as download_mock:
+        download_geobench_v1(out, datasets=["m-eurosat", "m-forestnet"])
+
+    download_mock.assert_called_once_with(
+        repo_id="isaaccorley/geobenchv1-webdataset",
+        repo_type="dataset",
+        local_dir=out / "classification_v1.0_wds",
+        allow_patterns=["m-eurosat/*", "m-forestnet/*"],
+    )
+
+
+def test_download_geobench_v1_rejects_empty_subset(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="at least one GeoBench V1"):
+        download_geobench_v1(tmp_path, datasets=[])
+
+
 def test_download_geobench_v2_subset(tmp_path: Path) -> None:
     out = tmp_path / "data"
     with mock.patch("torchgeo_bench.download.download_geobench_v2_dataset") as dl_mock:
@@ -39,6 +59,11 @@ def test_download_geobench_v2_subset(tmp_path: Path) -> None:
 
     assert (out / "geobenchv2").exists()
     dl_mock.assert_called_once_with("burn_scars", out / "geobenchv2")
+
+
+def test_download_geobench_v2_rejects_empty_subset(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="at least one GeoBench V2"):
+        download_geobench_v2(tmp_path, datasets=[])
 
 
 def test_download_geobench_v2_defaults_to_registry_list(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- add `--datasets` support for GeoBench V1 downloads
- fetch selected V1 datasets from the sharded WebDataset mirror while preserving the full legacy HDF5 download
- reject empty dataset lists and `--datasets` for EuroSAT
- document the CLI and add focused regression tests

## Why

GeoBench V1 downloads previously required the full collection even when a run needed only one dataset. The existing sharded mirror already supports per-dataset downloads, but the download CLI did not expose that path.

Fixes #167

## Validation

- `uv run pytest -n auto --dist=loadfile -q` (434 passed, 55 skipped)
- `uv run pre-commit run --all-files -v`
- `uv run --extra docs --frozen sphinx-build -W -b html docs docs/_build/html`
- verified the live Hugging Face mirror contains all six supported V1 dataset directories
