### PR TITLE
Fall back to true Sentinel-2 wavelengths for undeclared bands

### DIFF
--- a/src/torchgeo_bench/models/_band_mapping.py
+++ b/src/torchgeo_bench/models/_band_mapping.py
@@ -85,6 +85,31 @@ _BAND_ALIASES: dict[str, str] = {
 }
 
 
+#: True Sentinel-2 (MSI) centre wavelengths in micrometres, by canonical band
+#: name -- the same constants already hardcoded per-dataset in
+#: ``datasets/eurosat.py`` and similar. Most classification datasets here are
+#: Sentinel-2 derived, so this is the right default for any dataset that
+#: doesn't ship its own ``wavelength_um`` (e.g. a Landsat dataset's nir/swir
+#: bands are close enough in practice to be a useful fallback, not exact --
+#: see ``wavelengths_um``'s docstring). Values: ESA Sentinel-2 MSI spectral
+#: response, S2A center wavelengths.
+S2_WAVELENGTHS_UM: dict[str, float] = {
+    "coastal": 0.443,
+    "blue": 0.490,
+    "green": 0.560,
+    "red": 0.665,
+    "rededge1": 0.705,
+    "rededge2": 0.740,
+    "rededge3": 0.783,
+    "nir": 0.842,
+    "nir_narrow": 0.865,
+    "watervapor": 0.945,
+    "cirrus": 1.375,
+    "swir1": 1.610,
+    "swir2": 2.190,
+}
+
+
 def canonical_band_name(name: str) -> str:
     """Map an input band name to the canonical short name."""
     key = name.strip().lower().replace(" ", "")
@@ -216,15 +241,31 @@ def map_to_model_bands(
 def wavelengths_um(bands: list[BandSpec], default_um: float | None = None) -> list[float]:
     """Return per-band centre wavelengths in micrometres.
 
-    Missing wavelengths raise by default. Passing ``default_um`` is an explicit
-    opt-in for callers running a known fallback ablation.
+    A band missing ``wavelength_um`` (e.g. a Landsat dataset that didn't
+    bother declaring it, since most datasets here are Sentinel-2) falls back
+    to :data:`S2_WAVELENGTHS_UM` by canonical band name -- most datasets
+    genuinely are Sentinel-2, and even for Landsat the true wavelengths are
+    close enough (nir 0.842 vs. ~0.865 um) to be a useful default rather than
+    a hard stop. Only a band whose canonical name has no known S2 wavelength
+    either (e.g. SAR) raises, unless the caller passes an explicit
+    ``default_um`` for that case.
     """
-    missing = [b.name for b in bands if b.wavelength_um is None]
-    if missing and default_um is None:
-        raise ValueError(
-            f"Missing wavelengths for {missing}. Pass explicit wavelengths or default_um "
-            "only for a deliberate fallback ablation."
-        )
-    return [
-        float(b.wavelength_um) if b.wavelength_um is not None else float(default_um) for b in bands
+    still_missing = [
+        b.name
+        for b in bands
+        if b.wavelength_um is None and canonical_band_name(b.name) not in S2_WAVELENGTHS_UM
     ]
+    if still_missing and default_um is None:
+        raise ValueError(
+            f"Missing wavelengths for {still_missing}: not in S2_WAVELENGTHS_UM either. "
+            "Pass explicit wavelengths or default_um only for a deliberate fallback ablation."
+        )
+    resolved = []
+    for b in bands:
+        if b.wavelength_um is not None:
+            resolved.append(float(b.wavelength_um))
+        elif canonical_band_name(b.name) in S2_WAVELENGTHS_UM:
+            resolved.append(S2_WAVELENGTHS_UM[canonical_band_name(b.name)])
+        else:
+            resolved.append(float(default_um))
+    return resolved

--- a/src/torchgeo_bench/models/torchgeo_models.py
+++ b/src/torchgeo_bench/models/torchgeo_models.py
@@ -597,16 +597,22 @@ def _resolve_dofa_wavelengths(
 ) -> list[float]:
     """Return one DOFA wavelength per selected input channel.
 
-    Raises on any non-SAR ``BandSpec`` lacking ``wavelength_um`` rather than
-    silently defaulting to ~green (0.6 µm).  DOFA's wavelength embedding is
-    the only way the model "knows" what spectral channel each tensor index
-    represents; a silent default would assign green-band weights to e.g.
-    thermal or elevation channels and quietly produce garbage features. SAR
-    bands (``sensor in {"s1", "sar"}``) are the one documented exception:
-    they get DOFA's own placeholder, :data:`_DOFA_SAR_WAVELENGTH_UM`.
+    Raises on any ``BandSpec`` lacking ``wavelength_um`` whose canonical
+    band name has no known fallback, rather than silently defaulting to
+    ~green (0.6 µm).  DOFA's wavelength embedding is the only way the model
+    "knows" what spectral channel each tensor index represents; a silent
+    default would assign green-band weights to e.g. thermal or elevation
+    channels and quietly produce garbage features. Two documented
+    exceptions: SAR bands (``sensor in {"s1", "sar"}``) get DOFA's own
+    placeholder, :data:`_DOFA_SAR_WAVELENGTH_UM`; other optical bands with
+    no declared wavelength (e.g. a Landsat dataset that never set one) fall
+    back to the true Sentinel-2 centre wavelength for that canonical band
+    name via :data:`~torchgeo_bench.models._band_mapping.S2_WAVELENGTHS_UM`.
     Callers that want a different default must pass an explicit
     ``wavelengths=`` list.
     """
+    from ._band_mapping import S2_WAVELENGTHS_UM, canonical_band_name
+
     if wavelengths is not None:
         if len(wavelengths) != len(bands):
             raise ValueError(
@@ -615,17 +621,22 @@ def _resolve_dofa_wavelengths(
             )
         return [float(w) for w in wavelengths]
 
-    missing = [b.name for b in bands if b.wavelength_um is None and b.sensor not in _SAR_SENSORS]
+    def _resolved(b: BandSpec) -> float | None:
+        if b.wavelength_um is not None:
+            return float(b.wavelength_um)
+        if b.sensor in _SAR_SENSORS:
+            return _DOFA_SAR_WAVELENGTH_UM
+        return S2_WAVELENGTHS_UM.get(canonical_band_name(b.name))
+
+    resolved = [_resolved(b) for b in bands]
+    missing = [b.name for b, w in zip(bands, resolved, strict=True) if w is None]
     if missing:
         raise ValueError(
             f"DOFA wavelengths missing for {missing}: every BandSpec must have a "
             f"`wavelength_um` set.  SAR / non-optical channels need either an "
             f"explicit wavelength or to be filtered out of the input."
         )
-    return [
-        _DOFA_SAR_WAVELENGTH_UM if b.wavelength_um is None else float(b.wavelength_um)
-        for b in bands
-    ]
+    return [w for w in resolved if w is not None]
 
 
 class TorchGeoDOFABench(_TorchGeoBackboneBench):

--- a/tests/test_band_mapping.py
+++ b/tests/test_band_mapping.py
@@ -5,6 +5,7 @@ import torch
 
 from torchgeo_bench.datasets.base import BandSpec
 from torchgeo_bench.models._band_mapping import (
+    S2_WAVELENGTHS_UM,
     canonical_band_name,
     map_to_model_bands,
     select_src_bands,
@@ -175,6 +176,28 @@ class TestWavelengthsUm:
         bands = [_band("red", 0.665), _band("vv", None)]
         wls = wavelengths_um(bands, default_um=1.5)
         assert wls == [0.665, 1.5]
+
+    def test_falls_back_to_s2_wavelength_by_canonical_name(self) -> None:
+        """A Landsat dataset's nir/swir bands with no declared wavelength_um
+        (m_forestnet.py) must not hard-fail -- most datasets here are
+        Sentinel-2, so its true wavelength is a reasonable default."""
+        bands = [
+            _band("nir", None, sensor="landsat"),
+            _band("swir_1", None, sensor="landsat"),
+            _band("swir_2", None, sensor="landsat"),
+        ]
+        assert wavelengths_um(bands) == [
+            S2_WAVELENGTHS_UM["nir"],
+            S2_WAVELENGTHS_UM["swir1"],
+            S2_WAVELENGTHS_UM["swir2"],
+        ]
+
+    def test_sar_still_raises_without_s2_default_or_explicit_default(self) -> None:
+        """SAR has no canonical S2 wavelength -- must still raise, not
+        silently invent an optical wavelength for radar backscatter."""
+        bands = [_band("red", 0.665), _band("vv", None, sensor="sar")]
+        with pytest.raises(ValueError, match="Missing wavelengths"):
+            wavelengths_um(bands)
 
 
 class TestDofaWavelengths:

--- a/tests/test_torchgeo_models.py
+++ b/tests/test_torchgeo_models.py
@@ -279,13 +279,37 @@ def test_dofa_wavelengths_default_sar_bands_to_zhu_xlab_placeholder() -> None:
 
 
 def test_dofa_wavelengths_still_raises_for_non_sar_missing_wavelength() -> None:
-    """A non-SAR band with no wavelength is a real data-declaration gap, not
-    something DOFA has a documented default for -- must still raise."""
+    """A non-SAR band with no wavelength and no known S2 canonical name is a
+    real data-declaration gap, not something DOFA has a default for."""
     bad_band = BandSpec(
         sensor="dem", name="elevation", source_name="DEM", mean=0.0, std=1.0, min=0.0, max=1.0
     )
     with pytest.raises(ValueError, match="DOFA wavelengths missing"):
         _resolve_dofa_wavelengths([bad_band], None)
+
+
+def test_dofa_wavelengths_fall_back_to_s2_table_for_landsat_bands() -> None:
+    """m_forestnet.py's Landsat nir/swir_1/swir_2 bands don't set
+    wavelength_um -- must fall back to the true Sentinel-2 centre
+    wavelength by canonical name rather than raising."""
+    from torchgeo_bench.models._band_mapping import S2_WAVELENGTHS_UM
+
+    landsat_bands = [
+        BandSpec(
+            sensor="landsat", name="nir", source_name="NIR", mean=0.0, std=1.0, min=0.0, max=1.0
+        ),
+        BandSpec(
+            sensor="landsat",
+            name="swir_1",
+            source_name="SWIR1",
+            mean=0.0,
+            std=1.0,
+            min=0.0,
+            max=1.0,
+        ),
+    ]
+    wavelengths = _resolve_dofa_wavelengths(landsat_bands, None)
+    assert wavelengths == [S2_WAVELENGTHS_UM["nir"], S2_WAVELENGTHS_UM["swir1"]]
 
 
 def test_torchgeo_dofa_forward_shape(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
A band with no declared wavelength_um (e.g. a Landsat dataset that never set one) now defaults to the true Sentinel-2 centre wavelength for its canonical band name instead of hard-failing DOFA/Panopticon -- most datasets here are Sentinel-2, and even for Landsat the true wavelengths are close enough to be useful. DOFA's SAR placeholder now shares this same fallback for non-SAR bands.

Stacked on #230.