### PR TITLE
fix(torchgeo): honor dataset.normalization in torchgeo wrappers

### DIFF
--- a/src/torchgeo_bench/models/torchgeo_models.py
+++ b/src/torchgeo_bench/models/torchgeo_models.py
@@ -339,10 +339,13 @@ class _TorchGeoBackboneBench(BenchModel):
         # applying unit conversion first would corrupt it (e.g. z-score uses
         # DN-scale mean/std — dividing raw DN by 10 000 before z-scoring
         # produces values ≈ 0 - 1000/500 ≈ -2, i.e. garbage).
-        weights_norm = self._weights_normalize
-        _need_unit_conv = self._weights_target_unit is not None and (
-            weights_norm is not None or self.normalization is NormalizationStrategy.MODEL_NATIVE
-        )
+        # The weights' own Normalize *is* the model-native pipeline, so it runs
+        # only under model_native.  Applying it under every strategy made
+        # dataset.normalization a no-op for each torchgeo model that ships a
+        # transform, silently collapsing the normalization ablation.
+        native = self.normalization is NormalizationStrategy.MODEL_NATIVE
+        weights_norm = self._weights_normalize if native else None
+        _need_unit_conv = self._weights_target_unit is not None and native
         if _need_unit_conv:
             images = convert_unit(images, self._dataset_input_unit, self._weights_target_unit)
         if weights_norm is not None:

--- a/src/torchgeo_bench/models/torchgeo_models.py
+++ b/src/torchgeo_bench/models/torchgeo_models.py
@@ -225,6 +225,13 @@ class _TorchGeoBackboneBench(BenchModel):
         input_unit_check: str = "warn",
         **kwargs: Any,
     ) -> None:
+        # The pretraining scale is already named by weights_input_unit, so
+        # derive expected_input_unit from it rather than making every wrapper
+        # restate it — model_native fails without it.
+        if type(self).expected_input_unit is None and self.weights_input_unit:
+            derived = _UNIT_EXPECTED_SOURCE.get(self.weights_input_unit)
+            if derived is not None:
+                type(self).expected_input_unit = derived
         super().__init__(bands=bands, **kwargs)
         weights = _resolve_torchgeo_weights(weights_class, weights_member)
         self.weights = weights
@@ -452,6 +459,7 @@ class TorchGeoSwinBench(_TorchGeoBackboneBench):
             auto_resize=auto_resize,
             target_size=target_size,
             input_unit_check=input_unit_check,
+            **_kwargs,
         )
         self.backbone.head = nn.Identity()
         # Adapt the patch-embed projection conv so RGB-pretrained Swin
@@ -502,6 +510,7 @@ class TorchGeoScaleMAEBench(_TorchGeoBackboneBench):
             auto_resize=auto_resize,
             target_size=target_size,
             input_unit_check=input_unit_check,
+            **_kwargs,
         )
         if pool not in VALID_MODES:
             raise ValueError(f"pool={pool!r} not in {VALID_MODES}")
@@ -587,6 +596,7 @@ class TorchGeoDOFABench(_TorchGeoBackboneBench):
             auto_resize=auto_resize,
             target_size=target_size,
             input_unit_check=input_unit_check,
+            **_kwargs,
         )
         self.wavelengths = _resolve_dofa_wavelengths(bands, wavelengths)
 
@@ -630,6 +640,7 @@ class TorchGeoEarthLocBench(_TorchGeoBackboneBench):
             auto_resize=auto_resize,
             target_size=target_size,
             input_unit_check=input_unit_check,
+            **_kwargs,
         )
         # EarthLoc wraps a ResNet50; adapt its first conv for N-channel input.
         # Results on N!=3 channels are "adapted*" (input-conv weights are
@@ -685,6 +696,7 @@ class TorchGeoCromaBench(_TorchGeoBackboneBench):
             auto_resize=auto_resize,
             target_size=target_size,
             input_unit_check=input_unit_check,
+            **_kwargs,
         )
 
     @torch.no_grad()
@@ -726,6 +738,7 @@ class TorchGeoPanopticonBench(_TorchGeoBackboneBench):
             auto_resize=auto_resize,
             target_size=target_size,
             input_unit_check=input_unit_check,
+            **_kwargs,
         )
         from ._band_mapping import wavelengths_um
 

--- a/tests/test_torchgeo_models.py
+++ b/tests/test_torchgeo_models.py
@@ -414,7 +414,7 @@ def test_channel_mismatch_preserves_tiled_normalize_chain(
     ]
     model = TorchGeoResNetBench(
         bands=six_bands,
-        normalization="identity",
+        normalization="model_native",
         input_unit_check="ignore",
     )
     normalized = model.normalize_inputs(torch.ones(1, 6, 8, 8))
@@ -557,3 +557,53 @@ def test_normalize_inputs_bandspec_zscore_no_unit_conversion(monkeypatch):
     x = torch.full((1, 3, 8, 8), 1200.0)
     normed = model.normalize_inputs(x)
     assert torch.allclose(normed, torch.zeros_like(normed), atol=1e-4)
+
+
+def test_weights_normalize_only_applies_under_model_native(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """dataset.normalization must not be silently overridden by the weights transform."""
+    import torchgeo_bench.models.torchgeo_models as tg_models
+
+    class _TinyResNet(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.conv1 = nn.Conv2d(3, 4, 1)
+            self.fc = nn.Identity()
+
+        def forward(self, images: torch.Tensor) -> torch.Tensor:
+            return images.mean(dim=(2, 3))
+
+    class _FakeWeights:
+        @staticmethod
+        def transforms() -> nn.Sequential:
+            return nn.Sequential(Normalize(mean=[0.0, 0.0, 0.0], std=[2.0, 2.0, 2.0]))
+
+    monkeypatch.setattr(
+        tg_models, "_resolve_torchgeo_factory", lambda _name: lambda weights: _TinyResNet()
+    )
+    monkeypatch.setattr(
+        tg_models,
+        "_resolve_torchgeo_weights",
+        lambda _weights_class, _weights_member: _FakeWeights(),
+    )
+
+    bands = _dn_bands()
+    sample = torch.full((1, 3, 4, 4), 1000.0)
+
+    native = TorchGeoResNetBench(
+        bands=bands, normalization="model_native", input_unit_check="ignore"
+    ).normalize_inputs(sample)
+    zscore = TorchGeoResNetBench(
+        bands=bands, normalization="bandspec_zscore", input_unit_check="ignore"
+    ).normalize_inputs(sample)
+    identity = TorchGeoResNetBench(
+        bands=bands, normalization="identity", input_unit_check="ignore"
+    ).normalize_inputs(sample)
+
+    # bandspec_zscore standardises with the BandSpec stats (mean 1200, std 400);
+    # identity passes raw values through; only model_native uses the weights'
+    # Normalize (std=2 -> 500.0).  Before the fix all three returned 500.0.
+    assert torch.allclose(zscore, torch.full_like(zscore, (1000.0 - 1200.0) / 400.0))
+    assert torch.allclose(identity, sample)
+    assert torch.allclose(native, torch.full_like(native, 500.0))

--- a/tests/test_torchgeo_models.py
+++ b/tests/test_torchgeo_models.py
@@ -607,3 +607,31 @@ def test_weights_normalize_only_applies_under_model_native(
     assert torch.allclose(zscore, torch.full_like(zscore, (1000.0 - 1200.0) / 400.0))
     assert torch.allclose(identity, sample)
     assert torch.allclose(native, torch.full_like(native, 500.0))
+
+
+def test_expected_input_unit_derived_from_weights_unit(monkeypatch):
+    """model_native needs expected_input_unit; wrappers only name weights_input_unit."""
+    import torchgeo_bench.models.torchgeo_models as tg_models
+    from torchgeo_bench.models._input_units import InputUnit
+
+    class _TinySwin(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.features = nn.Sequential(nn.Sequential(nn.Conv2d(3, 4, 1)))
+            self.head = nn.Identity()
+
+        def forward(self, images: torch.Tensor) -> torch.Tensor:
+            return images.mean(dim=(2, 3))
+
+    monkeypatch.setattr(
+        tg_models, "_resolve_torchgeo_factory", lambda _name: lambda weights: _TinySwin()
+    )
+    monkeypatch.setattr(
+        tg_models,
+        "_resolve_torchgeo_weights",
+        lambda _weights_class, _weights_member: SimpleNamespace(transforms=nn.Identity()),
+    )
+    # TorchGeoSwinBench declares weights_input_unit="uint8_div255" and no
+    # expected_input_unit; the base class must fill it in.
+    TorchGeoSwinBench(bands=_rgb_bands(), normalization="identity", input_unit_check="ignore")
+    assert TorchGeoSwinBench.expected_input_unit is InputUnit.UINT8


### PR DESCRIPTION
`dataset.normalization` was a no-op for every torchgeo model, for two reasons:

1. `normalize_inputs` applied the weights-bound `Normalize` whenever the checkpoint had one, ignoring the selected strategy. That transform *is* the model-native pipeline, so it now runs only under `model_native`.
2. Six of the seven wrappers (Swin, ScaleMAE, DOFA, EarthLoc, CROMA, Panopticon) never forwarded `**_kwargs` to `super().__init__`, so `normalization=` was dropped on the floor. Only ResNet forwarded it.

Together these meant a `bandspec_zscore` run and a `model_native` run produced bit-identical numbers — 81 of 290 model/dataset/bands combos in the rerun were exactly equal across normalizations before this.

Also derives `expected_input_unit` from `weights_input_unit` in the torchgeo base, since `model_native` raises without it and the wrappers already name the pretraining scale.

Same input, three strategies, after the fix:

```
model_native     -> -1.68122   (unit convert -> /255 -> ImageNet z-score)
bandspec_zscore  -> -0.50000   (dataset band stats)
identity         -> 1000.00000 (raw)
```

This changes results for every torchgeo model under non-native normalizations; those sweeps have been re-run.