### PR TITLE
Substitute nearest-neighbor band for missing coastal aerosol

### DIFF
--- a/src/torchgeo_bench/models/_band_mapping.py
+++ b/src/torchgeo_bench/models/_band_mapping.py
@@ -145,6 +145,15 @@ def select_src_bands(
     return indices, selected
 
 
+#: When a target band is absent, substitute this spectrally-nearest
+#: neighbor's data instead of zero-filling or raising. Coastal aerosol
+#: (0.443 um) is the only band this currently applies to -- it sits right
+#: next to blue (0.49 um) in the spectrum, and a real (if approximate) blue
+#: reading is a better stand-in for a required "coastal" slot than a zeroed
+#: channel. Callers can override or disable via ``band_fallbacks``.
+DEFAULT_BAND_FALLBACKS: dict[str, str] = {"coastal": "blue"}
+
+
 def map_to_model_bands(
     images: torch.Tensor,
     src_bands: list[BandSpec],
@@ -152,11 +161,19 @@ def map_to_model_bands(
     *,
     allow_missing: bool = False,
     preferred_sensors: tuple[str, ...] = (),
+    band_fallbacks: dict[str, str] | None = None,
 ) -> tuple[torch.Tensor, list[bool]]:
     """Rearrange ``images`` from src band order to ``target_band_names``, zero-filling gaps.
 
+    A target band missing from ``src_bands`` first tries
+    ``band_fallbacks`` (default :data:`DEFAULT_BAND_FALLBACKS`) -- copying a
+    spectrally-nearest neighbor's real data -- before falling through to
+    zero-fill (``allow_missing=True``) or raising. Pass ``band_fallbacks={}``
+    to disable.
+
     Returns ``(mapped, missing)`` where ``missing[i]`` is True iff slot
-    ``i`` was zero-filled.
+    ``i`` was zero-filled (a fallback-substituted slot is *not* counted as
+    missing, since it carries real, if approximate, data).
     """
     if images.shape[1] != len(src_bands):
         raise ValueError(
@@ -164,12 +181,24 @@ def map_to_model_bands(
             f"src_bands has {len(src_bands)} entries."
         )
     src_index = resolve_src_indices(src_bands, preferred_sensors=preferred_sensors)
+    fallbacks = DEFAULT_BAND_FALLBACKS if band_fallbacks is None else band_fallbacks
 
     B, _, H, W = images.shape
     out = torch.zeros(B, len(target_band_names), H, W, device=images.device, dtype=images.dtype)
     missing: list[bool] = []
     for j, name in enumerate(target_band_names):
-        idx = src_index.get(canonical_band_name(name))
+        canon = canonical_band_name(name)
+        idx = src_index.get(canon)
+        if idx is None and canon in fallbacks:
+            fallback_idx = src_index.get(canonical_band_name(fallbacks[canon]))
+            if fallback_idx is not None:
+                logger.warning(
+                    "map_to_model_bands: %r missing from source bands; substituting %r "
+                    "(spectrally nearest available band) instead of zero-fill.",
+                    name,
+                    fallbacks[canon],
+                )
+                idx = fallback_idx
         if idx is None:
             if not allow_missing:
                 available = [canonical_band_name(b.name) for b in src_bands]

--- a/tests/test_band_mapping.py
+++ b/tests/test_band_mapping.py
@@ -78,6 +78,24 @@ class TestMapToModelBands:
         assert torch.equal(out[:, 3], torch.zeros(1, 4, 4))
         assert missing == [False, False, False, True, True, True]
 
+    def test_missing_coastal_falls_back_to_blue_by_default(self) -> None:
+        """A dataset with no coastal-aerosol band (most GeoBench S2 datasets)
+        must not hard-fail a coastal-requiring model (CROMA) -- blue is the
+        spectrally nearest available band, so substitute it instead of
+        zero-filling or raising."""
+        src = [_band("red"), _band("green"), _band("blue")]
+        x = torch.arange(3 * 4 * 4, dtype=torch.float32).reshape(1, 3, 4, 4)
+        out, missing = map_to_model_bands(x, src, ["coastal", "blue"])
+        assert torch.equal(out[:, 0], x[:, 2])  # coastal <- blue (src[2])
+        assert torch.equal(out[:, 1], x[:, 2])  # blue <- blue
+        assert missing == [False, False]  # fallback-filled, not zero-filled
+
+    def test_band_fallbacks_can_be_disabled(self) -> None:
+        src = [_band("red"), _band("green"), _band("blue")]
+        x = torch.zeros(1, 3, 4, 4)
+        with pytest.raises(ValueError, match="Missing required model band"):
+            map_to_model_bands(x, src, ["coastal"], band_fallbacks={})
+
     def test_alias_resolution(self) -> None:
         src = [_band("B04"), _band("B03"), _band("B02")]
         x = torch.zeros(2, 3, 2, 2)


### PR DESCRIPTION
CROMA requires a coastal-aerosol band most GeoBench Sentinel-2 datasets don't ship. map_to_model_bands now substitutes blue (spectrally nearest, 0.49um vs coastal's 0.443um) for a missing coastal slot by default, instead of zero-filling or raising. Configurable/disableable via band_fallbacks.