### PR TITLE
Add PR/commit conventions to AGENTS.md, refresh stale sections

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Guidelines for AI coding agents working in the torchgeo-bench repository.
 
 ## Project Overview
 
-**torchgeo-bench** is a Python benchmarking framework for evaluating geospatial foundation models on GeoBench datasets (V1 and V2). Uses PyTorch, Hydra configuration, and provides KNN-5, Linear Probing, and Segmentation (mIoU) evaluation with bootstrapped confidence intervals.
+**torchgeo-bench** is a Python benchmarking framework for evaluating geospatial foundation models on GeoBench datasets (V1 and V2). Uses PyTorch and an OmegaConf-based config system (see `config.py` — replaces Hydra, same `model=…`/`key=value` override syntax), and provides KNN-5, Linear Probing, and Segmentation (mIoU) evaluation with bootstrapped confidence intervals.
 
 ### Key Features
 - **Resume Mode**: Skip already-computed experiments when interrupted/restarted
@@ -15,16 +15,19 @@ Guidelines for AI coding agents working in the torchgeo-bench repository.
 
 ```
 src/torchgeo_bench/        # Main source package (importable as torchgeo_bench)
-  ├── cli.py               # CLI entry point (torchgeo-bench command)
-  ├── main.py              # Hydra-decorated benchmark runner
+  ├── cli.py               # CLI entry point (torchgeo-bench command: run/flops/download)
+  ├── main.py              # Benchmark runner (classification + segmentation)
+  ├── config.py            # OmegaConf config composition + _target_ instantiation
+  ├── resume.py            # config_hash-based resume/skip logic
+  ├── results.py            # EvaluationResult schema + atomic per-model CSV writes
   ├── download.py          # Dataset downloads (geobench_v1/v2 + torchgeo eurosat)
   ├── datasets/            # Per-dataset BenchDataset wrappers + V1/V2 base classes
   ├── linear.py            # Custom LogisticRegression (PyTorch-based)
   ├── knn.py               # FAISS-CPU KNN classifier
   ├── segmentation_task.py # Segmentation task solver
   ├── segmentation_probe.py# Hook-based segmentation probe
-  ├── conf/                # Hydra config files (packaged inside the source tree)
-  └── models/              # Model implementations (interface.py, bench_models.py, timm.py, etc.)
+  ├── conf/                # Config YAMLs (packaged inside the source tree)
+  └── models/              # Model implementations (interface.py, timm.py, torchgeo_models.py, etc.)
 data/                      # Datasets always live here (relative to CWD)
   ├── classification_v1.0/ # GeoBench V1
   ├── geobenchv2/          # GeoBench V2
@@ -34,6 +37,61 @@ experiments/               # Experiment runners, analysis scripts, SLURM jobs
   └── slurm/               # Standalone SLURM batch files
 tests/                     # Test suite (pytest)
 pyproject.toml             # Project config, dependencies, tool settings
+```
+
+## Contributing: Commits, PRs, and Splitting Changes
+
+Most contributors here are driving an AI coding agent and may not write Python
+day to day themselves — that's fine, but it means the PR is often the only
+thing a human reviewer has to go on. Optimize for a reviewer who wants to
+understand *and approve* a change in one pass, not one who has to reconstruct
+what happened from a wall of text or untangle five unrelated edits from one
+diff.
+
+**One PR per logical change, each with its own tests.**
+If an agent's exploration turns up more than one fix, bug, or improvement,
+that's multiple PRs, not one. Bundling unrelated changes together forces a
+reviewer to approve or block all of them as a set, and it flattens the
+changelog — a small, real bug fix deserves its own commit/PR so it shows up
+as its own trackable entry in history, not a buried line in something else's
+diff. If change B only makes sense on top of change A (e.g. B extends a
+function A just added), stack B's PR on A's branch instead of merging them
+into one.
+
+**Commit messages: one Conventional Commits subject line, nothing else.**
+`fix(models): handle missing coastal band` — no body, no bullet list, no
+restating the diff. Nobody reads commit bodies; the PR description is where
+context goes.
+
+**PR descriptions: say what changed and why, in a few plain sentences.**
+- No "Test plan" / "How I tested this" section unless the reviewer asks.
+- No AI-assistance disclosure boilerplate.
+- Don't restate the diff line by line — the diff is right there.
+- Skip it if the code and a one-line summary already make the change obvious.
+
+**Every PR should be independently reviewable.**
+A reviewer should be able to read the diff top to bottom, understand the
+change, check the tests cover it, and approve — without needing chat history,
+a linked doc, or a walkthrough. If a change needs more than a few sentences
+to explain *why* it's safe, that's a sign it should be split further or the
+code needs a comment (see below), not that the PR description needs to be
+longer.
+
+**Minimal code comments.**
+Don't comment what the code already says. A comment earns its place only
+when it captures something the code can't: a non-obvious constraint, a
+citation for a magic number, a workaround for a specific upstream bug, or a
+"why not the obvious alternative" note. When in doubt, leave it out.
+
+```python
+# BAD: restates the line below
+# increment the counter
+count += 1
+
+# GOOD: explains a non-obvious constraint
+# DOFA's hypernetwork requires ints here, not floats -- passing 3.75 silently
+# truncates to 3 with no warning.
+wavelength = int(round(wavelength_um))
 ```
 
 ## Environment Setup
@@ -112,7 +170,27 @@ torchgeo-bench run dataset.names=[burn_scars,pastis,flair2]
 
 # Select specific GPU device
 torchgeo-bench run device=cuda:1
+
+# Measure per-sample compute cost (GFLOPs, params, throughput) -> results/compute_cost.csv
+torchgeo-bench flops model=timm/resnet50
 ```
+
+## Results Layout & Resume
+
+- Each model writes to its own `results/models/<model name>.csv` (not one
+  shared file), so re-running one model only touches that file. Rows are
+  appended, never rewritten in place.
+- `resume=true` skips a (dataset, method, bands, normalization, ...) combo
+  only if an existing row's `config_hash` matches the current run's config.
+  Changing any hashed config field (including additive passes like
+  `eval.profile`/`eval.intrinsic_dim`) invalidates the match and reruns.
+- One-time, hardware-dependent measurements (`torchgeo-bench flops`,
+  intrinsic-dimension probes) live in their own side files —
+  `results/compute_cost.csv` and `results/intrinsic_dim/<model name>.csv` —
+  so a routine metrics rerun doesn't touch them.
+- Don't hand-edit `config_hash`/`KEY_COLS` logic without checking
+  `resume.py`'s docstring first; it's easy to silently invalidate every
+  existing row across `results/models/`.
 
 ## Datasets
 
@@ -274,22 +352,28 @@ class TestGeoBenchDatasetBasics:
 
 ## Key Dependencies
 
-`torch>=2.0`, `torchvision>=0.15`, `numpy>=1.24`, `scikit-learn>=1.3`, `hydra-core>=1.3`, `timm>=0.9`, `torchgeo>=0.8`, `h5py>=3.8`, `faiss-cpu>=1.7`, `huggingface-hub>=0.20`, `geobenchv2>=0.9`
+Core (see `pyproject.toml` for the authoritative list): `torch>=2`, `torchvision>=0.15`,
+`numpy>=1.24`, `scikit-learn>=1.3`, `timm>=0.9`, `torchgeo>=0.9`, `torchmetrics>=1.4`,
+`omegaconf>=2.3`, `h5py>=3.8`, `faissknn` (CPU or CUDA variant, picked by platform),
+`huggingface-hub>=0.20`, `geobenchv2>=0.9`, `pandas>=2`, `pyarrow>=14`, `safetensors>=0.4`,
+`filelock>=3.12`, `rich>=13`.
+
+Optional extras (`pip install 'torchgeo-bench[extra]'`, or `[all]` for everything):
+`cleanlab`, `coordbench`, `dev`, `docs`, `id` (intrinsic-dimension estimators),
+`olmoearth`, `sam3`, `terratorch`, `viz`. Model wrappers behind an extra
+(OlmoEarth, SAM3, terratorch-backed models) import that dependency lazily —
+don't add a top-level import for one at module scope.
 
 ## Common Gotchas
 
 1. **Data lives at `data/`**: Always `data/<canonical-subdir>/` from CWD. No env vars, no overrides.
 2. **No documentation for refactoring**: Don't create docs for internal refactors.
 3. **Tests need data**: Tests skip if `data/classification_v1.0` / `data/geobenchv2` / `data/eurosat` aren't on disk.
-4. **Hydra outputs**: Benchmark runs create `outputs/` directory with logs.
-5. **Model reinitialization**: Models are reinitialized per-dataset to handle varying input channels.
-6. **V1 vs V2 datasets**: V1 uses `m-` prefix, V2 uses no prefix.
+4. **Model reinitialization**: Models are reinitialized per-dataset to handle varying input channels.
+5. **V1 vs V2 datasets**: V1 uses `m-` prefix, V2 uses no prefix.
 
 ## Copilot/Cursor Instructions
 
-From `.github/copilot-instructions.md` (applies to `**/*.py, **/*.ipynb`):
-- Always `conda activate torchgeo-bench` before running commands
-- Assume Python 3.12+ and Pydantic v2.0
-- Prefer modern type hints (`list[str]` not `List[str]`)
-- Use `logging` for logging, not `print()`
-- Don't create documentation for refactoring
+`.github/copilot-instructions.md` covers the same ground in more depth
+(source layout, build/test/lint, architecture notes, conventions) — read it
+directly for anything not covered here rather than relying on a summary.


### PR DESCRIPTION
Adds guidance for splitting changes into separate, independently-reviewable PRs (each with its own tests), terse commit/PR conventions, and minimal code comments -- aimed at contributors driving an agent who may not review Python day to day themselves.

Also refreshes sections that had drifted from the current codebase: dependency list, the Hydra->OmegaConf config migration, missing `results/models/` and resume/config_hash conventions, a stale `outputs/` gotcha, and a Copilot-instructions summary that no longer matched the source file.