### PR TITLE
fix(terratorch): Clay v1.5 model_native pretrain mean/std

### DIFF
--- a/src/torchgeo_bench/models/terratorch_models.py
+++ b/src/torchgeo_bench/models/terratorch_models.py
@@ -191,6 +191,16 @@ _CLAY_WAVELENGTH_BY_BAND: dict[str, float] = dict(
     zip(CLAY_BANDS, _CLAY_WAVELENGTHS_UM, strict=True)
 )
 
+# Sentinel-2-L2A per-band pretraining stats, raw DN scale, from Clay's own
+# https://github.com/Clay-foundation/model/blob/main/configs/metadata.yaml
+# (nir/swir16/swir22 renamed to this file's nir/swir1/swir2).
+_CLAY_PRETRAIN_MEAN_BY_BAND: dict[str, float] = dict(
+    zip(CLAY_BANDS, [1105.0, 1355.0, 1552.0, 2743.0, 2388.0, 1835.0], strict=True)
+)
+_CLAY_PRETRAIN_STD_BY_BAND: dict[str, float] = dict(
+    zip(CLAY_BANDS, [1809.0, 1757.0, 1888.0, 1742.0, 1470.0, 1379.0], strict=True)
+)
+
 
 class TerraTorchClayBench(_TerraTorchBench):
     """Clay v1.5 — S2 bands @ 256, conditioned on per-band ``waves`` (µm) and ``gsd``.
@@ -204,7 +214,9 @@ class TerraTorchClayBench(_TerraTorchBench):
     ``waves`` values exactly as they were.
     """
 
-    expected_input_unit = InputUnit.REFLECTANCE_0_1
+    # Clay's published mean/std (see _CLAY_PRETRAIN_MEAN_BY_BAND) are raw S2
+    # digital numbers, not 0-1 reflectance.
+    expected_input_unit = InputUnit.S2_DN
 
     def __init__(
         self,
@@ -219,8 +231,18 @@ class TerraTorchClayBench(_TerraTorchBench):
     ) -> None:
         # Resolved before super().__init__ so a band set with no Clay band at
         # all raises before the pretrained checkpoint is downloaded.
-        _, model_bands = select_src_bands(bands, CLAY_BANDS, preferred_sensors=("s2",))
+        indices, model_bands = select_src_bands(bands, CLAY_BANDS, preferred_sensors=("s2",))
         self.backbone_name = backbone_name
+        # model_native standardises with Clay's published per-band statistics.
+        # normalize_inputs runs on the dataset's raw channels, before
+        # _prepare_input maps them onto Clay's band slots; bands Clay does not
+        # consume keep mean 0 / std 1 and are dropped by the mapping anyway.
+        mean = [0.0] * len(bands)
+        std = [1.0] * len(bands)
+        for name, ds_idx in zip(model_bands, indices, strict=True):
+            mean[ds_idx] = _CLAY_PRETRAIN_MEAN_BY_BAND[name]
+            std[ds_idx] = _CLAY_PRETRAIN_STD_BY_BAND[name]
+        self.pretrain_mean, self.pretrain_std = mean, std
         super().__init__(
             bands=bands,
             target_size=target_size,

--- a/uv.lock
+++ b/uv.lock
@@ -590,7 +590,7 @@ name = "cuda-bindings"
 version = "13.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/52/c8/b2589d68acf7e3d63e2be330b84bc25712e97ed799affbca7edd7eae25d6/cuda_bindings-13.2.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e865447abfb83d6a98ad5130ed3c70b1fc295ae3eeee39fd07b4ddb0671b6788", size = 5722404, upload-time = "2026-03-11T00:12:44.041Z" },
@@ -621,34 +621,34 @@ wheels = [
 
 [package.optional-dependencies]
 cudart = [
-    { name = "nvidia-cuda-runtime" },
+    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux'" },
 ]
 cufft = [
-    { name = "nvidia-cufft" },
+    { name = "nvidia-cufft", marker = "sys_platform == 'linux'" },
 ]
 cufile = [
-    { name = "nvidia-cufile" },
+    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti" },
+    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux'" },
 ]
 curand = [
-    { name = "nvidia-curand" },
+    { name = "nvidia-curand", marker = "sys_platform == 'linux'" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver" },
+    { name = "nvidia-cusolver", marker = "sys_platform == 'linux'" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse" },
+    { name = "nvidia-cusparse", marker = "sys_platform == 'linux'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux'" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx" },
+    { name = "nvidia-nvtx", marker = "sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -730,8 +730,8 @@ name = "faiss-cpu"
 version = "1.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
-    { name = "packaging" },
+    { name = "numpy", marker = "platform_machine != 'x86_64' or sys_platform != 'linux'" },
+    { name = "packaging", marker = "platform_machine != 'x86_64' or sys_platform != 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/8b/5d2cd7c9fd60bc4d1ca6e9f5e8b0eb57254a7b301daaa12d5853fdf48afe/faiss_cpu-1.14.2-cp310-abi3-macosx_14_0_arm64.whl", hash = "sha256:a20011b8a97318e6d5e29143a773277ca71f1c33140024aeec91f05ad56cdd04", size = 4621203, upload-time = "2026-05-22T19:58:27.415Z" },
@@ -748,10 +748,10 @@ name = "faiss-cuda"
 version = "1.14.3.post0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cuda-runtime-cu12" },
-    { name = "packaging" },
+    { name = "numpy", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "packaging", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cf/d9/ff4dc8cbae70a4f5c76a953ac1e189044940be7a22808b1c3ff865a2a1e6/faiss_cuda-1.14.3.post0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d83e92f341a1f79b5ab52fa0982eab3fe80428fcb1a69591ab2021b95f568f33", size = 106476496, upload-time = "2026-07-11T21:36:01.577Z" },
@@ -774,10 +774,10 @@ wheels = [
 
 [package.optional-dependencies]
 cpu = [
-    { name = "faiss-cpu" },
+    { name = "faiss-cpu", marker = "platform_machine != 'x86_64' or sys_platform != 'linux'" },
 ]
 cuda = [
-    { name = "faiss-cuda" },
+    { name = "faiss-cuda", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -1906,7 +1906,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -1918,7 +1918,7 @@ name = "nvidia-cublas-cu12"
 version = "12.9.2.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc-cu12" },
+    { name = "nvidia-cuda-nvrtc-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/c0/0a517bfe63ccd3b92eb254d264e28fca3c7cab75d07daea315250fb1bf73/nvidia_cublas_cu12-12.9.2.10-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:e4f53a8ca8c5d6e8c492d0d0a3d565ecb59a751b19cfdaa4f6da0ab2104c1702", size = 581240110, upload-time = "2026-04-08T18:52:31.532Z" },
@@ -1972,7 +1972,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -1984,7 +1984,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -2014,9 +2014,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
-    { name = "nvidia-cusparse" },
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cusparse", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -2028,7 +2028,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -4010,7 +4010,6 @@ dependencies = [
     { name = "geobenchv2" },
     { name = "h5py" },
     { name = "huggingface-hub" },
-    { name = "hydra-core" },
     { name = "numpy" },
     { name = "omegaconf" },
     { name = "pandas" },
@@ -4023,7 +4022,6 @@ dependencies = [
     { name = "torchgeo" },
     { name = "torchmetrics" },
     { name = "torchvision" },
-    { name = "typer" },
 ]
 
 [package.optional-dependencies]
@@ -4103,7 +4101,6 @@ requires-dist = [
     { name = "geobenchv2", specifier = ">=0.9" },
     { name = "h5py", specifier = ">=3.8" },
     { name = "huggingface-hub", specifier = ">=0.20" },
-    { name = "hydra-core", specifier = ">=1.3" },
     { name = "imagehash", marker = "extra == 'cleanlab'", specifier = ">=4.3" },
     { name = "linkify-it-py", marker = "extra == 'docs'", specifier = ">=2" },
     { name = "matplotlib", marker = "extra == 'cleanlab'", specifier = ">=3.5" },
@@ -4148,7 +4145,6 @@ requires-dist = [
     { name = "torchmetrics", specifier = ">=1.4" },
     { name = "torchvision", specifier = ">=0.15" },
     { name = "transformers", marker = "extra == 'sam3'", specifier = ">=4.50" },
-    { name = "typer", specifier = ">=0.9" },
 ]
 provides-extras = ["all", "cleanlab", "coordbench", "dev", "docs", "id", "olmoearth", "sam3", "terratorch", "viz"]
 
@@ -4157,10 +4153,10 @@ name = "torchid"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
-    { name = "scipy" },
-    { name = "torch" },
-    { name = "torchmetrics" },
+    { name = "numpy", marker = "python_full_version >= '3.13'" },
+    { name = "scipy", marker = "python_full_version >= '3.13'" },
+    { name = "torch", marker = "python_full_version >= '3.13'" },
+    { name = "torchmetrics", marker = "python_full_version >= '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/27/a7/cb4d5a769984d9aded6a779d6ecdd7e172224ae675af3180a0cf196034cb/torchid-0.4.0.tar.gz", hash = "sha256:2a48c8a7f4b11bc495f3e63f22c9b09ef30e2c5f93555e3f78986722ac07c463", size = 27304, upload-time = "2026-05-20T10:38:03.921Z" }
 wheels = [


### PR DESCRIPTION
Clay v1.5 had no pretrain_mean/std, so model_native raised for every Clay config. Adds Clay's published per-band S2-L2A DN mean/std and fixes expected_input_unit to match (s2_dn, not reflectance).