### PR TITLE
fix(cli): correct stale --output default in help text

### DIFF
--- a/src/torchgeo_bench/cli.py
+++ b/src/torchgeo_bench/cli.py
@@ -51,7 +51,10 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     run.add_argument("--device", default=None, help="Torch device, e.g. cuda:1 or cpu")
     run.add_argument(
-        "-o", "--output", default=None, help="Results CSV path (default: results/all_results.csv)"
+        "-o",
+        "--output",
+        default=None,
+        help="Results CSV path (default: results/models/<model name>.csv)",
     )
     run.add_argument(
         "--resume",


### PR DESCRIPTION
`torchgeo-bench run --help` still advertised `default: results/all_results.csv`. That stopped being true in #205, which moved routing to per-model files; `_resolve_output_path` now derives `results/models/<model name>.csv` from the model config when `output` is unset.

Noticed while working through the contributing guide.
