### PR TITLE
feat: add feature spectrum diagnostics

### DIFF
--- a/docs/api/intrinsic_dim.rst
+++ b/docs/api/intrinsic_dim.rst
@@ -4,7 +4,8 @@ torchgeo_bench.intrinsic_dim
 .. module:: torchgeo_bench.intrinsic_dim
 
 Wrapper around the `torchid <https://github.com/jacobpennington/torchid>`__
-intrinsic-dimension estimators.  Used by
+intrinsic-dimension estimators plus dependency-free centered feature-spectrum
+diagnostics.  Used by
 :func:`torchgeo_bench.main.evaluate_intrinsic_dim` to attach
 ``method="intrinsic_dim"`` rows to the standard results CSV alongside the
 KNN and linear-probe metrics.
@@ -16,4 +17,8 @@ is not installed an :class:`ImportError` is raised on first use.
 Public API
 ----------
 
+.. autoexception:: DegenerateSpectrumError
+
 .. autofunction:: compute_intrinsic_dim
+
+.. autofunction:: compute_feature_spectrum

--- a/docs/user/methodology.rst
+++ b/docs/user/methodology.rst
@@ -57,6 +57,46 @@ reused by both KNN and the linear probe.
 5. Embeddings and labels are concatenated across batches into NumPy
    arrays for downstream evaluation.
 
+Feature-spectrum diagnostics
+----------------------------
+
+When ``eval.intrinsic_dim.enabled=true``, each selected split also emits five
+scale-invariant diagnostics from the **centered** embedding matrix.  Let
+``s_i`` be its singular values and let
+
+.. math::
+
+   p_i = \frac{s_i^2}{\sum_j s_j^2}
+
+be the fraction of feature variance carried by principal component ``i``.
+The reported metrics are:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 32 68
+
+   * - Metric
+     - Definition
+   * - ``effective_rank``
+     - :math:`\exp(-\sum_{i:p_i>0} p_i \log p_i)`, the exponential spectral entropy.
+   * - ``participation_ratio``
+     - :math:`1 / \sum_i p_i^2`, an alternative effective dimensionality.
+   * - ``pc1_variance_ratio``
+     - :math:`p_1`, the variance explained by the leading principal component.
+   * - ``pc10_variance_ratio``
+     - :math:`\sum_{i=1}^{\min(10,d)} p_i`, the cumulative variance explained by
+       the first ten components (or all components when ``d < 10``).
+   * - ``spectral_anisotropy``
+     - :math:`(d p_1 - 1)/(d - 1)`, leading-component dominance normalized so an
+       isotropic ``d``-dimensional spectrum is 0 and a rank-one spectrum is 1.
+       The one-dimensional convention is 0 because no direction can dominate
+       another.
+
+The same deterministic ``max_samples`` cap and seed used for intrinsic
+dimension are applied before centering. Non-finite inputs, fewer than two
+samples, and zero total variance raise an error rather than producing a
+plausible-looking diagnostic.
+
 KNN (k=5)
 ---------
 

--- a/docs/user/methodology.rst
+++ b/docs/user/methodology.rst
@@ -87,9 +87,13 @@ The reported metrics are:
      - :math:`\sum_{i=1}^{\min(10,d)} p_i`, the cumulative variance explained by
        the first ten components (or all components when ``d < 10``).
    * - ``spectral_anisotropy``
-     - :math:`(d p_1 - 1)/(d - 1)`, leading-component dominance normalized so an
-       isotropic ``d``-dimensional spectrum is 0 and a rank-one spectrum is 1.
-       The one-dimensional convention is 0 because no direction can dominate
+     - :math:`(d_{\text{eff}} p_1 - 1)/(d_{\text{eff}} - 1)`, leading-component
+       dominance normalized so an isotropic spectrum is 0 and a rank-one
+       spectrum is 1, where :math:`d_{\text{eff}} = \min(d, n - 1)` is the
+       number of singular values centering can leave nonzero. Normalizing by
+       the raw feature dimension ``d`` instead would give small splits
+       (``n <= d``) an anisotropy floor above zero even for isotropic data.
+       The ``d_eff <= 1`` convention is 0 because no direction can dominate
        another.
 
 The same deterministic ``max_samples`` cap and seed used for intrinsic

--- a/docs/user/results-format.rst
+++ b/docs/user/results-format.rst
@@ -73,7 +73,10 @@ Method values
 ``knn5``           KNN-5 classification (multilabel KNN for ``m-bigearthnet``). -> ``results/models/``
 ``linear``         L-BFGS logistic regression with C-sweep on the validation set. -> ``results/models/``
 ``intrinsic_dim``  Optional intrinsic-dimension metrics on extracted embeddings (requires
-                   the ``[id]`` extra and ``eval.intrinsic_dim.enabled=true``). -> ``results/intrinsic_dim/``
+                   the ``[id]`` extra) plus dependency-free centered feature-spectrum
+                   diagnostics. Both are emitted when
+                   ``eval.intrinsic_dim.enabled=true``; set ``estimators=[]`` for
+                   spectrum-only output without ``torchid``. -> ``results/intrinsic_dim/``
 ``profile``        Optional throughput/latency/param-count measurement (requires
                    ``eval.profile.enabled=true``). -> ``results/profiles/``
 ``seg-<head>``     Segmentation probe with the configured head (``linear`` / ``conv_block`` /
@@ -89,7 +92,8 @@ Column               Description
 ``dataset``          Dataset CLI name (e.g. ``m-eurosat``).
 ``method``           ``knn5``, ``linear``, ``intrinsic_dim``, or ``seg-<head_type>``.
 ``metric_name``      Primary metric (``accuracy``, ``micro_mAP``, ``mIoU``,
-                     or ``id_<estimator>_<split>`` for intrinsic dim rows).
+                     ``id_<estimator>_<split>`` for intrinsic-dimension rows,
+                     or ``spectrum_<metric>_<split>`` for feature-spectrum rows).
 ``metric_value``     Point estimate.
 ``ci_lower``         Bootstrap CI lower bound (0.0 when not applicable).
 ``ci_upper``         Bootstrap CI upper bound (0.0 when not applicable).

--- a/src/torchgeo_bench/conf/config.yaml
+++ b/src/torchgeo_bench/conf/config.yaml
@@ -64,9 +64,11 @@ eval:
     n_bins_linear: 15
     temp_scale: false      # requires merge_val=false so validation remains held out
 
-  # Optional intrinsic dimension (ID) metrics on extracted embeddings.
-  # Computed alongside KNN/linear probing when enabled. Adds rows with
-  # method="intrinsic_dim" and metric_name="id_<estimator>_<split>".
+  # Optional intrinsic dimension (ID) metrics and centered feature-spectrum
+  # diagnostics on extracted embeddings. Computed alongside KNN/linear probing
+  # when enabled. Adds method="intrinsic_dim" rows named
+  # "id_<estimator>_<split>" plus effective rank, participation ratio, PC1/PC10
+  # variance ratios, and spectral anisotropy for each selected split.
   intrinsic_dim:
     enabled: false
     estimators: [TwoNN, MLE, lPCA]   # subset of torchid global estimators
@@ -115,4 +117,3 @@ eval:
     save_viz: false            # set true to save prediction grids and confusion matrices
     viz_dir: "viz"             # root output directory for visualizations
     n_viz_samples: 8           # number of test samples shown in the sample grid
-

--- a/src/torchgeo_bench/intrinsic_dim.py
+++ b/src/torchgeo_bench/intrinsic_dim.py
@@ -86,6 +86,16 @@ def _subsample(X: np.ndarray, max_samples: int | None, seed: int) -> np.ndarray:
     return X[idx]
 
 
+def _validate_max_samples(max_samples: int | None) -> None:
+    """Reject a ``max_samples`` that would make ``_subsample`` misbehave."""
+    if max_samples is not None and (
+        isinstance(max_samples, bool) or not isinstance(max_samples, int) or max_samples < 2
+    ):
+        raise ValueError(
+            f"max_samples must be an integer of at least 2 or None, got {max_samples!r}"
+        )
+
+
 def compute_feature_spectrum(
     X: np.ndarray,
     max_samples: int | None = 10_000,
@@ -96,8 +106,12 @@ def compute_feature_spectrum(
     The squared singular values of the centered feature matrix are normalized
     into variance proportions ``p``. Effective rank is ``exp(H(p))``;
     participation ratio is ``1 / sum(p**2)``. Spectral anisotropy normalizes
-    leading-component dominance against the isotropic ``1 / d`` baseline:
-    ``(d * p[0] - 1) / (d - 1)``.
+    leading-component dominance against the isotropic ``1 / d_eff`` baseline,
+    where ``d_eff = min(d, n - 1)`` is the number of singular values centering
+    can leave nonzero: ``(d_eff * p[0] - 1) / (d_eff - 1)``. Using the raw
+    feature dimension ``d`` here would give small splits (``n <= d``, common
+    for val/test) an anisotropy floor above zero even for isotropic data,
+    making the score incomparable across datasets with different split sizes.
 
     Args:
         X: Feature matrix of shape ``(n_samples, n_features)``.
@@ -122,12 +136,7 @@ def compute_feature_spectrum(
         raise ValueError(f"X must contain at least one feature, got shape {X.shape}")
     if not np.isfinite(X).all():
         raise ValueError("X must contain only finite values")
-    if max_samples is not None and (
-        isinstance(max_samples, bool) or not isinstance(max_samples, int) or max_samples < 2
-    ):
-        raise ValueError(
-            f"max_samples must be an integer of at least 2 or None, got {max_samples!r}"
-        )
+    _validate_max_samples(max_samples)
 
     Xs = np.asarray(_subsample(X, max_samples, seed), dtype=np.float64)
     centered = Xs - Xs.mean(axis=0, keepdims=True)
@@ -147,13 +156,13 @@ def compute_feature_spectrum(
     pc1_variance_ratio = float(proportions[0])
     pc10_variance_ratio = float(proportions[:10].sum())
 
-    feature_dim = Xs.shape[1]
-    if feature_dim == 1:
+    effective_dim = min(Xs.shape[1], Xs.shape[0] - 1)
+    if effective_dim <= 1:
         spectral_anisotropy = 0.0
     else:
         spectral_anisotropy = float(
             np.clip(
-                (feature_dim * pc1_variance_ratio - 1.0) / (feature_dim - 1.0),
+                (effective_dim * pc1_variance_ratio - 1.0) / (effective_dim - 1.0),
                 0.0,
                 1.0,
             )
@@ -239,6 +248,7 @@ def compute_intrinsic_dim(
     """
     if X.ndim != 2:
         raise ValueError(f"X must be 2D, got shape {X.shape}")
+    _validate_max_samples(max_samples)
     if not estimators:
         return {}
 

--- a/src/torchgeo_bench/intrinsic_dim.py
+++ b/src/torchgeo_bench/intrinsic_dim.py
@@ -4,6 +4,9 @@ Thin wrapper around ``torchid`` (https://github.com/isaaccorley/torchid).
 Provides a single entry point to compute one or more global ID estimates on a
 feature matrix and return scalar values per estimator.
 
+The module also provides dependency-free effective-rank, participation-ratio,
+variance-explained, and anisotropy diagnostics from centered embeddings.
+
 ID is computed on raw embeddings (no L2-normalization) to match the distance
 geometry used by KNN/linear probes elsewhere in this package.
 """
@@ -31,6 +34,18 @@ SUPPORTED_ESTIMATORS: tuple[str, ...] = (
     "DANCo",
     "FisherS",
 )
+
+FEATURE_SPECTRUM_METRICS: tuple[str, ...] = (
+    "effective_rank",
+    "participation_ratio",
+    "pc1_variance_ratio",
+    "pc10_variance_ratio",
+    "spectral_anisotropy",
+)
+
+
+class DegenerateSpectrumError(ValueError):
+    """Feature spectrum is undefined because the centered matrix has no variance."""
 
 
 def _load_estimator(name: str) -> type:
@@ -69,6 +84,88 @@ def _subsample(X: np.ndarray, max_samples: int | None, seed: int) -> np.ndarray:
     rng = np.random.default_rng(seed)
     idx = rng.choice(X.shape[0], size=max_samples, replace=False)
     return X[idx]
+
+
+def compute_feature_spectrum(
+    X: np.ndarray,
+    max_samples: int | None = 10_000,
+    seed: int = 0,
+) -> dict[str, float]:
+    """Compute scale-invariant spectral diagnostics on centered embeddings.
+
+    The squared singular values of the centered feature matrix are normalized
+    into variance proportions ``p``. Effective rank is ``exp(H(p))``;
+    participation ratio is ``1 / sum(p**2)``. Spectral anisotropy normalizes
+    leading-component dominance against the isotropic ``1 / d`` baseline:
+    ``(d * p[0] - 1) / (d - 1)``.
+
+    Args:
+        X: Feature matrix of shape ``(n_samples, n_features)``.
+        max_samples: Cap row count via deterministic random subsampling.
+            ``None`` disables subsampling.
+        seed: RNG seed for subsampling determinism.
+
+    Returns:
+        Mapping containing effective rank, participation ratio, variance
+        explained by PC1 and the first 10 PCs, and spectral anisotropy.
+
+    Raises:
+        ValueError: If the input is not a finite 2-D matrix with at least two
+            samples and one feature.
+        DegenerateSpectrumError: If centering leaves no feature variance.
+    """
+    if X.ndim != 2:
+        raise ValueError(f"X must be 2D, got shape {X.shape}")
+    if X.shape[0] < 2:
+        raise ValueError(f"X must contain at least two samples, got shape {X.shape}")
+    if X.shape[1] < 1:
+        raise ValueError(f"X must contain at least one feature, got shape {X.shape}")
+    if not np.isfinite(X).all():
+        raise ValueError("X must contain only finite values")
+    if max_samples is not None and (
+        isinstance(max_samples, bool) or not isinstance(max_samples, int) or max_samples < 2
+    ):
+        raise ValueError(
+            f"max_samples must be an integer of at least 2 or None, got {max_samples!r}"
+        )
+
+    Xs = np.asarray(_subsample(X, max_samples, seed), dtype=np.float64)
+    centered = Xs - Xs.mean(axis=0, keepdims=True)
+    singular_values = np.linalg.svd(centered, compute_uv=False, full_matrices=False)
+    variances = singular_values**2
+    total_variance = float(variances.sum())
+    if not np.isfinite(total_variance) or total_variance <= 0:
+        raise DegenerateSpectrumError(
+            "Feature spectrum is undefined: centering left zero total variance "
+            f"for X{tuple(Xs.shape)}."
+        )
+
+    proportions = variances / total_variance
+    positive = proportions[proportions > 0]
+    effective_rank = float(np.exp(-np.sum(positive * np.log(positive))))
+    participation_ratio = float(1.0 / np.sum(proportions**2))
+    pc1_variance_ratio = float(proportions[0])
+    pc10_variance_ratio = float(proportions[:10].sum())
+
+    feature_dim = Xs.shape[1]
+    if feature_dim == 1:
+        spectral_anisotropy = 0.0
+    else:
+        spectral_anisotropy = float(
+            np.clip(
+                (feature_dim * pc1_variance_ratio - 1.0) / (feature_dim - 1.0),
+                0.0,
+                1.0,
+            )
+        )
+
+    return {
+        "effective_rank": effective_rank,
+        "participation_ratio": participation_ratio,
+        "pc1_variance_ratio": pc1_variance_ratio,
+        "pc10_variance_ratio": pc10_variance_ratio,
+        "spectral_anisotropy": spectral_anisotropy,
+    }
 
 
 def _two_nearest_distances(X: torch.Tensor) -> torch.Tensor:

--- a/src/torchgeo_bench/main.py
+++ b/src/torchgeo_bench/main.py
@@ -24,7 +24,9 @@ from torchgeo_bench.datasets import (
     list_datasets,
 )
 from torchgeo_bench.intrinsic_dim import (
+    FEATURE_SPECTRUM_METRICS,
     DegenerateManifoldError,
+    DegenerateSpectrumError,
     compute_feature_spectrum,
     compute_intrinsic_dim,
 )
@@ -373,6 +375,7 @@ def evaluate_intrinsic_dim(
     feature_dim: int,
     n_counts: dict[str, int],
     verbose: bool = False,
+    only_metrics: frozenset[str] | None = None,
 ) -> list[dict]:
     """Compute intrinsic-dimension metrics over selected splits and return CSV rows.
 
@@ -381,6 +384,12 @@ def evaluate_intrinsic_dim(
     ``spectrum_<metric>_<split>`` name. All rows use
     ``method="intrinsic_dim"`` so they share the existing side-output and
     resume path.
+
+    ``only_metrics``, when given, restricts computation to metric names not
+    already present on disk -- resuming a run that's missing only the newer
+    spectrum rows shouldn't re-run the far more expensive torchid estimators
+    just to recompute rows that already exist and would be filtered out
+    anyway. ``None`` computes everything (a fresh, non-resumed run).
     """
     rows: list[dict] = []
     for split_name in selected_splits:
@@ -397,6 +406,8 @@ def evaluate_intrinsic_dim(
         # non-finite dimension, which would otherwise cost the other rows too.
         dims: dict[str, float] = {}
         for est_name in estimators:
+            if only_metrics is not None and f"id_{est_name}_{split_name}" not in only_metrics:
+                continue
             try:
                 dims.update(
                     compute_intrinsic_dim(
@@ -426,8 +437,26 @@ def evaluate_intrinsic_dim(
                     n_counts=n_counts,
                 )
             )
-        spectrum = compute_feature_spectrum(X, max_samples=max_samples, seed=seed)
+
+        spectrum_names = {f"spectrum_{metric}_{split_name}" for metric in FEATURE_SPECTRUM_METRICS}
+        if only_metrics is not None and only_metrics.isdisjoint(spectrum_names):
+            continue
+        try:
+            spectrum = compute_feature_spectrum(X, max_samples=max_samples, seed=seed)
+        except DegenerateSpectrumError as exc:
+            logger.warning(
+                f"[intrinsic-dim] spectrum split={split_name} model={common_meta.get('model')} "
+                f"dataset={common_meta.get('dataset')} bands={common_meta.get('bands')} "
+                f"norm={common_meta.get('normalization')}: degenerate features, writing NaN. "
+                f"Diagnostic: {exc}"
+            )
+            spectrum = {metric: float("nan") for metric in FEATURE_SPECTRUM_METRICS}
         for metric_name, value in spectrum.items():
+            if (
+                only_metrics is not None
+                and f"spectrum_{metric_name}_{split_name}" not in only_metrics
+            ):
+                continue
             rows.append(
                 metric_row(
                     common_meta,
@@ -1009,6 +1038,7 @@ def main(cfg: DictConfig) -> None:
                     feature_dim=feature_dim,
                     n_counts=n_counts,
                     verbose=cfg.verbose,
+                    only_metrics=plan.id_missing_metrics if cfg.resume else None,
                 )
                 if cfg.resume:
                     id_rows = _filter_completed_metric_rows(id_rows, completed_metrics, key_cols)

--- a/src/torchgeo_bench/main.py
+++ b/src/torchgeo_bench/main.py
@@ -23,7 +23,11 @@ from torchgeo_bench.datasets import (
     get_datasets,
     list_datasets,
 )
-from torchgeo_bench.intrinsic_dim import DegenerateManifoldError, compute_intrinsic_dim
+from torchgeo_bench.intrinsic_dim import (
+    DegenerateManifoldError,
+    compute_feature_spectrum,
+    compute_intrinsic_dim,
+)
 from torchgeo_bench.knn import KNNClassifier, resolve_knn_device
 from torchgeo_bench.linear import LogisticRegression
 from torchgeo_bench.model_profile import measure_cpu_throughput, measure_profile
@@ -372,8 +376,11 @@ def evaluate_intrinsic_dim(
 ) -> list[dict]:
     """Compute intrinsic-dimension metrics over selected splits and return CSV rows.
 
-    Each (split, estimator) yields one row with ``method="intrinsic_dim"`` and
-    ``metric_name=f"id_{estimator}_{split}"``.
+    Each (split, estimator) yields one ``id_<estimator>_<split>`` row. Five
+    centered feature-spectrum diagnostics are also emitted per split with a
+    ``spectrum_<metric>_<split>`` name. All rows use
+    ``method="intrinsic_dim"`` so they share the existing side-output and
+    resume path.
     """
     rows: list[dict] = []
     for split_name in selected_splits:
@@ -415,6 +422,18 @@ def evaluate_intrinsic_dim(
                     method="intrinsic_dim",
                     metric_name=f"id_{est_name}_{split_name}",
                     metric_value=float(dim),
+                    feature_dim=feature_dim,
+                    n_counts=n_counts,
+                )
+            )
+        spectrum = compute_feature_spectrum(X, max_samples=max_samples, seed=seed)
+        for metric_name, value in spectrum.items():
+            rows.append(
+                metric_row(
+                    common_meta,
+                    method="intrinsic_dim",
+                    metric_name=f"spectrum_{metric_name}_{split_name}",
+                    metric_value=value,
                     feature_dim=feature_dim,
                     n_counts=n_counts,
                 )

--- a/src/torchgeo_bench/resume.py
+++ b/src/torchgeo_bench/resume.py
@@ -14,6 +14,8 @@ from dataclasses import dataclass
 import pandas as pd
 from omegaconf import DictConfig, OmegaConf
 
+from torchgeo_bench.intrinsic_dim import FEATURE_SPECTRUM_METRICS
+
 logger = logging.getLogger(__name__)
 
 KEY_COLS = (
@@ -226,11 +228,13 @@ def _plan_dataset_run(
 
     id_cfg = getattr(cfg.eval, "intrinsic_dim", None)
     id_enabled = bool(id_cfg and id_cfg.get("enabled", False))
-    id_metric_names = (
-        [f"id_{est}_{split}" for split in id_cfg.splits for est in id_cfg.estimators]
-        if id_enabled
-        else []
-    )
+    id_metric_names = []
+    if id_enabled:
+        for split in id_cfg.splits:
+            id_metric_names.extend(f"id_{est}_{split}" for est in id_cfg.estimators)
+            id_metric_names.extend(
+                f"spectrum_{metric}_{split}" for metric in FEATURE_SPECTRUM_METRICS
+            )
     skip_id = (not id_enabled) or bool(
         cfg.resume
         and id_metric_names

--- a/src/torchgeo_bench/resume.py
+++ b/src/torchgeo_bench/resume.py
@@ -192,6 +192,7 @@ class DatasetRunPlan:
     skip_linear: bool
     skip_id: bool
     skip_profile: bool
+    id_missing_metrics: frozenset[str] = frozenset()
 
 
 def _plan_dataset_run(
@@ -235,11 +236,15 @@ def _plan_dataset_run(
             id_metric_names.extend(
                 f"spectrum_{metric}_{split}" for metric in FEATURE_SPECTRUM_METRICS
             )
-    skip_id = (not id_enabled) or bool(
-        cfg.resume
-        and id_metric_names
-        and all(id_key in completed_metrics.get(metric, set()) for metric in id_metric_names)
+    # Per-metric, not just per-dataset: a run that already has its (expensive)
+    # torchid estimator rows but is missing only the (cheap) newer spectrum
+    # rows shouldn't have to redo the estimators just to backfill the rest.
+    id_missing_metrics = frozenset(
+        metric
+        for metric in id_metric_names
+        if not (cfg.resume and id_key in completed_metrics.get(metric, set()))
     )
+    skip_id = (not id_enabled) or bool(id_metric_names and not id_missing_metrics)
 
     profile_cfg = getattr(cfg.eval, "profile", None)
     profile_enabled = bool(profile_cfg and profile_cfg.get("enabled", False))
@@ -259,4 +264,5 @@ def _plan_dataset_run(
         skip_linear=skip_linear,
         skip_id=skip_id,
         skip_profile=skip_profile,
+        id_missing_metrics=id_missing_metrics,
     )

--- a/tests/test_intrinsic_dim.py
+++ b/tests/test_intrinsic_dim.py
@@ -9,11 +9,14 @@ import pytest
 import torch
 
 from torchgeo_bench.intrinsic_dim import (
+    FEATURE_SPECTRUM_METRICS,
     DegenerateManifoldError,
+    DegenerateSpectrumError,
     _drop_zero_distance_rows,
     _load_estimator,
     _resolve_device,
     _subsample,
+    compute_feature_spectrum,
     compute_intrinsic_dim,
 )
 
@@ -75,6 +78,76 @@ class TestComputeBasic:
     def test_empty_estimator_list_returns_empty(self) -> None:
         out = compute_intrinsic_dim(np.zeros((10, 3)), estimators=[])
         assert out == {}
+
+
+class TestFeatureSpectrum:
+    def test_isotropic_features(self) -> None:
+        X = np.vstack([np.eye(4), -np.eye(4)])
+
+        metrics = compute_feature_spectrum(X, max_samples=None)
+
+        assert set(metrics) == set(FEATURE_SPECTRUM_METRICS)
+        assert metrics["effective_rank"] == pytest.approx(4.0)
+        assert metrics["participation_ratio"] == pytest.approx(4.0)
+        assert metrics["pc1_variance_ratio"] == pytest.approx(0.25)
+        assert metrics["pc10_variance_ratio"] == pytest.approx(1.0)
+        assert metrics["spectral_anisotropy"] == pytest.approx(0.0)
+
+    def test_rank_one_features(self) -> None:
+        samples = np.arange(-3, 4, dtype=np.float64)
+        direction = np.array([1.0, -2.0, 3.0, 0.5])
+        X = np.outer(samples, direction)
+
+        metrics = compute_feature_spectrum(X, max_samples=None)
+
+        assert metrics["effective_rank"] == pytest.approx(1.0)
+        assert metrics["participation_ratio"] == pytest.approx(1.0)
+        assert metrics["pc1_variance_ratio"] == pytest.approx(1.0)
+        assert metrics["pc10_variance_ratio"] == pytest.approx(1.0)
+        assert metrics["spectral_anisotropy"] == pytest.approx(1.0)
+
+    def test_known_low_rank_spectrum(self) -> None:
+        X = np.zeros((6, 12), dtype=np.float64)
+        X[0:2, 0] = [3.0, -3.0]
+        X[2:4, 1] = [2.0, -2.0]
+        X[4:6, 2] = [1.0, -1.0]
+        proportions = np.array([9.0, 4.0, 1.0]) / 14.0
+
+        metrics = compute_feature_spectrum(X + 100.0, max_samples=None)
+
+        expected_effective_rank = np.exp(-np.sum(proportions * np.log(proportions)))
+        expected_participation_ratio = 1.0 / np.sum(proportions**2)
+        expected_anisotropy = (12 * proportions[0] - 1) / 11
+        assert metrics["effective_rank"] == pytest.approx(expected_effective_rank)
+        assert metrics["participation_ratio"] == pytest.approx(expected_participation_ratio)
+        assert metrics["pc1_variance_ratio"] == pytest.approx(proportions[0])
+        assert metrics["pc10_variance_ratio"] == pytest.approx(1.0)
+        assert metrics["spectral_anisotropy"] == pytest.approx(expected_anisotropy)
+
+    @pytest.mark.parametrize(
+        "X,match",
+        [
+            (np.ones((5, 3)), "zero total variance"),
+            (np.ones((1, 3)), "at least two samples"),
+            (np.array([[0.0, np.nan], [1.0, 2.0]]), "finite values"),
+        ],
+    )
+    def test_degenerate_inputs_fail_clearly(self, X: np.ndarray, match: str) -> None:
+        error = DegenerateSpectrumError if "zero total variance" in match else ValueError
+        with pytest.raises(error, match=match):
+            compute_feature_spectrum(X, max_samples=None)
+
+    def test_subsampling_is_deterministic(self) -> None:
+        X = np.random.default_rng(0).normal(size=(100, 8))
+        first = compute_feature_spectrum(X, max_samples=20, seed=17)
+        second = compute_feature_spectrum(X, max_samples=20, seed=17)
+
+        assert first == second
+
+    def test_subsampling_requires_two_samples(self) -> None:
+        X = np.random.default_rng(0).normal(size=(10, 3))
+        with pytest.raises(ValueError, match="at least 2"):
+            compute_feature_spectrum(X, max_samples=1)
 
 
 # ---- error paths (mocked torchid) ----------------------------------------

--- a/tests/test_intrinsic_dim.py
+++ b/tests/test_intrinsic_dim.py
@@ -79,6 +79,13 @@ class TestComputeBasic:
         out = compute_intrinsic_dim(np.zeros((10, 3)), estimators=[])
         assert out == {}
 
+    def test_rejects_invalid_max_samples_same_as_feature_spectrum(self) -> None:
+        # compute_feature_spectrum validates max_samples explicitly; without
+        # the same check here, a bad value (e.g. a negative int) would just
+        # silently misbehave in _subsample instead of failing clearly.
+        with pytest.raises(ValueError, match="max_samples must be an integer"):
+            compute_intrinsic_dim(np.zeros((10, 3)), estimators=[], max_samples=-1)
+
 
 class TestFeatureSpectrum:
     def test_isotropic_features(self) -> None:
@@ -115,10 +122,13 @@ class TestFeatureSpectrum:
         assert metrics["spectral_anisotropy"] == pytest.approx(0.0)
 
     def test_known_low_rank_spectrum(self) -> None:
-        X = np.zeros((6, 12), dtype=np.float64)
-        X[0:2, 0] = [3.0, -3.0]
-        X[2:4, 1] = [2.0, -2.0]
-        X[4:6, 2] = [1.0, -1.0]
+        # n - 1 = 17 >= d = 12 here, so effective_dim == d and the ambient
+        # feature dimension is the binding constraint on anisotropy.
+        block = np.zeros((6, 12), dtype=np.float64)
+        block[0:2, 0] = [3.0, -3.0]
+        block[2:4, 1] = [2.0, -2.0]
+        block[4:6, 2] = [1.0, -1.0]
+        X = np.tile(block, (3, 1))
         proportions = np.array([9.0, 4.0, 1.0]) / 14.0
 
         metrics = compute_feature_spectrum(X + 100.0, max_samples=None)
@@ -158,6 +168,20 @@ class TestFeatureSpectrum:
         X = np.random.default_rng(0).normal(size=(10, 3))
         with pytest.raises(ValueError, match="at least 2"):
             compute_feature_spectrum(X, max_samples=1)
+
+    def test_small_split_isotropic_still_maps_to_zero(self) -> None:
+        # n=6 rows in d=64 ambient features: after centering, only n - 1 = 5
+        # singular values are nonzero. Centered standard-basis rows are a
+        # regular simplex -- equidistant, so those 5 singular values are
+        # exactly equal (isotropic). Normalizing by the raw feature dimension
+        # d=64 instead of effective_dim = min(d, n - 1) = 5 would give this an
+        # anisotropy floor well above zero, even though it's isotropic.
+        X = np.zeros((6, 64))
+        X[:, :6] = np.eye(6)
+
+        metrics = compute_feature_spectrum(X, max_samples=None)
+
+        assert metrics["spectral_anisotropy"] == pytest.approx(0.0, abs=1e-9)
 
 
 # ---- error paths (mocked torchid) ----------------------------------------

--- a/tests/test_intrinsic_dim.py
+++ b/tests/test_intrinsic_dim.py
@@ -106,6 +106,14 @@ class TestFeatureSpectrum:
         assert metrics["pc10_variance_ratio"] == pytest.approx(1.0)
         assert metrics["spectral_anisotropy"] == pytest.approx(1.0)
 
+    def test_single_feature_uses_zero_anisotropy_convention(self) -> None:
+        X = np.arange(5, dtype=np.float64)[:, None]
+
+        metrics = compute_feature_spectrum(X, max_samples=None)
+
+        assert metrics["effective_rank"] == pytest.approx(1.0)
+        assert metrics["spectral_anisotropy"] == pytest.approx(0.0)
+
     def test_known_low_rank_spectrum(self) -> None:
         X = np.zeros((6, 12), dtype=np.float64)
         X[0:2, 0] = [3.0, -3.0]
@@ -127,6 +135,8 @@ class TestFeatureSpectrum:
     @pytest.mark.parametrize(
         "X,match",
         [
+            (np.ones(5), "2D"),
+            (np.empty((2, 0)), "at least one feature"),
             (np.ones((5, 3)), "zero total variance"),
             (np.ones((1, 3)), "at least two samples"),
             (np.array([[0.0, np.nan], [1.0, 2.0]]), "finite values"),

--- a/tests/test_main_intrinsic_dim_fast.py
+++ b/tests/test_main_intrinsic_dim_fast.py
@@ -44,6 +44,43 @@ def test_intrinsic_dim_rows_emitted(tmp_path: Path):
     assert not id_df.empty
     assert "id_twonn_train" in id_df["metric_name"].values
     assert "id_mle_train" in id_df["metric_name"].values
+    assert {
+        "spectrum_effective_rank_train",
+        "spectrum_participation_ratio_train",
+        "spectrum_pc1_variance_ratio_train",
+        "spectrum_pc10_variance_ratio_train",
+        "spectrum_spectral_anisotropy_train",
+    }.issubset(set(id_df["metric_name"]))
+
+
+def test_spectrum_rows_do_not_require_torchid_estimators(tmp_path: Path):
+    out = tmp_path / "out.csv"
+    cfg = _compose_cfg(
+        out,
+        overrides=[
+            "eval.skip_linear=true",
+            "eval.intrinsic_dim.enabled=true",
+            "eval.intrinsic_dim.estimators=[]",
+            "eval.intrinsic_dim.splits=[train]",
+            "eval.intrinsic_dim.max_samples=100",
+        ],
+    )
+
+    with (
+        mock.patch("torchgeo_bench.main.get_datasets", return_value=_synthetic_loaders()),
+        mock.patch("torchgeo_bench.main.embed_split", side_effect=_synthetic_embeddings()),
+        mock.patch(
+            "torchgeo_bench.main.evaluate_knn",
+            return_value=(0.5, 0.45, 0.55, {"ece": 0.05, "rms_ce": 0.07, "mce": 0.1}, 6),
+        ),
+        mock.patch("torchgeo_bench.main.compute_intrinsic_dim") as id_mock,
+    ):
+        main(cfg)
+
+    id_mock.assert_not_called()
+    df = pd.read_csv(out)
+    spectrum_rows = df[df["metric_name"].str.startswith("spectrum_")]
+    assert len(spectrum_rows) == 5
 
 
 def test_intrinsic_dim_resume_per_estimator(tmp_path: Path):
@@ -63,6 +100,11 @@ def test_intrinsic_dim_resume_per_estimator(tmp_path: Path):
     seed_rows = [
         _resume_row(cfg, method="knn5", metric_name="accuracy"),
         _resume_row(cfg, method="intrinsic_dim", metric_name="id_twonn_train"),
+        _resume_row(
+            cfg,
+            method="intrinsic_dim",
+            metric_name="spectrum_effective_rank_train",
+        ),
     ]
     pd.DataFrame(seed_rows).to_csv(out, index=False)
 
@@ -86,3 +128,5 @@ def test_intrinsic_dim_resume_per_estimator(tmp_path: Path):
     id_df = df[df["method"] == "intrinsic_dim"]
     assert int((id_df["metric_name"] == "id_twonn_train").sum()) == 1
     assert int((id_df["metric_name"] == "id_mle_train").sum()) == 1
+    assert int((id_df["metric_name"] == "spectrum_effective_rank_train").sum()) == 1
+    assert len(id_df[id_df["metric_name"].str.startswith("spectrum_")]) == 5

--- a/tests/test_main_intrinsic_dim_fast.py
+++ b/tests/test_main_intrinsic_dim_fast.py
@@ -3,9 +3,10 @@
 from pathlib import Path
 from unittest import mock
 
+import numpy as np
 import pandas as pd
 
-from torchgeo_bench.main import main
+from torchgeo_bench.main import evaluate_intrinsic_dim, main
 
 from .test_main_fast import _compose_cfg, _resume_row, _synthetic_embeddings, _synthetic_loaders
 
@@ -83,6 +84,52 @@ def test_spectrum_rows_do_not_require_torchid_estimators(tmp_path: Path):
     assert len(spectrum_rows) == 5
 
 
+def test_degenerate_spectrum_writes_nan_and_keeps_other_splits(caplog) -> None:
+    # A degenerate split (e.g. constant embeddings) used to propagate a
+    # DegenerateSpectrumError straight out of evaluate_intrinsic_dim, which
+    # would abort the whole sweep and lose every row already computed for
+    # other datasets/models. It should instead behave like the existing
+    # per-estimator DegenerateManifoldError handling: warn and write NaN.
+    good_X = np.random.default_rng(0).normal(size=(20, 8))
+    degenerate_X = np.ones((20, 8))  # zero variance after centering
+    common_meta = {
+        "dataset": "d",
+        "model": "m",
+        "name": "m",
+        "normalization": "n",
+        "image_size": None,
+        "interpolation": "bilinear",
+        "partition": "default",
+        "bands": "rgb",
+        "num_classes": 2,
+        "config_hash": "abc123",
+        "c_range_start": -6,
+        "c_range_stop": 4,
+        "c_range_num": 40,
+        "merge_val": True,
+        "bootstrap": 200,
+        "seed": 0,
+    }
+
+    with caplog.at_level("WARNING"):
+        rows = evaluate_intrinsic_dim(
+            splits={"train": good_X, "val": degenerate_X},
+            estimators=[],
+            selected_splits=["train", "val"],
+            device="cpu",
+            max_samples=None,
+            seed=0,
+            common_meta=common_meta,
+            feature_dim=8,
+            n_counts={},
+        )
+
+    by_split = {row["metric_name"]: row["metric_value"] for row in rows}
+    assert by_split["spectrum_effective_rank_train"] > 0
+    assert np.isnan(by_split["spectrum_effective_rank_val"])
+    assert "degenerate features, writing NaN" in caplog.text
+
+
 def test_intrinsic_dim_resume_per_estimator(tmp_path: Path):
     out = tmp_path / "out.csv"
     cfg = _compose_cfg(
@@ -129,4 +176,48 @@ def test_intrinsic_dim_resume_per_estimator(tmp_path: Path):
     assert int((id_df["metric_name"] == "id_twonn_train").sum()) == 1
     assert int((id_df["metric_name"] == "id_mle_train").sum()) == 1
     assert int((id_df["metric_name"] == "spectrum_effective_rank_train").sum()) == 1
+    assert len(id_df[id_df["metric_name"].str.startswith("spectrum_")]) == 5
+
+
+def test_resume_backfills_spectrum_without_rerunning_completed_estimators(tmp_path: Path):
+    # A run finished under #223, before spectrum rows existed, has both
+    # torchid estimator rows already but neither is expensive to redo here
+    # in the test -- assert compute_intrinsic_dim isn't even called, so a
+    # resumed sweep of many already-finished models doesn't silently redo
+    # the (real-world) expensive TwoNN/MLE/lPCA passes just to backfill 5
+    # cheap spectrum values.
+    out = tmp_path / "out.csv"
+    cfg = _compose_cfg(
+        out,
+        overrides=[
+            "resume=true",
+            "eval.skip_linear=true",
+            "eval.intrinsic_dim.enabled=true",
+            "eval.intrinsic_dim.estimators=[twonn,mle]",
+            "eval.intrinsic_dim.splits=[train]",
+            "eval.intrinsic_dim.max_samples=100",
+        ],
+    )
+
+    seed_rows = [
+        _resume_row(cfg, method="knn5", metric_name="accuracy"),
+        _resume_row(cfg, method="intrinsic_dim", metric_name="id_twonn_train"),
+        _resume_row(cfg, method="intrinsic_dim", metric_name="id_mle_train"),
+    ]
+    pd.DataFrame(seed_rows).to_csv(out, index=False)
+
+    with (
+        mock.patch("torchgeo_bench.main.get_datasets", return_value=_synthetic_loaders()),
+        mock.patch("torchgeo_bench.main.embed_split", side_effect=_synthetic_embeddings()),
+        mock.patch(
+            "torchgeo_bench.main.evaluate_knn",
+            return_value=(0.5, 0.45, 0.55, {"ece": 0.05, "rms_ce": 0.07, "mce": 0.1}, 6),
+        ),
+        mock.patch("torchgeo_bench.main.compute_intrinsic_dim") as id_mock,
+    ):
+        main(cfg)
+
+    id_mock.assert_not_called()
+    df = pd.read_csv(out)
+    id_df = df[df["method"] == "intrinsic_dim"]
     assert len(id_df[id_df["metric_name"].str.startswith("spectrum_")]) == 5


### PR DESCRIPTION
## Summary

Fixes #172.

- compute effective rank, participation ratio, PC1/PC10 variance ratios, and a normalized spectral-anisotropy score from centered embeddings
- emit the five diagnostics per selected split through the existing intrinsic-dimension CSV and resume path
- support dependency-free spectrum-only runs with `eval.intrinsic_dim.estimators=[]`
- document every formula, output name, sampling behavior, and degenerate-input policy

## Design

For centered embeddings, squared singular values are normalized to variance proportions `p`:

- effective rank: `exp(-sum(p * log(p)))`
- participation ratio: `1 / sum(p**2)`
- PC1/PC10 ratios: `p[0]` and `sum(p[:10])`
- spectral anisotropy: `(d * p[0] - 1) / (d - 1)`, mapping an isotropic `d`-dimensional spectrum to 0 and a rank-one spectrum to 1 (with a documented 0 convention for `d == 1`)

The implementation uses the intrinsic-dimension branch's deterministic `max_samples`/seed settings. Non-finite matrices, insufficient samples, invalid sample caps, and zero centered variance fail explicitly instead of writing a plausible value.

Existing `method="intrinsic_dim"` routing is retained so this remains one embedding-diagnostics path rather than a parallel output framework. Resume completeness now requires all five spectrum rows and the per-row filter prevents duplicates after partial runs.

## Validation

- `uv run pytest --no-cov -q`: 445 passed, 54 skipped, 86 slow tests deselected
- focused intrinsic-dimension/output/resume tests: 29 passed, 10 optional-`torchid` tests skipped
- synthetic coverage includes exactly isotropic, rank-one, and known low-rank spectra, plus translation invariance, deterministic subsampling, non-finite input, insufficient input, and zero variance
- `uv run ruff check .`: passed
- `uv run ruff format --check .`: passed
- `uv run --extra docs sphinx-build -W --keep-going -b html docs docs/_build/html`: passed with zero warnings
- `git diff --check`: passed

## AI assistance disclosure

OpenAI Codex assisted with implementation and test execution. I reviewed the formulas, diff, generated CSV rows, and documentation and can respond to review feedback.
