### PR TITLE
Permute RGB-pretrained input channels by wavelength

### DIFF
--- a/src/torchgeo_bench/models/timm.py
+++ b/src/torchgeo_bench/models/timm.py
@@ -15,6 +15,38 @@ logger = logging.getLogger(__name__)
 
 _VALID_INPUT_NORMALIZATIONS = ("bands_zscore", "imagenet", "timm_default", "none")
 
+# Visible-light wavelength windows (micrometres) used to identify the red/
+# green/blue bands by physical wavelength rather than by name -- datasets
+# name their optical bands inconsistently (``"red"`` vs Sentinel-2's native
+# ``"b04"``), but ``BandSpec.wavelength_um`` is populated consistently.
+_BLUE_UM = (0.45, 0.515)
+_GREEN_UM = (0.515, 0.60)
+_RED_UM = (0.60, 0.70)
+
+
+def _rgb_first_permutation(bands: list[BandSpec]) -> list[int] | None:
+    """Return a channel permutation with red/green/blue moved to the front.
+
+    ``None`` if the band list doesn't contain exactly one band in each of
+    the red/green/blue wavelength windows -- e.g. a SAR-only or otherwise
+    non-optical band set, where there is nothing to reorder.
+    """
+    windows = {"red": _RED_UM, "green": _GREEN_UM, "blue": _BLUE_UM}
+    matches: dict[str, list[int]] = {"red": [], "green": [], "blue": []}
+    for i, band in enumerate(bands):
+        if band.wavelength_um is None:
+            continue
+        for key, (lo, hi) in windows.items():
+            if lo <= band.wavelength_um < hi:
+                matches[key].append(i)
+
+    if any(len(idx) != 1 for idx in matches.values()):
+        return None
+
+    rgb_idx = [matches["red"][0], matches["green"][0], matches["blue"][0]]
+    rest = [i for i in range(len(bands)) if i not in rgb_idx]
+    return rgb_idx + rest
+
 
 class TimmPatchBenchModel(BenchModel):
     """BenchModel wrapper for any timm backbone.
@@ -110,6 +142,18 @@ class TimmPatchBenchModel(BenchModel):
             global_pool=global_pool,
         )
 
+        # timm's first-conv channel adaptation for in_chans > 3 (see
+        # ``timm.models._manipulate.adapt_input_conv``) doesn't average the
+        # pretrained RGB kernel across the extra channels -- it *tiles*
+        # [R, G, B] across channel indices 0, 1, 2, 3, ... To land the
+        # pretrained R/G/B kernel weights on the physically-matching red/
+        # green/blue bands (rather than whatever order the dataset happens
+        # to declare them, e.g. Sentinel-2's native B02/B03/B04 = blue/
+        # green/red), permute the input channels once at construction.
+        self._channel_perm: list[int] | None = None
+        if self.pretrained and self.num_channels != 3:
+            self._channel_perm = _rgb_first_permutation(self.bands)
+
         default_cfg = getattr(self.backbone, "default_cfg", {}) or {}
         cfg_input_size = default_cfg.get("input_size", None)
         inferred_size: int | None = None
@@ -186,12 +230,19 @@ class TimmPatchBenchModel(BenchModel):
         std = self._rgb_std.to(dtype=images.dtype)  # type: ignore[attr-defined]
         return (scaled - mean) / std
 
+    def _permute_channels(self, images: torch.Tensor) -> torch.Tensor:
+        """Reorder input channels so red/green/blue lead, if identifiable."""
+        if self._channel_perm is None:
+            return images
+        return images[:, self._channel_perm, :, :]
+
     @torch.no_grad()
     def _forward_patch_features(
         self,
         images: torch.Tensor,
     ) -> torch.Tensor:
         """Return pooled patch embeddings of shape ``(B, K)`` from normalized inputs."""
+        images = self._permute_channels(images)
         if self.auto_resize and self.target_size is not None:
             h, w = images.shape[-2], images.shape[-1]
             if h != self.target_size or w != self.target_size:

--- a/tests/test_timm_normalization.py
+++ b/tests/test_timm_normalization.py
@@ -196,6 +196,69 @@ def test_minmax_zscore_uses_actual_bandspec_stats():
     assert abs(out_max.item() - 3.5) < 1e-4, f"expected 3.5 at band max, got {out_max.item()}"
 
 
+def _band(name: str, wavelength_um: float | None) -> "BandSpec":
+    from torchgeo_bench.datasets.base import BandSpec
+
+    return BandSpec(
+        sensor="s2",
+        name=name,
+        source_name=name.upper(),
+        mean=0.0,
+        std=1.0,
+        min=0.0,
+        max=1.0,
+        wavelength_um=wavelength_um,
+    )
+
+
+def test_rgb_first_permutation_reorders_bgr_native_bands():
+    """Sentinel-2's native declaration order (blue, green, red, ...) must be
+    reordered so the pretrained RGB kernel's R/G/B weights line up with the
+    physically-matching bands, identified by wavelength (name-agnostic)."""
+    from torchgeo_bench.models.timm import _rgb_first_permutation
+
+    # Native S2 order: b02=blue, b03=green, b04=red, b08=nir
+    bands = [_band("b02", 0.49), _band("b03", 0.56), _band("b04", 0.665), _band("b08", 0.842)]
+    perm = _rgb_first_permutation(bands)
+    assert perm == [2, 1, 0, 3]  # red, green, blue, nir
+
+
+def test_rgb_first_permutation_none_without_full_triplet():
+    """SAR-only or otherwise non-optical band sets have nothing to reorder."""
+    from torchgeo_bench.models.timm import _rgb_first_permutation
+
+    bands = [_band("vv", None), _band("vh", None)]
+    assert _rgb_first_permutation(bands) is None
+
+    # Missing the red band entirely.
+    bands = [_band("b02", 0.49), _band("b03", 0.56), _band("nir", 0.842)]
+    assert _rgb_first_permutation(bands) is None
+
+
+def test_multichannel_pretrained_permutes_channels_before_backbone():
+    """Pretrained + multi-channel must feed the backbone R/G/B-first, even
+    when the dataset declares bands in native blue/green/red/... order."""
+    from torchgeo_bench.models.timm import TimmPatchBenchModel
+
+    bands = [_band("b02", 0.49), _band("b03", 0.56), _band("b04", 0.665), _band("b08", 0.842)]
+    model = TimmPatchBenchModel(bands=bands, model_name="resnet18", pretrained=True)
+    assert model._channel_perm == [2, 1, 0, 3]
+
+    seen = {}
+
+    class _Capture(torch.nn.Module):
+        def forward(self, images):
+            seen["images"] = images
+            return torch.zeros(images.shape[0], 8)
+
+    model.backbone = _Capture()
+    raw = torch.arange(4).float().view(1, 4, 1, 1).expand(1, 4, 2, 2).clone()
+    model._forward_patch_features(raw)
+    # channel 0 (native blue=1.0) must now carry channel-index-2's original
+    # value (0.0, native red) after the R/G/B-first permutation, etc.
+    assert torch.equal(seen["images"][0, :, 0, 0], torch.tensor([2.0, 1.0, 0.0, 3.0]))
+
+
 def test_unknown_timm_model_name_raises_clearly():
     """A typo in ``model_name`` must fail loudly at construction (we don't
     silently swallow the missing pretrained_cfg)."""


### PR DESCRIPTION
timm's channel adaptation for in_chans > 3 tiles the pretrained [R,G,B] kernel across channels rather than averaging, so band order matters. Sentinel-2 declares bands blue,green,red; reorder to red,green,blue first (by wavelength, name-agnostic) so the pretrained kernel lines up with the right band.