### PR TITLE
feat(segmentation): pool features over time for multi-temporal datasets

### DIFF
--- a/src/torchgeo_bench/conf/config.yaml
+++ b/src/torchgeo_bench/conf/config.yaml
@@ -41,6 +41,8 @@ dataset:
   normalization: bandspec_zscore   # bandspec_zscore | model_native | minmax | minmax_zscore | identity
   bands: rgb                  # rgb | all | list of band names (e.g., [red, green, blue, nir])
   image_size: 224           # e.g., 224; if null, no resizing
+  time_steps: null          # multi-temporal datasets only (pastis): dates per
+                            # sample; null keeps the upstream single-date default
   interpolation: bilinear     # area | bilinear | bicubic | nearest; used if image_size set
 
 # Evaluation settings
@@ -94,6 +96,10 @@ eval:
 
   segmentation:
     head_type: "fpn"
+    # How multi-temporal inputs (B, T, C, H, W) are reduced before the decoder:
+    # the backbone encodes each date, then features are pooled over T.  Only
+    # applies to datasets that actually deliver a time axis.
+    temporal_pool: "mean"   # mean | max
     layers: []                 # must be overridden per model for segmentation datasets
     lr: 1e-3
     epochs: 10

--- a/src/torchgeo_bench/datasets/loading.py
+++ b/src/torchgeo_bench/datasets/loading.py
@@ -171,6 +171,7 @@ def get_datasets(
     image_size: int | None = None,
     interpolation: str = "bilinear",
     bands: str | Iterable[str] | None = "rgb",
+    time_steps: int | None = None,
 ) -> tuple:
     """Load benchmark dataset splits and dataloaders.
 
@@ -190,6 +191,9 @@ def get_datasets(
             ``"bilinear"``, ``"nearest"``).
         bands: ``"rgb"`` (use the dataset's ``rgb_bands``), ``"all"`` /
             ``None`` (load all bands), or an explicit iterable of band names.
+        time_steps: Number of acquisition dates per sample.  Only accepted by
+            multi-temporal wrappers (PASTIS); ``None`` keeps each dataset's
+            own default.
 
     Returns:
         Either ``(train_dataset, train_loader, test_loader)`` or, when
@@ -225,7 +229,11 @@ def get_datasets(
     transform = _make_resize_transform(image_size, interpolation)
     train_partition = partition_name if bench.supports_partitions else "default"
 
-    common = {"bands": bands_tuple, "transform": transform}
+    common: dict = {"bands": bands_tuple, "transform": transform}
+    if time_steps is not None:
+        # Only multi-temporal wrappers accept this; others would not know what
+        # to do with a time axis, so passing it to them is a config error.
+        common["time_steps"] = time_steps
     train_ds = bench.get_dataset("train", partition=train_partition, **common)
     val_ds = bench.get_dataset("val", partition="default", **common)
     test_ds = bench.get_dataset("test", partition="default", **common)

--- a/src/torchgeo_bench/datasets/pastis.py
+++ b/src/torchgeo_bench/datasets/pastis.py
@@ -1,7 +1,12 @@
 """PASTIS (GeoBench V2) benchmark dataset."""
 
+from collections.abc import Callable
+
+import torch.nn as nn
+from torch.utils.data import Dataset
+
 from .base import BandSpec
-from .geobench_v2 import _V2Dataset
+from .geobench_v2 import GeoBenchv2, _V2Dataset
 
 
 class PASTIS(_V2Dataset):
@@ -39,3 +44,36 @@ class PASTIS(_V2Dataset):
         BandSpec("s1_desc", "vv_vh_desc", "VV/VH_desc", mean=6.189, std=3.2708, min=-21.0469, max=44.75),
     ]
     # fmt: on
+
+    def get_dataset(
+        self,
+        split: str,
+        *,
+        partition: str = "default",
+        bands: tuple[str, ...] | None = None,
+        transform: Callable | None = None,
+        time_steps: int | None = None,
+    ) -> Dataset:
+        """Return a :class:`GeoBenchv2` split, optionally as a time series.
+
+        PASTIS is multi-temporal and upstream defaults to ``num_time_steps=1``,
+        i.e. the last acquisition only.  Crop type is a phenological signal, so
+        a single date discards most of what separates the classes; request more
+        dates and let the probe pool over them.  ``time_steps=None`` keeps the
+        single-date behaviour so existing results stay comparable.
+        """
+        del partition
+        band_order = self.build_band_order(bands)
+        extra: dict = {}
+        if time_steps is not None:
+            extra["num_time_steps"] = int(time_steps)
+            extra["temporal_output_format"] = "TCHW"
+        return GeoBenchv2(
+            root=self.data_root(),
+            dataset_name=self.name,
+            split=split,
+            band_order=band_order,
+            transforms=transform,
+            data_normalizer=nn.Identity,
+            **extra,
+        )

--- a/src/torchgeo_bench/main.py
+++ b/src/torchgeo_bench/main.py
@@ -732,6 +732,7 @@ def main(cfg: DictConfig) -> None:
                 image_size=effective_image_size,
                 interpolation=effective_interpolation,
                 bands=getattr(cfg.dataset, "bands", "rgb"),
+                time_steps=cfg.dataset.get("time_steps", None),
             )
         except (FileNotFoundError, DatasetNotFoundError) as exc:
             logger.warning(f"Skipping dataset {ds_name} (data not found: {exc})")

--- a/src/torchgeo_bench/segmentation_probe.py
+++ b/src/torchgeo_bench/segmentation_probe.py
@@ -179,8 +179,12 @@ class SegmentationProbe(nn.Module):
         freeze_backbone: bool = True,
         head_type: str = "linear",
         hidden_dim: int | None = None,
+        temporal_pool: str = "mean",
     ) -> None:
         super().__init__()
+        if temporal_pool not in ("mean", "max"):
+            raise ValueError(f"temporal_pool must be 'mean' or 'max', got {temporal_pool!r}")
+        self.temporal_pool = temporal_pool
         self.backbone = backbone
         self.layer_names = layer_names
         self.freeze_backbone = freeze_backbone
@@ -421,12 +425,19 @@ class SegmentationProbe(nn.Module):
         """Compute segmentation logits from input images.
 
         Args:
-            x: Input tensor of shape ``(B, C, H, W)``.
+            x: ``(B, C, H, W)``, or ``(B, T, C, H, W)`` for a time series.  A
+                time series is folded into the batch, encoded once, and pooled
+                back over ``T`` in feature space — the backbone stays a
+                single-image encoder and the decoder sees one map per sample.
 
         Returns:
             Logits tensor of shape ``(B, num_classes, H, W)``.
         """
         input_h, input_w = x.shape[-2:]
+        steps = 0
+        if x.ndim == 5:
+            batch, steps = x.shape[0], x.shape[1]
+            x = x.reshape(batch * steps, *x.shape[2:])
 
         if self.freeze_backbone:
             self.backbone.eval()
@@ -437,4 +448,12 @@ class SegmentationProbe(nn.Module):
             _ = self.backbone(x)
 
         features = [self._process_feature(self._features[n]) for n in self.layer_names]
+        if steps:
+            features = [self._pool_time(f, steps) for f in features]
         return self.head(features, input_h, input_w)
+
+    def _pool_time(self, feat: torch.Tensor, steps: int) -> torch.Tensor:
+        """Reduce ``(B*T, C, H, W)`` back to ``(B, C, H, W)`` over time."""
+        c, h, w = feat.shape[1:]
+        feat = feat.view(-1, steps, c, h, w)
+        return feat.mean(dim=1) if self.temporal_pool == "mean" else feat.amax(dim=1)

--- a/src/torchgeo_bench/segmentation_task.py
+++ b/src/torchgeo_bench/segmentation_task.py
@@ -445,6 +445,7 @@ def build_seg_probe_and_solver(
         num_classes=num_classes,
         head_type=eval_cfg.segmentation.head_type,
         freeze_backbone=True,
+        temporal_pool=str(eval_cfg.segmentation.get("temporal_pool", "mean")),
     )
     criterion = instantiate(eval_cfg.segmentation.criterion)
     criterion_ignore = getattr(criterion, "ignore_index", None)

--- a/tests/test_segmentation.py
+++ b/tests/test_segmentation.py
@@ -819,3 +819,38 @@ def test_solver_fit_cached_builds_missing_validation_gpu_cache(mock_backbone, du
     )
 
     assert isinstance(val_miou, float)
+
+
+def test_probe_pools_time_series_features(mock_backbone, dummy_data):
+    """A (B, T, C, H, W) input is encoded per date then pooled back to (B, ...).
+
+    PASTIS is multi-temporal and upstream hands back only the last acquisition
+    by default; crop type is phenological, so the probe has to accept a time
+    axis rather than the pipeline silently seeing one date.
+    """
+    probe = SegmentationProbe(mock_backbone, ["layer1", "layer2"], NUM_CLASSES, head_type="fpn")
+    images = dummy_data["image"]
+    single = probe(images)
+    series = probe(images.unsqueeze(1).repeat(1, 3, 1, 1, 1))
+    assert series.shape == single.shape
+    # Repeating one date must pool back to that date's logits.
+    assert torch.allclose(series, single, atol=1e-4)
+
+
+def test_probe_temporal_pool_max_differs_from_mean(mock_backbone, dummy_data):
+    """max and mean pooling must not silently be the same reduction."""
+    images = dummy_data["image"]
+    series = torch.stack([images, images * 0.5], dim=1)
+    mean_probe = SegmentationProbe(
+        mock_backbone, ["layer1"], NUM_CLASSES, head_type="fpn", temporal_pool="mean"
+    )
+    max_probe = SegmentationProbe(
+        mock_backbone, ["layer1"], NUM_CLASSES, head_type="fpn", temporal_pool="max"
+    )
+    max_probe.head.load_state_dict(mean_probe.head.state_dict())
+    assert not torch.allclose(mean_probe(series), max_probe(series), atol=1e-5)
+
+
+def test_probe_rejects_unknown_temporal_pool(mock_backbone):
+    with pytest.raises(ValueError, match="temporal_pool"):
+        SegmentationProbe(mock_backbone, ["layer1"], NUM_CLASSES, temporal_pool="median")


### PR DESCRIPTION
Splits the temporal average/max pooling out of #214 into its own PR, since it's independent of the rcf/mosaiks work.

Single-image backbones can now be evaluated on multi-temporal datasets (PASTIS): each date is fed through the encoder, and features are pooled over time (mean or max, config: eval.segmentation.temporal_pool) before the decoder. PASTIS's num_time_steps is exposed via dataset.time_steps so more than the last acquisition can be requested. Defaults keep single-date behavior, so existing results are unaffected.