### PR TITLE
Route OlmoEarth's s1 sensor tag and treesatai's vv_vh band

### DIFF
--- a/src/torchgeo_bench/models/olmoearth.py
+++ b/src/torchgeo_bench/models/olmoearth.py
@@ -178,6 +178,10 @@ _MODALITY_INFO: dict[str, dict] = {
             "vh_lee": 1,
             "vh_lee_real": 1,
             "vh_lee_imag": 1,
+            # treesatai's derived VV/VH ratio band -- not a real physical
+            # channel, so it wins whichever slot it lands on (vh, matching
+            # the existing "later variant overwrites" convention above).
+            "vv_vh": 1,
         },
     },
     # NAIP / aerial: no dedicated OlmoEarth modality, route RGB through
@@ -200,6 +204,10 @@ _MODALITY_INFO: dict[str, dict] = {
     },
 }
 _MODALITY_INFO["naip"] = _MODALITY_INFO["aerial"]
+# Datasets declare Sentinel-1 SAR bands under either sensor tag ("s1" in
+# so2sat/benv2/treesatai, "sar" in m_so2sat/kuro_siwo) -- both route to the
+# same OlmoEarth Sentinel-1 modality.
+_MODALITY_INFO["s1"] = _MODALITY_INFO["sar"]
 
 
 # Canonical GSD (meters) per sensor for OlmoEarth's positional encodings.
@@ -207,6 +215,7 @@ _MODALITY_INFO["naip"] = _MODALITY_INFO["aerial"]
 _SENSOR_INPUT_RES: dict[str, int] = {
     "s2": 10,
     "sar": 10,  # S1 coregistered to S2 10 m grid in OlmoEarth pretraining
+    "s1": 10,  # same modality, dataset-declared under the "s1" sensor tag
     "landsat": 30,
     "aerial": 1,
     "naip": 1,
@@ -217,7 +226,7 @@ _SENSOR_INPUT_RES: dict[str, int] = {
 # (Lee-filtered max ~10 000) and the S1 Normalizer expects the original scale.
 # detect_input_unit returns S2_DN for them, making to_s2_dn a no-op anyway,
 # but being explicit avoids surprises if the heuristic ever changes.
-_PASSTHROUGH_SENSORS: frozenset[str] = frozenset({"sar"})
+_PASSTHROUGH_SENSORS: frozenset[str] = frozenset({"sar", "s1"})
 
 # Sensors normalized with dataset (BandSpec) stats rather than OlmoEarth's
 # pretrained normalizer when ``norm_from_pretrained="auto"`` (the default).
@@ -338,7 +347,7 @@ class OlmoEarthBenchModel(BenchModel):
 
     * ``"s2"`` -> ``Modality.SENTINEL2_L2A`` (12 channels, 3 band-sets)
     * ``"landsat"`` -> ``Modality.LANDSAT`` (11 channels, 2 band-sets)
-    * ``"sar"`` -> ``Modality.SENTINEL1`` (2 channels, 1 band-set)
+    * ``"sar"`` / ``"s1"`` -> ``Modality.SENTINEL1`` (2 channels, 1 band-set)
     * ``"aerial"`` / ``"naip"`` -> S2 path with RGB zero-fill
 
     Mixed-sensor inputs (e.g. ``["s2", "sar"]``) are handled by
@@ -616,7 +625,7 @@ class OlmoEarthBenchModel(BenchModel):
                     g_images = to_s2_dn(g_images, input_unit)
                     if group["sensor"] == "landsat" and self.landsat_scale_factor is not None:
                         g_images = g_images * self.landsat_scale_factor
-                if group["sensor"] == "sar" and self.sar_log_scale:
+                if group["sensor"] in ("sar", "s1") and self.sar_log_scale:
                     g_images = 10.0 * torch.log10(g_images.clamp(min=1e-6))
 
                 g_images = self._pad_group(g_images, group["dst_indices"], group["channels"])

--- a/tests/test_olmoearth.py
+++ b/tests/test_olmoearth.py
@@ -485,6 +485,81 @@ def test_mixed_s2_sar_forward_pass() -> None:
 
 
 @requires_olmoearth
+def test_s1_sensor_tag_aliases_to_sar_modality() -> None:
+    """so2sat/benv2/treesatai declare SAR bands under sensor="s1" (m-so2sat/
+    kuro_siwo use "sar") -- both must route to the same Sentinel-1 modality
+    rather than "s1" raising "no layout for sensor"."""
+    from olmoearth_pretrain_minimal.olmoearth_pretrain_v1.utils.constants import Modality
+
+    from torchgeo_bench.models.olmoearth import OlmoEarthBenchModel
+
+    bands = [
+        BandSpec(
+            sensor="s1", name="vv", source_name="VV", mean=-19.4, std=5.6, min=-66.5, max=24.3
+        ),
+        BandSpec(
+            sensor="s1", name="vh", source_name="VH", mean=-12.6, std=5.1, min=-65.3, max=33.6
+        ),
+    ]
+    model = OlmoEarthBenchModel(bands=bands, model_size="nano", normalization="identity")
+    assert len(model._sensor_groups) == 1
+    s1_group = model._sensor_groups[0]
+    assert s1_group["sensor"] == "s1"
+    assert s1_group["modality"] == Modality.SENTINEL1
+    assert s1_group["sample_field"] == "sentinel1"
+    assert s1_group["channels"] == 2
+    assert model.input_res == 10
+    model.eval()
+    out = model.forward_patch_features(torch.rand(2, 2, 64, 64) * 30.0)
+    assert out.shape == (2, EXPECTED_DIM["nano"])
+    assert torch.isfinite(out).all()
+
+
+@requires_olmoearth
+def test_treesatai_vv_vh_ratio_band_routes_to_sar_modality() -> None:
+    """treesatai declares vv, vh, AND a derived vv/vh ratio band under
+    sensor="s1" -- the ratio band has no physical polarization of its own
+    but must still resolve to a known slot instead of raising "can't map
+    BandSpec names"."""
+    from torchgeo_bench.models.olmoearth import OlmoEarthBenchModel
+
+    bands = [
+        BandSpec(
+            sensor="s1",
+            name="vv",
+            source_name="vv",
+            mean=60197.8,
+            std=17913.3,
+            min=0.0,
+            max=65535.0,
+        ),
+        BandSpec(
+            sensor="s1",
+            name="vh",
+            source_name="vh",
+            mean=65496.9,
+            std=1326.41,
+            min=0.0,
+            max=65535.0,
+        ),
+        BandSpec(
+            sensor="s1",
+            name="vv_vh",
+            source_name="vv/vh",
+            mean=88.73,
+            std=2409.44,
+            min=0.0,
+            max=65535.0,
+        ),
+    ]
+    model = OlmoEarthBenchModel(bands=bands, model_size="nano", normalization="identity")
+    model.eval()
+    out = model.forward_patch_features(torch.rand(2, 3, 64, 64) * 30.0)
+    assert out.shape == (2, EXPECTED_DIM["nano"])
+    assert torch.isfinite(out).all()
+
+
+@requires_olmoearth
 def test_invalid_model_size_at_construction_not_forward() -> None:
     """Invalid model_size must fail in __init__ before any model loading call."""
     import olmoearth_pretrain_minimal as oepm


### PR DESCRIPTION
so2sat/benv2/treesatai declare SAR bands under sensor="s1"; only "sar" (m-so2sat/kuro_siwo) was registered in the sensor-layout table, even though OlmoEarth's pretraining covers Sentinel-1 either way. Alias "s1" to the same layout, and add treesatai's derived vv_vh ratio band to the name-to-slot mapping.