### PR TITLE
fix(prithvi): select pretrained patch-embed bands instead of zero-filling

### DIFF
--- a/src/torchgeo_bench/models/terratorch_models.py
+++ b/src/torchgeo_bench/models/terratorch_models.py
@@ -91,17 +91,30 @@ class _TerraTorchBench(BenchModel):
 
 PRITHVI_BANDS: list[str] = ["blue", "green", "red", "nir_narrow", "swir1", "swir2"]
 
+# Canonical band name -> TerraTorch HLSBands member used for patch-embed selection.
+_PRITHVI_HLS_BANDS: dict[str, str] = {
+    "blue": "BLUE",
+    "green": "GREEN",
+    "red": "RED",
+    "nir_narrow": "NIR_NARROW",
+    "swir1": "SWIR_1",
+    "swir2": "SWIR_2",
+}
+
 
 class TerraTorchPrithviBench(_TerraTorchBench):
-    """IBM/NASA Prithvi-EO v1/v2 — auto-maps dataset bands onto 6 HLS slots @ 224.
+    """IBM/NASA Prithvi-EO v1/v2 — maps dataset bands onto its HLS slots @ 224.
 
     ``expected_input_unit = S2_DN``: under ``model_native`` the wrapper
     rescales the input to S2 DN scale before band-mapping.  Per-version
     pretraining mean/std are deliberately *not* applied here — they
-    correspond to the post-mapped 6-band layout, while strategy
-    normalisation runs on the dataset's raw channel count.  The BandSpec
-    z-score (default) and minmax strategies compose cleanly with the
-    band-mapping zero-fill that follows.
+    correspond to the post-mapped layout, while strategy normalisation runs
+    on the dataset's raw channel count.
+
+    Datasets that lack some of :data:`PRITHVI_BANDS` (RGB-only, for instance)
+    use TerraTorch's ``model_bands=`` patch-embed selection, which keeps the
+    pretrained weights for the bands that are present and drops the rest,
+    rather than zero-filling the missing channels.
     """
 
     expected_input_unit = InputUnit.S2_DN
@@ -115,16 +128,23 @@ class TerraTorchPrithviBench(_TerraTorchBench):
         target_size: int | None = 224,
         **kwargs: Any,
     ) -> None:
+        _, selected = select_src_bands(bands, PRITHVI_BANDS, preferred_sensors=("s2",))
+        backbone_kwargs: dict[str, Any] = {"pretrained": pretrained, "num_frames": 1}
+        if len(selected) < len(PRITHVI_BANDS):
+            backbone_kwargs["bands"] = [_PRITHVI_HLS_BANDS[name] for name in selected]
         self.backbone_name = backbone_name
         super().__init__(
             bands=bands,
             target_size=target_size,
-            backbone_kwargs={"pretrained": pretrained, "num_frames": 1},
+            backbone_kwargs=backbone_kwargs,
             **kwargs,
         )
+        self.model_bands = selected
 
     def _prepare_input(self, images: torch.Tensor) -> torch.Tensor:
-        mapped, _ = map_to_model_bands(images, self.bands, PRITHVI_BANDS, preferred_sensors=("s2",))
+        mapped, _ = map_to_model_bands(
+            images, self.bands, self.model_bands, preferred_sensors=("s2",)
+        )
         return mapped
 
 

--- a/tests/test_terratorch.py
+++ b/tests/test_terratorch.py
@@ -82,6 +82,30 @@ def test_prithvi_input_shape_accepted(mock_registry):
     assert mock_registry["build_calls"][0][0] == "prithvi_eo_v2_300"
 
 
+def test_prithvi_full_band_set_does_not_select_bands(mock_registry):
+    bands = _bands(["blue", "green", "red", "nir_narrow", "swir1", "swir2"])
+    TerraTorchPrithviBench(bands=bands, normalization="identity")
+    assert "bands" not in mock_registry["build_calls"][0][1]
+
+
+def test_prithvi_rgb_selects_pretrained_band_subset(mock_registry):
+    bands = _bands(["blue", "green", "red"])
+    model = TerraTorchPrithviBench(bands=bands, normalization="identity")
+    # RGB-only datasets must select the matching patch-embed slots rather than
+    # zero-filling the four missing Prithvi bands.
+    assert mock_registry["build_calls"][0][1]["bands"] == ["BLUE", "GREEN", "RED"]
+    assert model.model_bands == ["blue", "green", "red"]
+    out = model.forward_patch_features(torch.rand(2, 3, 224, 224))
+    assert out.shape == (2, 8)
+    assert model.backbone.last_forward_input.shape[1] == 3
+
+
+def test_prithvi_rejects_dataset_with_no_matching_band(mock_registry):
+    bands = _bands(["vv", "vh"], sensor="sar")
+    with pytest.raises(ValueError, match="none of the target bands"):
+        TerraTorchPrithviBench(bands=bands, normalization="identity")
+
+
 def test_clay_auxiliary_args_forwarded(mock_registry):
     bands = _bands(["blue", "green", "red", "nir", "swir1", "swir2"])
     model = TerraTorchClayBench(bands=bands, normalization="identity", gsd=20.0)


### PR DESCRIPTION
Prithvi mapped dataset bands onto a fixed 6-band HLS list, so an RGB dataset hit `Missing required model band 'nir_narrow'` and could not run at all — 231 model/dataset combos in the full rerun. Before #90 added that guard, the same combos silently ran on zero-filled channels, which is where the published Prithvi RGB numbers came from.

TerraTorch's Prithvi factories take `bands=`, which routes to `select_patch_embed_weights`: bands present in the checkpoint but absent from the request are dropped, keeping the pretrained weights for the rest. Clay and TerraMind in this repo already use that pattern; Prithvi was the odd one out.

Verified against the real checkpoint — the RGB patch embed is exactly the pretrained blue/green/red slices, not a re-init:

```
full patch_embed: (1024, 6, 1, 16, 16)
rgb  patch_embed: (1024, 3, 1, 16, 16)
rgb weights == first 3 pretrained band slices: True
```

Re-running the 290 previously-failing Prithvi combos leaves only mixed-sensor `bands=all` failures, which are a separate and legitimate incompatibility.