### PR TITLE
Default DOFA's SAR bands to zhu-xlab's 3.75um wavelength placeholder

### DIFF
--- a/src/torchgeo_bench/models/torchgeo_models.py
+++ b/src/torchgeo_bench/models/torchgeo_models.py
@@ -580,18 +580,32 @@ class TorchGeoScaleMAEBench(_TorchGeoBackboneBench):
 # ---------------------------------------------------------------------------
 
 
+#: DOFA's own pretraining wave table (github.com/zhu-xlab/DOFA,
+#: ``pretraining/datasets/waves.json``) assigns both channels of its 2-band
+#: Sentinel-1 (VH, VV) modality this placeholder wavelength: ``"2": [3.75,
+#: 3.75]``. Radar backscatter has no optical wavelength, so this is a
+#: deliberate, sourced placeholder from the original authors -- not a guess
+#: -- used to give the wavelength-conditioned hypernetwork a fixed token for
+#: "this is the SAR modality" rather than raising.
+_DOFA_SAR_WAVELENGTH_UM = 3.75
+_SAR_SENSORS = frozenset({"s1", "sar"})
+
+
 def _resolve_dofa_wavelengths(
     bands: list[BandSpec],
     wavelengths: list[float] | None,
 ) -> list[float]:
     """Return one DOFA wavelength per selected input channel.
 
-    Raises on any ``BandSpec`` lacking ``wavelength_um`` rather than silently
-    defaulting to ~green (0.6 µm).  DOFA's wavelength embedding is the only
-    way the model "knows" what spectral channel each tensor index represents;
-    a silent default would assign green-band weights to e.g. SAR backscatter
-    channels and quietly produce garbage features.  Callers that genuinely
-    want a default must pass an explicit ``wavelengths=`` list.
+    Raises on any non-SAR ``BandSpec`` lacking ``wavelength_um`` rather than
+    silently defaulting to ~green (0.6 µm).  DOFA's wavelength embedding is
+    the only way the model "knows" what spectral channel each tensor index
+    represents; a silent default would assign green-band weights to e.g.
+    thermal or elevation channels and quietly produce garbage features. SAR
+    bands (``sensor in {"s1", "sar"}``) are the one documented exception:
+    they get DOFA's own placeholder, :data:`_DOFA_SAR_WAVELENGTH_UM`.
+    Callers that want a different default must pass an explicit
+    ``wavelengths=`` list.
     """
     if wavelengths is not None:
         if len(wavelengths) != len(bands):
@@ -601,14 +615,17 @@ def _resolve_dofa_wavelengths(
             )
         return [float(w) for w in wavelengths]
 
-    missing = [b.name for b in bands if b.wavelength_um is None]
+    missing = [b.name for b in bands if b.wavelength_um is None and b.sensor not in _SAR_SENSORS]
     if missing:
         raise ValueError(
             f"DOFA wavelengths missing for {missing}: every BandSpec must have a "
             f"`wavelength_um` set.  SAR / non-optical channels need either an "
             f"explicit wavelength or to be filtered out of the input."
         )
-    return [float(b.wavelength_um) for b in bands]
+    return [
+        _DOFA_SAR_WAVELENGTH_UM if b.wavelength_um is None else float(b.wavelength_um)
+        for b in bands
+    ]
 
 
 class TorchGeoDOFABench(_TorchGeoBackboneBench):

--- a/tests/test_torchgeo_models.py
+++ b/tests/test_torchgeo_models.py
@@ -12,6 +12,7 @@ from torchgeo_bench.datasets.base import BandSpec
 from torchgeo_bench.datasets.m_eurosat import MEurosat
 from torchgeo_bench.datasets.m_so2sat import MSo2Sat
 from torchgeo_bench.models.torchgeo_models import (
+    _DOFA_SAR_WAVELENGTH_UM,
     TorchGeoCromaBench,
     TorchGeoDOFABench,
     TorchGeoPanopticonBench,
@@ -20,6 +21,7 @@ from torchgeo_bench.models.torchgeo_models import (
     TorchGeoSwinBench,
     _adapt_first_conv,
     _extract_normalize_transforms,
+    _resolve_dofa_wavelengths,
     _resolve_torchgeo_factory,
     _resolve_torchgeo_weights,
     _warn_unit_mismatch,
@@ -258,6 +260,32 @@ def test_torchgeo_resnet_forward_shape(monkeypatch):
     assert out.ndim == 2
     assert out.shape[0] == 2
     assert torch.isfinite(out).all()
+
+
+def _sar_band(name: str) -> BandSpec:
+    return BandSpec(
+        sensor="s1", name=name, source_name=name.upper(), mean=0.0, std=1.0, min=-1.0, max=1.0
+    )
+
+
+def test_dofa_wavelengths_default_sar_bands_to_zhu_xlab_placeholder() -> None:
+    """SAR bands (sensor s1/sar) with no wavelength get DOFA's own 3.75um
+    placeholder (github.com/zhu-xlab/DOFA waves.json key "2") instead of
+    raising, since radar backscatter has no optical wavelength to declare."""
+    bands = _s2_multispectral_bands()[:3] + [_sar_band("vh"), _sar_band("vv")]
+    wavelengths = _resolve_dofa_wavelengths(bands, None)
+    assert wavelengths[-2:] == [_DOFA_SAR_WAVELENGTH_UM, _DOFA_SAR_WAVELENGTH_UM]
+    assert wavelengths[:3] == [b.wavelength_um for b in bands[:3]]
+
+
+def test_dofa_wavelengths_still_raises_for_non_sar_missing_wavelength() -> None:
+    """A non-SAR band with no wavelength is a real data-declaration gap, not
+    something DOFA has a documented default for -- must still raise."""
+    bad_band = BandSpec(
+        sensor="dem", name="elevation", source_name="DEM", mean=0.0, std=1.0, min=0.0, max=1.0
+    )
+    with pytest.raises(ValueError, match="DOFA wavelengths missing"):
+        _resolve_dofa_wavelengths([bad_band], None)
 
 
 def test_torchgeo_dofa_forward_shape(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
DOFA needs one wavelength per channel and SAR has none to declare. Use the same placeholder github.com/zhu-xlab/DOFA's own pretraining wave table assigns its 2-channel Sentinel-1 modality, instead of raising.