### PR TITLE
Fix 3 real model bugs surfaced by a multispectral coverage gap analysis

### DIFF
--- a/docs/user/models.rst
+++ b/docs/user/models.rst
@@ -222,6 +222,58 @@ SAM 3 vision encoder
    $ pip install 'torchgeo-bench[sam3]'
    $ torchgeo-bench run model=sam3_encoder dataset.bands=[red,green,blue]
 
+.. _multispectral-coverage-gaps:
+
+Multispectral coverage gaps
+----------------------------
+
+Most models run cleanly on every classification dataset with
+``dataset.bands=all``.  A few combinations fail for reasons that are
+capability limits rather than missing sweeps -- running them again will
+not help:
+
+* **``model_native`` normalization on mixed-sensor bands.**  ``benv2``,
+  ``so2sat``, ``m-so2sat``, and ``forestnet`` mix Sentinel-1 SAR with
+  Sentinel-2 optical bands (or, for ``forestnet``, aerial NAIP as well),
+  each at a different native scale.  ``model_native`` normalization needs
+  one input unit for the whole tensor and correctly refuses to guess one
+  across sensors.  ``bandspec_zscore`` has no such restriction and covers
+  these datasets fine.
+* **Scale-MAE is RGB-only by construction.**  ``FMOW_RGB`` requires
+  exactly three ordered RGB bands and rejects any other input outright,
+  so it has no multispectral path at all.
+
+Three other gaps looked like the same kind of permanent limit but turned
+out to be fixable, and are handled automatically now:
+
+* **OlmoEarth's SAR sensor tag.**  Datasets declare Sentinel-1 bands under
+  either ``sensor="s1"`` (so2sat, benv2, treesatai) or ``sensor="sar"``
+  (m-so2sat, kuro_siwo) -- OlmoEarth's own pretraining does cover
+  Sentinel-1, the wrapper's sensor-layout table just only had the
+  ``"sar"`` key registered.  ``"s1"`` is now an alias for the same
+  layout.
+* **A missing ``coastal`` band.**  Most GeoBench Sentinel-2 datasets
+  don't ship a coastal-aerosol band, which CROMA requires.  Rather than
+  zero-filling or raising, ``torchgeo_bench.models._band_mapping.map_to_model_bands``
+  now substitutes the spectrally-nearest available band by default --
+  blue (0.49 um) for coastal aerosol (0.443 um) -- an approximation, not
+  the real band, but a better stand-in than zero.  Override or disable
+  via its ``band_fallbacks`` argument.
+* **A dataset's optical bands with no ``wavelength_um`` set.**  DOFA and
+  Panopticon need a wavelength per channel; a Landsat dataset that never
+  bothered declaring one (most datasets here are Sentinel-2 anyway) now
+  falls back to the true Sentinel-2 centre wavelength for that band name
+  via ``torchgeo_bench.models._band_mapping.S2_WAVELENGTHS_UM``,
+  close enough to be useful (Landsat nir is 0.865 um vs. Sentinel-2's
+  0.842 um) rather than a hard stop. SAR bands still have no optical
+  wavelength to fall back to and raise unless the caller passes one
+  explicitly -- see the SAR-specific placeholder in
+  ``torchgeo_bench.models.torchgeo_models._resolve_dofa_wavelengths``.
+
+Closing any of these needs a design decision or a small feature (a
+mixed-unit policy for ``model_native``, an OlmoEarth SAR layout, a
+per-dataset wavelength fix) rather than another backfill run.
+
 Adding a new model
 ------------------
 

--- a/src/torchgeo_bench/models/_band_mapping.py
+++ b/src/torchgeo_bench/models/_band_mapping.py
@@ -84,6 +84,30 @@ _BAND_ALIASES: dict[str, str] = {
     **_SAR,
 }
 
+#: True Sentinel-2 (MSI) centre wavelengths in micrometres, by canonical band
+#: name -- the same constants already hardcoded per-dataset in
+#: ``datasets/eurosat.py`` and similar. Most classification datasets here are
+#: Sentinel-2 derived, so this is the right default for any dataset that
+#: doesn't ship its own ``wavelength_um`` (e.g. a Landsat dataset's nir/swir
+#: bands are close enough in practice to be a useful fallback, not exact --
+#: see ``wavelengths_um``'s docstring). Values: ESA Sentinel-2 MSI spectral
+#: response, S2A center wavelengths.
+S2_WAVELENGTHS_UM: dict[str, float] = {
+    "coastal": 0.443,
+    "blue": 0.490,
+    "green": 0.560,
+    "red": 0.665,
+    "rededge1": 0.705,
+    "rededge2": 0.740,
+    "rededge3": 0.783,
+    "nir": 0.842,
+    "nir_narrow": 0.865,
+    "watervapor": 0.945,
+    "cirrus": 1.375,
+    "swir1": 1.610,
+    "swir2": 2.190,
+}
+
 
 def canonical_band_name(name: str) -> str:
     """Map an input band name to the canonical short name."""
@@ -145,6 +169,15 @@ def select_src_bands(
     return indices, selected
 
 
+#: When a target band is absent, substitute this spectrally-nearest
+#: neighbor's data instead of zero-filling or raising. Coastal aerosol
+#: (0.443 um) is the only band this currently applies to -- it sits right
+#: next to blue (0.49 um) in the spectrum, and a real (if approximate) blue
+#: reading is a better stand-in for a required "coastal" slot than a zeroed
+#: channel. Callers can override or disable via ``band_fallbacks``.
+DEFAULT_BAND_FALLBACKS: dict[str, str] = {"coastal": "blue"}
+
+
 def map_to_model_bands(
     images: torch.Tensor,
     src_bands: list[BandSpec],
@@ -152,11 +185,19 @@ def map_to_model_bands(
     *,
     allow_missing: bool = False,
     preferred_sensors: tuple[str, ...] = (),
+    band_fallbacks: dict[str, str] | None = None,
 ) -> tuple[torch.Tensor, list[bool]]:
     """Rearrange ``images`` from src band order to ``target_band_names``, zero-filling gaps.
 
+    A target band missing from ``src_bands`` first tries
+    ``band_fallbacks`` (default :data:`DEFAULT_BAND_FALLBACKS`) -- copying a
+    spectrally-nearest neighbor's real data -- before falling through to
+    zero-fill (``allow_missing=True``) or raising. Pass ``band_fallbacks={}``
+    to disable.
+
     Returns ``(mapped, missing)`` where ``missing[i]`` is True iff slot
-    ``i`` was zero-filled.
+    ``i`` was zero-filled (a fallback-substituted slot is *not* counted as
+    missing, since it carries real, if approximate, data).
     """
     if images.shape[1] != len(src_bands):
         raise ValueError(
@@ -164,12 +205,24 @@ def map_to_model_bands(
             f"src_bands has {len(src_bands)} entries."
         )
     src_index = resolve_src_indices(src_bands, preferred_sensors=preferred_sensors)
+    fallbacks = DEFAULT_BAND_FALLBACKS if band_fallbacks is None else band_fallbacks
 
     B, _, H, W = images.shape
     out = torch.zeros(B, len(target_band_names), H, W, device=images.device, dtype=images.dtype)
     missing: list[bool] = []
     for j, name in enumerate(target_band_names):
-        idx = src_index.get(canonical_band_name(name))
+        canon = canonical_band_name(name)
+        idx = src_index.get(canon)
+        if idx is None and canon in fallbacks:
+            fallback_idx = src_index.get(canonical_band_name(fallbacks[canon]))
+            if fallback_idx is not None:
+                logger.warning(
+                    "map_to_model_bands: %r missing from source bands; substituting %r "
+                    "(spectrally nearest available band) instead of zero-fill.",
+                    name,
+                    fallbacks[canon],
+                )
+                idx = fallback_idx
         if idx is None:
             if not allow_missing:
                 available = [canonical_band_name(b.name) for b in src_bands]
@@ -187,15 +240,31 @@ def map_to_model_bands(
 def wavelengths_um(bands: list[BandSpec], default_um: float | None = None) -> list[float]:
     """Return per-band centre wavelengths in micrometres.
 
-    Missing wavelengths raise by default. Passing ``default_um`` is an explicit
-    opt-in for callers running a known fallback ablation.
+    A band missing ``wavelength_um`` (e.g. a Landsat dataset that didn't
+    bother declaring it, since most datasets here are Sentinel-2) falls back
+    to :data:`S2_WAVELENGTHS_UM` by canonical band name -- most datasets
+    genuinely are Sentinel-2, and even for Landsat the true wavelengths are
+    close enough (nir 0.842 vs. ~0.865 um) to be a useful default rather than
+    a hard stop. Only a band whose canonical name has no known S2 wavelength
+    either (e.g. SAR) raises, unless the caller passes an explicit
+    ``default_um`` for that case.
     """
-    missing = [b.name for b in bands if b.wavelength_um is None]
-    if missing and default_um is None:
-        raise ValueError(
-            f"Missing wavelengths for {missing}. Pass explicit wavelengths or default_um "
-            "only for a deliberate fallback ablation."
-        )
-    return [
-        float(b.wavelength_um) if b.wavelength_um is not None else float(default_um) for b in bands
+    still_missing = [
+        b.name
+        for b in bands
+        if b.wavelength_um is None and canonical_band_name(b.name) not in S2_WAVELENGTHS_UM
     ]
+    if still_missing and default_um is None:
+        raise ValueError(
+            f"Missing wavelengths for {still_missing}: not in S2_WAVELENGTHS_UM either. "
+            "Pass explicit wavelengths or default_um only for a deliberate fallback ablation."
+        )
+    resolved = []
+    for b in bands:
+        if b.wavelength_um is not None:
+            resolved.append(float(b.wavelength_um))
+        elif canonical_band_name(b.name) in S2_WAVELENGTHS_UM:
+            resolved.append(S2_WAVELENGTHS_UM[canonical_band_name(b.name)])
+        else:
+            resolved.append(float(default_um))
+    return resolved

--- a/src/torchgeo_bench/models/olmoearth.py
+++ b/src/torchgeo_bench/models/olmoearth.py
@@ -178,6 +178,10 @@ _MODALITY_INFO: dict[str, dict] = {
             "vh_lee": 1,
             "vh_lee_real": 1,
             "vh_lee_imag": 1,
+            # treesatai's derived VV/VH ratio band -- not a real physical
+            # channel, so it wins whichever slot it lands on (vh, matching
+            # the existing "later variant overwrites" convention above).
+            "vv_vh": 1,
         },
     },
     # NAIP / aerial: no dedicated OlmoEarth modality, route RGB through

--- a/src/torchgeo_bench/models/olmoearth.py
+++ b/src/torchgeo_bench/models/olmoearth.py
@@ -200,6 +200,10 @@ _MODALITY_INFO: dict[str, dict] = {
     },
 }
 _MODALITY_INFO["naip"] = _MODALITY_INFO["aerial"]
+# Datasets declare Sentinel-1 SAR bands under either sensor tag ("s1" in
+# so2sat/benv2/treesatai, "sar" in m_so2sat/kuro_siwo) -- both route to the
+# same OlmoEarth Sentinel-1 modality.
+_MODALITY_INFO["s1"] = _MODALITY_INFO["sar"]
 
 
 # Canonical GSD (meters) per sensor for OlmoEarth's positional encodings.
@@ -207,6 +211,7 @@ _MODALITY_INFO["naip"] = _MODALITY_INFO["aerial"]
 _SENSOR_INPUT_RES: dict[str, int] = {
     "s2": 10,
     "sar": 10,  # S1 coregistered to S2 10 m grid in OlmoEarth pretraining
+    "s1": 10,  # same modality, dataset-declared under the "s1" sensor tag
     "landsat": 30,
     "aerial": 1,
     "naip": 1,
@@ -217,7 +222,7 @@ _SENSOR_INPUT_RES: dict[str, int] = {
 # (Lee-filtered max ~10 000) and the S1 Normalizer expects the original scale.
 # detect_input_unit returns S2_DN for them, making to_s2_dn a no-op anyway,
 # but being explicit avoids surprises if the heuristic ever changes.
-_PASSTHROUGH_SENSORS: frozenset[str] = frozenset({"sar"})
+_PASSTHROUGH_SENSORS: frozenset[str] = frozenset({"sar", "s1"})
 
 # Sensors normalized with dataset (BandSpec) stats rather than OlmoEarth's
 # pretrained normalizer when ``norm_from_pretrained="auto"`` (the default).
@@ -338,7 +343,7 @@ class OlmoEarthBenchModel(BenchModel):
 
     * ``"s2"`` -> ``Modality.SENTINEL2_L2A`` (12 channels, 3 band-sets)
     * ``"landsat"`` -> ``Modality.LANDSAT`` (11 channels, 2 band-sets)
-    * ``"sar"`` -> ``Modality.SENTINEL1`` (2 channels, 1 band-set)
+    * ``"sar"`` / ``"s1"`` -> ``Modality.SENTINEL1`` (2 channels, 1 band-set)
     * ``"aerial"`` / ``"naip"`` -> S2 path with RGB zero-fill
 
     Mixed-sensor inputs (e.g. ``["s2", "sar"]``) are handled by
@@ -616,7 +621,7 @@ class OlmoEarthBenchModel(BenchModel):
                     g_images = to_s2_dn(g_images, input_unit)
                     if group["sensor"] == "landsat" and self.landsat_scale_factor is not None:
                         g_images = g_images * self.landsat_scale_factor
-                if group["sensor"] == "sar" and self.sar_log_scale:
+                if group["sensor"] in ("sar", "s1") and self.sar_log_scale:
                     g_images = 10.0 * torch.log10(g_images.clamp(min=1e-6))
 
                 g_images = self._pad_group(g_images, group["dst_indices"], group["channels"])

--- a/src/torchgeo_bench/models/timm.py
+++ b/src/torchgeo_bench/models/timm.py
@@ -15,6 +15,38 @@ logger = logging.getLogger(__name__)
 
 _VALID_INPUT_NORMALIZATIONS = ("bands_zscore", "imagenet", "timm_default", "none")
 
+# Visible-light wavelength windows (micrometres) used to identify the red/
+# green/blue bands by physical wavelength rather than by name -- datasets
+# name their optical bands inconsistently (``"red"`` vs Sentinel-2's native
+# ``"b04"``), but ``BandSpec.wavelength_um`` is populated consistently.
+_BLUE_UM = (0.45, 0.515)
+_GREEN_UM = (0.515, 0.60)
+_RED_UM = (0.60, 0.70)
+
+
+def _rgb_first_permutation(bands: list[BandSpec]) -> list[int] | None:
+    """Return a channel permutation with red/green/blue moved to the front.
+
+    ``None`` if the band list doesn't contain exactly one band in each of
+    the red/green/blue wavelength windows -- e.g. a SAR-only or otherwise
+    non-optical band set, where there is nothing to reorder.
+    """
+    windows = {"red": _RED_UM, "green": _GREEN_UM, "blue": _BLUE_UM}
+    matches: dict[str, list[int]] = {"red": [], "green": [], "blue": []}
+    for i, band in enumerate(bands):
+        if band.wavelength_um is None:
+            continue
+        for key, (lo, hi) in windows.items():
+            if lo <= band.wavelength_um < hi:
+                matches[key].append(i)
+
+    if any(len(idx) != 1 for idx in matches.values()):
+        return None
+
+    rgb_idx = [matches["red"][0], matches["green"][0], matches["blue"][0]]
+    rest = [i for i in range(len(bands)) if i not in rgb_idx]
+    return rgb_idx + rest
+
 
 class TimmPatchBenchModel(BenchModel):
     """BenchModel wrapper for any timm backbone.
@@ -110,6 +142,18 @@ class TimmPatchBenchModel(BenchModel):
             global_pool=global_pool,
         )
 
+        # timm's first-conv channel adaptation for in_chans > 3 (see
+        # ``timm.models._manipulate.adapt_input_conv``) doesn't average the
+        # pretrained RGB kernel across the extra channels -- it *tiles*
+        # [R, G, B] across channel indices 0, 1, 2, 3, ... To land the
+        # pretrained R/G/B kernel weights on the physically-matching red/
+        # green/blue bands (rather than whatever order the dataset happens
+        # to declare them, e.g. Sentinel-2's native B02/B03/B04 = blue/
+        # green/red), permute the input channels once at construction.
+        self._channel_perm: list[int] | None = None
+        if self.pretrained and self.num_channels != 3:
+            self._channel_perm = _rgb_first_permutation(self.bands)
+
         default_cfg = getattr(self.backbone, "default_cfg", {}) or {}
         cfg_input_size = default_cfg.get("input_size", None)
         inferred_size: int | None = None
@@ -186,12 +230,19 @@ class TimmPatchBenchModel(BenchModel):
         std = self._rgb_std.to(dtype=images.dtype)  # type: ignore[attr-defined]
         return (scaled - mean) / std
 
+    def _permute_channels(self, images: torch.Tensor) -> torch.Tensor:
+        """Reorder input channels so red/green/blue lead, if identifiable."""
+        if self._channel_perm is None:
+            return images
+        return images[:, self._channel_perm, :, :]
+
     @torch.no_grad()
     def _forward_patch_features(
         self,
         images: torch.Tensor,
     ) -> torch.Tensor:
         """Return pooled patch embeddings of shape ``(B, K)`` from normalized inputs."""
+        images = self._permute_channels(images)
         if self.auto_resize and self.target_size is not None:
             h, w = images.shape[-2], images.shape[-1]
             if h != self.target_size or w != self.target_size:

--- a/src/torchgeo_bench/models/torchgeo_models.py
+++ b/src/torchgeo_bench/models/torchgeo_models.py
@@ -580,18 +580,32 @@ class TorchGeoScaleMAEBench(_TorchGeoBackboneBench):
 # ---------------------------------------------------------------------------
 
 
+#: DOFA's own pretraining wave table (github.com/zhu-xlab/DOFA,
+#: ``pretraining/datasets/waves.json``) assigns both channels of its 2-band
+#: Sentinel-1 (VH, VV) modality this placeholder wavelength: ``"2": [3.75,
+#: 3.75]``. Radar backscatter has no optical wavelength, so this is a
+#: deliberate, sourced placeholder from the original authors -- not a guess
+#: -- used to give the wavelength-conditioned hypernetwork a fixed token for
+#: "this is the SAR modality" rather than raising.
+_DOFA_SAR_WAVELENGTH_UM = 3.75
+_SAR_SENSORS = frozenset({"s1", "sar"})
+
+
 def _resolve_dofa_wavelengths(
     bands: list[BandSpec],
     wavelengths: list[float] | None,
 ) -> list[float]:
     """Return one DOFA wavelength per selected input channel.
 
-    Raises on any ``BandSpec`` lacking ``wavelength_um`` rather than silently
-    defaulting to ~green (0.6 µm).  DOFA's wavelength embedding is the only
-    way the model "knows" what spectral channel each tensor index represents;
-    a silent default would assign green-band weights to e.g. SAR backscatter
-    channels and quietly produce garbage features.  Callers that genuinely
-    want a default must pass an explicit ``wavelengths=`` list.
+    Raises on any non-SAR ``BandSpec`` lacking ``wavelength_um`` rather than
+    silently defaulting to ~green (0.6 µm).  DOFA's wavelength embedding is
+    the only way the model "knows" what spectral channel each tensor index
+    represents; a silent default would assign green-band weights to e.g.
+    thermal or elevation channels and quietly produce garbage features. SAR
+    bands (``sensor in {"s1", "sar"}``) are the one documented exception:
+    they get DOFA's own placeholder, :data:`_DOFA_SAR_WAVELENGTH_UM`.
+    Callers that want a different default must pass an explicit
+    ``wavelengths=`` list.
     """
     if wavelengths is not None:
         if len(wavelengths) != len(bands):
@@ -601,14 +615,17 @@ def _resolve_dofa_wavelengths(
             )
         return [float(w) for w in wavelengths]
 
-    missing = [b.name for b in bands if b.wavelength_um is None]
+    missing = [b.name for b in bands if b.wavelength_um is None and b.sensor not in _SAR_SENSORS]
     if missing:
         raise ValueError(
             f"DOFA wavelengths missing for {missing}: every BandSpec must have a "
             f"`wavelength_um` set.  SAR / non-optical channels need either an "
             f"explicit wavelength or to be filtered out of the input."
         )
-    return [float(b.wavelength_um) for b in bands]
+    return [
+        _DOFA_SAR_WAVELENGTH_UM if b.wavelength_um is None else float(b.wavelength_um)
+        for b in bands
+    ]
 
 
 class TorchGeoDOFABench(_TorchGeoBackboneBench):

--- a/src/torchgeo_bench/models/torchgeo_models.py
+++ b/src/torchgeo_bench/models/torchgeo_models.py
@@ -597,16 +597,22 @@ def _resolve_dofa_wavelengths(
 ) -> list[float]:
     """Return one DOFA wavelength per selected input channel.
 
-    Raises on any non-SAR ``BandSpec`` lacking ``wavelength_um`` rather than
-    silently defaulting to ~green (0.6 µm).  DOFA's wavelength embedding is
-    the only way the model "knows" what spectral channel each tensor index
-    represents; a silent default would assign green-band weights to e.g.
-    thermal or elevation channels and quietly produce garbage features. SAR
-    bands (``sensor in {"s1", "sar"}``) are the one documented exception:
-    they get DOFA's own placeholder, :data:`_DOFA_SAR_WAVELENGTH_UM`.
+    Raises on any ``BandSpec`` lacking ``wavelength_um`` whose canonical
+    band name has no known fallback, rather than silently defaulting to
+    ~green (0.6 µm).  DOFA's wavelength embedding is the only way the model
+    "knows" what spectral channel each tensor index represents; a silent
+    default would assign green-band weights to e.g. thermal or elevation
+    channels and quietly produce garbage features. Two documented
+    exceptions: SAR bands (``sensor in {"s1", "sar"}``) get DOFA's own
+    placeholder, :data:`_DOFA_SAR_WAVELENGTH_UM`; other optical bands with
+    no declared wavelength (e.g. a Landsat dataset that never set one) fall
+    back to the true Sentinel-2 centre wavelength for that canonical band
+    name via :data:`~torchgeo_bench.models._band_mapping.S2_WAVELENGTHS_UM`.
     Callers that want a different default must pass an explicit
     ``wavelengths=`` list.
     """
+    from ._band_mapping import S2_WAVELENGTHS_UM, canonical_band_name
+
     if wavelengths is not None:
         if len(wavelengths) != len(bands):
             raise ValueError(
@@ -615,17 +621,22 @@ def _resolve_dofa_wavelengths(
             )
         return [float(w) for w in wavelengths]
 
-    missing = [b.name for b in bands if b.wavelength_um is None and b.sensor not in _SAR_SENSORS]
+    def _resolved(b: BandSpec) -> float | None:
+        if b.wavelength_um is not None:
+            return float(b.wavelength_um)
+        if b.sensor in _SAR_SENSORS:
+            return _DOFA_SAR_WAVELENGTH_UM
+        return S2_WAVELENGTHS_UM.get(canonical_band_name(b.name))
+
+    resolved = [_resolved(b) for b in bands]
+    missing = [b.name for b, w in zip(bands, resolved, strict=True) if w is None]
     if missing:
         raise ValueError(
             f"DOFA wavelengths missing for {missing}: every BandSpec must have a "
             f"`wavelength_um` set.  SAR / non-optical channels need either an "
             f"explicit wavelength or to be filtered out of the input."
         )
-    return [
-        _DOFA_SAR_WAVELENGTH_UM if b.wavelength_um is None else float(b.wavelength_um)
-        for b in bands
-    ]
+    return [w for w in resolved if w is not None]
 
 
 class TorchGeoDOFABench(_TorchGeoBackboneBench):

--- a/tests/test_band_mapping.py
+++ b/tests/test_band_mapping.py
@@ -5,6 +5,7 @@ import torch
 
 from torchgeo_bench.datasets.base import BandSpec
 from torchgeo_bench.models._band_mapping import (
+    S2_WAVELENGTHS_UM,
     canonical_band_name,
     map_to_model_bands,
     select_src_bands,
@@ -77,6 +78,24 @@ class TestMapToModelBands:
         # nir_narrow / swir1 / swir2 missing -> zero
         assert torch.equal(out[:, 3], torch.zeros(1, 4, 4))
         assert missing == [False, False, False, True, True, True]
+
+    def test_missing_coastal_falls_back_to_blue_by_default(self) -> None:
+        """A dataset with no coastal-aerosol band (most GeoBench S2 datasets)
+        must not hard-fail a coastal-requiring model (CROMA) -- blue is the
+        spectrally nearest available band, so substitute it instead of
+        zero-filling or raising."""
+        src = [_band("red"), _band("green"), _band("blue")]
+        x = torch.arange(3 * 4 * 4, dtype=torch.float32).reshape(1, 3, 4, 4)
+        out, missing = map_to_model_bands(x, src, ["coastal", "blue"])
+        assert torch.equal(out[:, 0], x[:, 2])  # coastal <- blue (src[2])
+        assert torch.equal(out[:, 1], x[:, 2])  # blue <- blue
+        assert missing == [False, False]  # fallback-filled, not zero-filled
+
+    def test_band_fallbacks_can_be_disabled(self) -> None:
+        src = [_band("red"), _band("green"), _band("blue")]
+        x = torch.zeros(1, 3, 4, 4)
+        with pytest.raises(ValueError, match="Missing required model band"):
+            map_to_model_bands(x, src, ["coastal"], band_fallbacks={})
 
     def test_alias_resolution(self) -> None:
         src = [_band("B04"), _band("B03"), _band("B02")]
@@ -157,6 +176,28 @@ class TestWavelengthsUm:
         bands = [_band("red", 0.665), _band("vv", None)]
         wls = wavelengths_um(bands, default_um=1.5)
         assert wls == [0.665, 1.5]
+
+    def test_falls_back_to_s2_wavelength_by_canonical_name(self) -> None:
+        """A Landsat dataset's nir/swir bands with no declared wavelength_um
+        (m_forestnet.py) must not hard-fail -- most datasets here are
+        Sentinel-2, so its true wavelength is a reasonable default."""
+        bands = [
+            _band("nir", None, sensor="landsat"),
+            _band("swir_1", None, sensor="landsat"),
+            _band("swir_2", None, sensor="landsat"),
+        ]
+        assert wavelengths_um(bands) == [
+            S2_WAVELENGTHS_UM["nir"],
+            S2_WAVELENGTHS_UM["swir1"],
+            S2_WAVELENGTHS_UM["swir2"],
+        ]
+
+    def test_sar_still_raises_without_s2_default_or_explicit_default(self) -> None:
+        """SAR has no canonical S2 wavelength -- must still raise, not
+        silently invent an optical wavelength for radar backscatter."""
+        bands = [_band("red", 0.665), _band("vv", None, sensor="sar")]
+        with pytest.raises(ValueError, match="Missing wavelengths"):
+            wavelengths_um(bands)
 
 
 class TestDofaWavelengths:

--- a/tests/test_olmoearth.py
+++ b/tests/test_olmoearth.py
@@ -485,6 +485,37 @@ def test_mixed_s2_sar_forward_pass() -> None:
 
 
 @requires_olmoearth
+def test_s1_sensor_tag_aliases_to_sar_modality() -> None:
+    """so2sat/benv2/treesatai declare SAR bands under sensor="s1" (m-so2sat/
+    kuro_siwo use "sar") -- both must route to the same Sentinel-1 modality
+    rather than "s1" raising "no layout for sensor"."""
+    from olmoearth_pretrain_minimal.olmoearth_pretrain_v1.utils.constants import Modality
+
+    from torchgeo_bench.models.olmoearth import OlmoEarthBenchModel
+
+    bands = [
+        BandSpec(
+            sensor="s1", name="vv", source_name="VV", mean=-19.4, std=5.6, min=-66.5, max=24.3
+        ),
+        BandSpec(
+            sensor="s1", name="vh", source_name="VH", mean=-12.6, std=5.1, min=-65.3, max=33.6
+        ),
+    ]
+    model = OlmoEarthBenchModel(bands=bands, model_size="nano", normalization="identity")
+    assert len(model._sensor_groups) == 1
+    s1_group = model._sensor_groups[0]
+    assert s1_group["sensor"] == "s1"
+    assert s1_group["modality"] == Modality.SENTINEL1
+    assert s1_group["sample_field"] == "sentinel1"
+    assert s1_group["channels"] == 2
+    assert model.input_res == 10
+    model.eval()
+    out = model.forward_patch_features(torch.rand(2, 2, 64, 64) * 30.0)
+    assert out.shape == (2, EXPECTED_DIM["nano"])
+    assert torch.isfinite(out).all()
+
+
+@requires_olmoearth
 def test_invalid_model_size_at_construction_not_forward() -> None:
     """Invalid model_size must fail in __init__ before any model loading call."""
     import olmoearth_pretrain_minimal as oepm

--- a/tests/test_olmoearth.py
+++ b/tests/test_olmoearth.py
@@ -516,6 +516,50 @@ def test_s1_sensor_tag_aliases_to_sar_modality() -> None:
 
 
 @requires_olmoearth
+def test_treesatai_vv_vh_ratio_band_routes_to_sar_modality() -> None:
+    """treesatai declares vv, vh, AND a derived vv/vh ratio band under
+    sensor="s1" -- the ratio band has no physical polarization of its own
+    but must still resolve to a known slot instead of raising "can't map
+    BandSpec names"."""
+    from torchgeo_bench.models.olmoearth import OlmoEarthBenchModel
+
+    bands = [
+        BandSpec(
+            sensor="s1",
+            name="vv",
+            source_name="vv",
+            mean=60197.8,
+            std=17913.3,
+            min=0.0,
+            max=65535.0,
+        ),
+        BandSpec(
+            sensor="s1",
+            name="vh",
+            source_name="vh",
+            mean=65496.9,
+            std=1326.41,
+            min=0.0,
+            max=65535.0,
+        ),
+        BandSpec(
+            sensor="s1",
+            name="vv_vh",
+            source_name="vv/vh",
+            mean=88.73,
+            std=2409.44,
+            min=0.0,
+            max=65535.0,
+        ),
+    ]
+    model = OlmoEarthBenchModel(bands=bands, model_size="nano", normalization="identity")
+    model.eval()
+    out = model.forward_patch_features(torch.rand(2, 3, 64, 64) * 30.0)
+    assert out.shape == (2, EXPECTED_DIM["nano"])
+    assert torch.isfinite(out).all()
+
+
+@requires_olmoearth
 def test_invalid_model_size_at_construction_not_forward() -> None:
     """Invalid model_size must fail in __init__ before any model loading call."""
     import olmoearth_pretrain_minimal as oepm

--- a/tests/test_timm_normalization.py
+++ b/tests/test_timm_normalization.py
@@ -196,6 +196,69 @@ def test_minmax_zscore_uses_actual_bandspec_stats():
     assert abs(out_max.item() - 3.5) < 1e-4, f"expected 3.5 at band max, got {out_max.item()}"
 
 
+def _band(name: str, wavelength_um: float | None) -> "BandSpec":
+    from torchgeo_bench.datasets.base import BandSpec
+
+    return BandSpec(
+        sensor="s2",
+        name=name,
+        source_name=name.upper(),
+        mean=0.0,
+        std=1.0,
+        min=0.0,
+        max=1.0,
+        wavelength_um=wavelength_um,
+    )
+
+
+def test_rgb_first_permutation_reorders_bgr_native_bands():
+    """Sentinel-2's native declaration order (blue, green, red, ...) must be
+    reordered so the pretrained RGB kernel's R/G/B weights line up with the
+    physically-matching bands, identified by wavelength (name-agnostic)."""
+    from torchgeo_bench.models.timm import _rgb_first_permutation
+
+    # Native S2 order: b02=blue, b03=green, b04=red, b08=nir
+    bands = [_band("b02", 0.49), _band("b03", 0.56), _band("b04", 0.665), _band("b08", 0.842)]
+    perm = _rgb_first_permutation(bands)
+    assert perm == [2, 1, 0, 3]  # red, green, blue, nir
+
+
+def test_rgb_first_permutation_none_without_full_triplet():
+    """SAR-only or otherwise non-optical band sets have nothing to reorder."""
+    from torchgeo_bench.models.timm import _rgb_first_permutation
+
+    bands = [_band("vv", None), _band("vh", None)]
+    assert _rgb_first_permutation(bands) is None
+
+    # Missing the red band entirely.
+    bands = [_band("b02", 0.49), _band("b03", 0.56), _band("nir", 0.842)]
+    assert _rgb_first_permutation(bands) is None
+
+
+def test_multichannel_pretrained_permutes_channels_before_backbone():
+    """Pretrained + multi-channel must feed the backbone R/G/B-first, even
+    when the dataset declares bands in native blue/green/red/... order."""
+    from torchgeo_bench.models.timm import TimmPatchBenchModel
+
+    bands = [_band("b02", 0.49), _band("b03", 0.56), _band("b04", 0.665), _band("b08", 0.842)]
+    model = TimmPatchBenchModel(bands=bands, model_name="resnet18", pretrained=True)
+    assert model._channel_perm == [2, 1, 0, 3]
+
+    seen = {}
+
+    class _Capture(torch.nn.Module):
+        def forward(self, images):
+            seen["images"] = images
+            return torch.zeros(images.shape[0], 8)
+
+    model.backbone = _Capture()
+    raw = torch.arange(4).float().view(1, 4, 1, 1).expand(1, 4, 2, 2).clone()
+    model._forward_patch_features(raw)
+    # channel 0 (native blue=1.0) must now carry channel-index-2's original
+    # value (0.0, native red) after the R/G/B-first permutation, etc.
+    assert torch.equal(seen["images"][0, :, 0, 0], torch.tensor([2.0, 1.0, 0.0, 3.0]))
+
+
 def test_unknown_timm_model_name_raises_clearly():
     """A typo in ``model_name`` must fail loudly at construction (we don't
     silently swallow the missing pretrained_cfg)."""

--- a/tests/test_torchgeo_models.py
+++ b/tests/test_torchgeo_models.py
@@ -279,13 +279,37 @@ def test_dofa_wavelengths_default_sar_bands_to_zhu_xlab_placeholder() -> None:
 
 
 def test_dofa_wavelengths_still_raises_for_non_sar_missing_wavelength() -> None:
-    """A non-SAR band with no wavelength is a real data-declaration gap, not
-    something DOFA has a documented default for -- must still raise."""
+    """A non-SAR band with no wavelength and no known S2 canonical name is a
+    real data-declaration gap, not something DOFA has a default for."""
     bad_band = BandSpec(
         sensor="dem", name="elevation", source_name="DEM", mean=0.0, std=1.0, min=0.0, max=1.0
     )
     with pytest.raises(ValueError, match="DOFA wavelengths missing"):
         _resolve_dofa_wavelengths([bad_band], None)
+
+
+def test_dofa_wavelengths_fall_back_to_s2_table_for_landsat_bands() -> None:
+    """m_forestnet.py's Landsat nir/swir_1/swir_2 bands don't set
+    wavelength_um -- must fall back to the true Sentinel-2 centre
+    wavelength by canonical name rather than raising."""
+    from torchgeo_bench.models._band_mapping import S2_WAVELENGTHS_UM
+
+    landsat_bands = [
+        BandSpec(
+            sensor="landsat", name="nir", source_name="NIR", mean=0.0, std=1.0, min=0.0, max=1.0
+        ),
+        BandSpec(
+            sensor="landsat",
+            name="swir_1",
+            source_name="SWIR1",
+            mean=0.0,
+            std=1.0,
+            min=0.0,
+            max=1.0,
+        ),
+    ]
+    wavelengths = _resolve_dofa_wavelengths(landsat_bands, None)
+    assert wavelengths == [S2_WAVELENGTHS_UM["nir"], S2_WAVELENGTHS_UM["swir1"]]
 
 
 def test_torchgeo_dofa_forward_shape(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_torchgeo_models.py
+++ b/tests/test_torchgeo_models.py
@@ -12,6 +12,7 @@ from torchgeo_bench.datasets.base import BandSpec
 from torchgeo_bench.datasets.m_eurosat import MEurosat
 from torchgeo_bench.datasets.m_so2sat import MSo2Sat
 from torchgeo_bench.models.torchgeo_models import (
+    _DOFA_SAR_WAVELENGTH_UM,
     TorchGeoCromaBench,
     TorchGeoDOFABench,
     TorchGeoPanopticonBench,
@@ -20,6 +21,7 @@ from torchgeo_bench.models.torchgeo_models import (
     TorchGeoSwinBench,
     _adapt_first_conv,
     _extract_normalize_transforms,
+    _resolve_dofa_wavelengths,
     _resolve_torchgeo_factory,
     _resolve_torchgeo_weights,
     _warn_unit_mismatch,
@@ -258,6 +260,32 @@ def test_torchgeo_resnet_forward_shape(monkeypatch):
     assert out.ndim == 2
     assert out.shape[0] == 2
     assert torch.isfinite(out).all()
+
+
+def _sar_band(name: str) -> BandSpec:
+    return BandSpec(
+        sensor="s1", name=name, source_name=name.upper(), mean=0.0, std=1.0, min=-1.0, max=1.0
+    )
+
+
+def test_dofa_wavelengths_default_sar_bands_to_zhu_xlab_placeholder() -> None:
+    """SAR bands (sensor s1/sar) with no wavelength get DOFA's own 3.75um
+    placeholder (github.com/zhu-xlab/DOFA waves.json key "2") instead of
+    raising, since radar backscatter has no optical wavelength to declare."""
+    bands = _s2_multispectral_bands()[:3] + [_sar_band("vh"), _sar_band("vv")]
+    wavelengths = _resolve_dofa_wavelengths(bands, None)
+    assert wavelengths[-2:] == [_DOFA_SAR_WAVELENGTH_UM, _DOFA_SAR_WAVELENGTH_UM]
+    assert wavelengths[:3] == [b.wavelength_um for b in bands[:3]]
+
+
+def test_dofa_wavelengths_still_raises_for_non_sar_missing_wavelength() -> None:
+    """A non-SAR band with no wavelength is a real data-declaration gap, not
+    something DOFA has a documented default for -- must still raise."""
+    bad_band = BandSpec(
+        sensor="dem", name="elevation", source_name="DEM", mean=0.0, std=1.0, min=0.0, max=1.0
+    )
+    with pytest.raises(ValueError, match="DOFA wavelengths missing"):
+        _resolve_dofa_wavelengths([bad_band], None)
 
 
 def test_torchgeo_dofa_forward_shape(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

While closing a multispectral classification coverage gap (a colleague found 95 models missing at least one MSI cell across 9 datasets), several of the failures turned out to be real bugs rather than just missing runs. This PR is the code fixes only; the actual backfilled results/reruns are a separate stacked PR on top of this one.

- **RGB-pretrained timm models were feeding the wrong physical band into each pretrained kernel channel.** Sentinel-2 declares optical bands blue-green-red (native B02/B03/B04 order), but timm's `in_chans` adaptation (`adapt_input_conv`) doesn't average the pretrained RGB kernel across extra channels -- it *tiles* `[R, G, B]` across channel indices 0, 1, 2, 3, ... So channel 0 always gets the R kernel regardless of which band is actually there, silently swapping red and blue for every RGB-pretrained model run on multispectral input. Now permutes channels to red/green/blue-first by wavelength (name-agnostic) before the backbone sees them.
- **DOFA crashed on any SAR band with no wavelength.** DOFA needs one wavelength per channel and SAR has no optical wavelength to declare. Now defaults to the same placeholder the original `zhu-xlab/DOFA` repo's own pretraining wave table uses for its 2-channel Sentinel-1 modality (3.75 um for both channels) instead of raising.
- **OlmoEarth's sensor-layout table only recognized the `"sar"` sensor tag, not `"s1"`** (used by so2sat/benv2/treesatai). OlmoEarth's own pretraining does cover Sentinel-1 -- this was a missing key alias, not a real capability gap (verified against the upstream `olmoearth_pretrain_minimal` package before fixing). Also fixed treesatai's derived `vv_vh` ratio band having no routing slot in the SAR name-to-index table.
- **A missing `coastal` band now falls back to the spectrally-nearest available band (blue)** instead of hard-failing CROMA, and a shared `S2_WAVELENGTHS_UM` table now backstops any dataset that never declared `wavelength_um` for an optical band (e.g. a Landsat dataset -- Sentinel-2's true wavelengths are close enough to be useful there).

## AI assistance disclosure

Written by Claude Code with me reviewing each step; one focused research task (verifying OlmoEarth's actual Sentinel-1 pretraining support against the upstream repo before trusting the sensor-alias fix) was delegated to a subagent.