### PR TITLE
feat(cli): add --skill flag printing agent usage instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,10 @@ Guidelines for AI coding agents working in the torchgeo-bench repository.
 
 **torchgeo-bench** is a Python benchmarking framework for evaluating geospatial foundation models on GeoBench datasets (V1 and V2). Uses PyTorch and an OmegaConf-based config system (see `config.py` — replaces Hydra, same `model=…`/`key=value` override syntax), and provides KNN-5, Linear Probing, and Segmentation (mIoU) evaluation with bootstrapped confidence intervals.
 
+`torchgeo-bench --skill` prints a condensed, self-contained version of this
+guide (`src/torchgeo_bench/skill/SKILL.md`) for agents working *outside* this
+repository — keep it in sync when commands or conventions change.
+
 ### Key Features
 - **Resume Mode**: Skip already-computed experiments when interrupted/restarted
 - **Atomic CSV Writes**: Results appended with file locking for parallel job safety
@@ -27,6 +31,7 @@ src/torchgeo_bench/        # Main source package (importable as torchgeo_bench)
   ├── segmentation_task.py # Segmentation task solver
   ├── segmentation_probe.py# Hook-based segmentation probe
   ├── conf/                # Config YAMLs (packaged inside the source tree)
+  ├── skill/               # SKILL.md printed by `torchgeo-bench --skill`
   └── models/              # Model implementations (interface.py, timm.py, torchgeo_models.py, etc.)
 data/                      # Datasets always live here (relative to CWD)
   ├── classification_v1.0/ # GeoBench V1
@@ -174,6 +179,9 @@ torchgeo-bench run device=cuda:1
 
 # Measure per-sample compute cost (GFLOPs, params, throughput) -> results/compute_cost.csv
 torchgeo-bench flops model=timm/resnet50
+
+# Print the packaged agent brief (src/torchgeo_bench/skill/SKILL.md)
+torchgeo-bench --skill
 ```
 
 ## Results Layout & Resume

--- a/README.md
+++ b/README.md
@@ -130,6 +130,10 @@ and the runnable
   workflow, and troubleshooting.
 - **[AGENTS.md](https://github.com/torchgeo/torchgeo-bench/blob/main/AGENTS.md)**
   — contributor guide and house style.
+- **`torchgeo-bench --skill`** — prints agent-facing instructions (commands,
+  override syntax, results layout, how to add a model or dataset). Pipe it
+  into your agent's skills directory:
+  `torchgeo-bench --skill > .claude/skills/torchgeo-bench/SKILL.md`.
 
 <!-- skip-on-docs-landing-end -->
 

--- a/docs/api/cli.rst
+++ b/docs/api/cli.rst
@@ -3,7 +3,8 @@ Command-line interface
 
 .. module:: torchgeo_bench.cli
 
-The ``torchgeo-bench`` console script exposes three subcommands:
+The ``torchgeo-bench`` console script exposes three subcommands and a
+``--skill`` flag:
 
 ``torchgeo-bench run [flags] [key=value ...]``
     Runs the benchmark pipeline. Common settings have flags (``--model``,
@@ -20,6 +21,13 @@ The ``torchgeo-bench`` console script exposes three subcommands:
 ``torchgeo-bench flops [flags] [key=value ...]``
     Measures per-sample backbone, head, and probe compute. Overrides are
     composed from :file:`src/torchgeo_bench/conf/flops_config.yaml`.
+
+``torchgeo-bench --skill``
+    Prints :file:`src/torchgeo_bench/skill/SKILL.md`, a self-contained brief
+    that teaches an AI coding agent how to drive the CLI, where results land,
+    and how to add a model or dataset. Redirect it into your agent's skills
+    directory, e.g.
+    ``torchgeo-bench --skill > .claude/skills/torchgeo-bench/SKILL.md``.
 
 Config composition
 ------------------

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -117,3 +117,22 @@ pandas:
    from torchgeo_bench.results import load_results
    df = load_results()
    print(df.groupby(["dataset", "method"])["metric_value"].mean())
+
+Point a coding agent at the benchmark
+-------------------------------------
+
+``--skill`` prints a self-contained brief -- commands, config-override syntax,
+dataset names, results layout, and the conventions for adding a model or
+dataset -- written for AI coding agents:
+
+.. code-block:: console
+
+   $ torchgeo-bench --skill
+
+Redirect it into whichever skills directory your agent reads, for example
+``.claude/skills/torchgeo-bench/SKILL.md`` or ``.github/skills/torchgeo-bench/SKILL.md``:
+
+.. code-block:: console
+
+   $ mkdir -p .claude/skills/torchgeo-bench
+   $ torchgeo-bench --skill > .claude/skills/torchgeo-bench/SKILL.md

--- a/src/torchgeo_bench/cli.py
+++ b/src/torchgeo_bench/cli.py
@@ -1,9 +1,10 @@
 """Command-line interface for ``torchgeo-bench``.
 
 Subcommands: ``run`` (benchmark), ``flops`` (compute-cost measurement), and
-``download`` (datasets).  This module imports only the standard library so
-``torchgeo-bench --help`` is instant; torch and friends load only once a
-command actually starts doing work.
+``download`` (datasets).  ``--skill`` prints agent-facing usage instructions.
+This module imports only the standard library so ``torchgeo-bench --help`` is
+instant; torch and friends load only once a command actually starts doing
+work.
 """
 
 import argparse
@@ -35,7 +36,17 @@ def _build_parser() -> argparse.ArgumentParser:
         prog="torchgeo-bench",
         description="Benchmark geospatial foundation models on GeoBench datasets.",
     )
-    sub = parser.add_subparsers(dest="command", required=True)
+    parser.add_argument(
+        "--skill",
+        action="store_true",
+        help=(
+            "Print agent-facing instructions for using torchgeo-bench "
+            "(save with: torchgeo-bench --skill > SKILL.md)"
+        ),
+    )
+    # Not required: `--skill` is a complete invocation on its own.  A bare
+    # `torchgeo-bench` still errors out below, same as before.
+    sub = parser.add_subparsers(dest="command")
 
     run = sub.add_parser(
         "run",
@@ -245,6 +256,12 @@ def _cmd_download(args: argparse.Namespace) -> None:
             download_resisc45(output_dir)
 
 
+def _cmd_skill() -> None:
+    from torchgeo_bench.skill import read_skill
+
+    print(read_skill(), end="")
+
+
 def main(argv: list[str] | None = None) -> None:
     """Entry point for the ``torchgeo-bench`` console script."""
     argv = list(sys.argv[1:] if argv is None else argv)
@@ -261,6 +278,11 @@ def main(argv: list[str] | None = None) -> None:
         argv = rest
     parser = _build_parser()
     args = parser.parse_args(argv)
+    if args.skill:
+        _cmd_skill()
+        return
+    if args.command is None:
+        parser.error("a command is required (run, flops, download) or use --skill")
     if hasattr(args, "overrides"):
         args.overrides = [*args.overrides, *overrides]
     args.func(args)

--- a/src/torchgeo_bench/skill/SKILL.md
+++ b/src/torchgeo_bench/skill/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: torchgeo-bench
+description: >-
+  Benchmark frozen geospatial foundation models on GeoBench V1/V2 (KNN-5,
+  linear probe, segmentation mIoU) and location encoders on CoordBench with
+  the torchgeo-bench CLI. Use when asked to evaluate a backbone, add a model
+  or dataset to torchgeo-bench, resume or interpret its result CSVs, or debug
+  a benchmark run.
+---
+
+# torchgeo-bench
+
+`torchgeo-bench` evaluates **frozen** backbones: it extracts embeddings once
+and fits cheap probes on top (KNN-5 and L-BFGS logistic regression for
+classification, a hook-based dense probe for segmentation). Backbone weights
+are never fine-tuned. Every run appends rows to a CSV with bootstrapped 95%
+confidence intervals.
+
+## Setup
+
+```bash
+pip install torchgeo-bench            # or: uv sync --extra dev (from a clone)
+torchgeo-bench --help
+```
+
+Python 3.12+. The default device is `cuda:0`; pass `device=cpu` on a machine
+without a working GPU. Optional model families live behind extras
+(`olmoearth`, `terratorch`, `sam3`, `coordbench`, `id`, `viz`); install with
+`pip install "torchgeo-bench[olmoearth]"`.
+
+## Get data first
+
+Datasets are always read from `./data/<subdir>` relative to the current
+working directory — there are no env vars or path overrides.
+
+```bash
+torchgeo-bench download geobench_v1                              # -> data/classification_v1.0/
+torchgeo-bench download geobench_v2 --datasets burn_scars,benv2  # -> data/geobenchv2/<name>/
+torchgeo-bench download eurosat                                  # -> data/eurosat/
+torchgeo-bench download resisc45                                 # -> data/resisc45/
+```
+
+`--datasets` is only accepted for the two GeoBench targets. Downloads are
+large; prefer a named subset over pulling a whole benchmark.
+
+## Run a benchmark
+
+```bash
+torchgeo-bench run                                          # default model rcf, all datasets
+torchgeo-bench run -m timm/resnet50 -d m-eurosat
+torchgeo-bench run -m torchgeo/scalemae_large_fmow -d m-eurosat,m-so2sat --device cuda:1
+torchgeo-bench run -m timm/resnet50 -d burn_scars,pastis     # segmentation datasets
+torchgeo-bench run mode=coord -m sincos                      # CoordBench location encoders
+```
+
+Flags are shorthand for config overrides, and any `key=value` pair overrides
+the config directly. The two forms mix freely on one command line, and flags
+win over `key=value`:
+
+```bash
+torchgeo-bench run model=timm/resnet50 dataset.names=[m-eurosat] eval.bootstrap=100
+```
+
+Values parse as YAML (`[a,b]` is a list, `true` is a bool). Unknown keys are
+rejected; prefix with `+` to force-add one (`+model.gsd=10`).
+
+Useful `run` flags: `-m/--model`, `-d/--datasets` (comma-separated or `all`),
+`--device`, `-o/--output`, `--resume`, `--seed`, `--partition`, `--bands`,
+`--batch-size`, `--image-size`, `--normalization`, `--skip-linear`,
+`--bootstrap`, `-v/--verbose`.
+
+Other commands:
+
+```bash
+torchgeo-bench run --list-models        # every value accepted by model=/-m
+torchgeo-bench run --print-config       # merged config, then exit (no compute)
+torchgeo-bench flops -m timm/resnet50   # per-sample GFLOPs -> results/compute_cost.csv
+torchgeo-bench --skill                  # print this document
+```
+
+**Always dry-run with `--print-config` before launching a long sweep** — it
+catches typo'd keys and wrong dataset/band combinations in under a second.
+
+## Configuration surface
+
+Frequently used keys (see `--print-config` for the full tree):
+
+| Key | Default | Notes |
+| --- | --- | --- |
+| `dataset.names` | `all` | list of dataset ids, or `all` |
+| `dataset.bands` | `rgb` | `rgb`, `all`, or explicit band names |
+| `dataset.normalization` | `bandspec_zscore` | also `model_native`, `minmax`, `minmax_zscore`, `identity` |
+| `dataset.image_size` | `224` | `null` disables resizing |
+| `dataset.batch_size` | `64` | lower it first when a run OOMs |
+| `eval.bootstrap` | `200` | resamples for the CIs |
+| `eval.skip_linear` | `false` | KNN-only, much faster smoke test |
+| `eval.segmentation.head_type` | `fpn` | `linear`, `conv_block`, `fpn`, `dpt`, `patch_linear` |
+| `eval.segmentation.layers` | `[]` | **must** be set per model for segmentation |
+| `mode` | `image` | `coord` switches to the CoordBench track |
+
+Segmentation on a new backbone fails until `eval.segmentation.layers` names
+real backbone module paths (e.g. `[layer4,layer3,layer2,layer1]` for a
+ResNet). Model YAMLs that support segmentation set this themselves.
+
+## Datasets
+
+- GeoBench V1 classification (`m-` prefix): `m-eurosat`, `m-forestnet`,
+  `m-so2sat`, `m-pv4ger`, `m-brick-kiln`, `m-bigearthnet` (multilabel →
+  reports `micro_mAP`, not accuracy).
+- GeoBench V2 classification: `benv2`, `treesatai`, `so2sat`, `forestnet`.
+- GeoBench V2 segmentation: `burn_scars`, `caffe`, `cloudsen12`,
+  `dynamic_earthnet`, `flair2`, `fotw`, `kuro_siwo`, `pastis`, `spacenet2`,
+  `spacenet7`.
+- torchgeo-backed: `eurosat`, `eurosat-spatial`, `resisc45`.
+
+`m-forestnet` (V1) and `forestnet` (V2) are different datasets with different
+sensors. For the authoritative list:
+
+```bash
+python -c "from torchgeo_bench.datasets import list_datasets; print(list_datasets())"
+```
+
+Channel count is `len(bands)`, and it changes per dataset — models are
+re-instantiated for every dataset with the right `num_channels`, so never
+hard-code 3 or 13 channels. With `dataset.bands=rgb` the runner picks each
+dataset's declared RGB band names, which differ across families
+(`red,green,blue` vs `b04,b03,b02`, `gray` for `caffe`, `vv,vh` for
+`kuro_siwo`).
+
+## Results and resume
+
+- Metrics land in `results/models/<model name>.csv` (one file per model).
+  `output=path.csv` redirects everything to one file instead.
+- One-time hardware measurements are kept apart: `results/profiles/` and
+  `results/intrinsic_dim/`, plus `results/compute_cost.csv` from `flops`.
+- The CoordBench track (`mode=coord`) streams its benchmarks from
+  HuggingFace — no download — and writes `results/coordbench_results.csv`.
+- `method` is `knn<eval.knn_k>` (`knn5` by default), `linear`, or
+  `seg-<head_type>` (e.g. `seg-fpn`); `metric_name` is `accuracy`,
+  `micro_mAP`, or `mIoU`, reported with `ci_lower` / `ci_upper`.
+- Rows are appended atomically under a file lock, so parallel jobs are safe.
+- `resume=true` skips a `(dataset, method, model, bands, normalization, ...)`
+  combo only when the stored `config_hash` matches the current config — any
+  hashed config change re-runs it.
+- The checked-in CSVs ship with reference results. To start clean, write to
+  your own file (`output=results/my_run.csv`) rather than deleting rows.
+
+Read a whole directory back with
+`from torchgeo_bench.results import load_results`.
+
+## Add a model
+
+Do **not** edit `main.py`. Subclass `BenchModel` and implement
+`_forward_patch_features(images) -> (B, K)`; the base class handles
+normalization and sets `self.num_channels = len(bands)` before your code
+runs. Then add `src/torchgeo_bench/conf/model/<name>.yaml` with a
+`_target_:` dotted path plus your kwargs — the runner injects `bands` at
+construction time, so never declare it in the YAML.
+
+Start from `src/torchgeo_bench/models/contrib_template.py`; it documents the
+three normalization strategies (`bandspec_zscore`, `identity`,
+`model_native`) and when each applies. Wrappers for optional extras import
+their dependency lazily, never at module scope.
+
+## Add a dataset
+
+Add `src/torchgeo_bench/datasets/<safe_name>.py` (hyphens → underscores)
+subclassing `_V1Dataset`, `_V2Dataset`, or `BenchDataset`, declaring `name`,
+`task`, `num_classes`, `multilabel`, `bands`, `rgb_bands`, and
+`split_sizes`. Multi-modality V2 datasets also set
+`band_order_strategy = "by_sensor"`. Register it in
+`datasets/loading.py::_REGISTRY_SPEC`, export it from `datasets/__init__.py`,
+and for new V2 downloads extend `download.py` and `geobench_v2.py`.
+
+## Repository conventions
+
+- Python 3.12+ typing (`list[str]`, `X | None`). No `typing.List/Optional`,
+  no `from __future__ import annotations`.
+- Google-style docstrings (ruff pydocstyle), `logging` instead of `print()`.
+- No defensive `try/except ImportError` around hard dependencies and no bare
+  `except Exception:` — catch the specific error and let the rest crash.
+- Comment only what the code cannot say itself.
+- One logical change per PR, with tests. Commit subjects are Conventional
+  Commits, one line, no body.
+
+```bash
+ruff check . --fix && ruff format .
+pytest                     # fast suite; -m slow adds tests that load real data
+pytest tests/test_cli.py -v
+```
+
+Tests skip themselves when the corresponding data directory is missing, so a
+"skipped" result usually means you need `torchgeo-bench download …` first.
+
+## Troubleshooting
+
+- CUDA errors or no GPU → `device=cpu`.
+- OOM → lower `dataset.batch_size`, then `eval.segmentation.batch_size`.
+- `Unknown model config` → run `torchgeo-bench run --list-models`.
+- Dataset not found → check the exact path under `./data/` from the **current
+  working directory**; the runner does not search elsewhere.
+- Slow iteration → `eval.skip_linear=true eval.bootstrap=100` on one dataset.

--- a/src/torchgeo_bench/skill/__init__.py
+++ b/src/torchgeo_bench/skill/__init__.py
@@ -1,0 +1,17 @@
+"""Agent-facing usage instructions shipped with the package.
+
+``SKILL.md`` is a self-contained brief that teaches a coding agent how to
+drive ``torchgeo-bench``: which commands exist, how config overrides work,
+where results land, and which repository conventions apply when extending
+it.  ``torchgeo-bench --skill`` prints it so an agent can read (or save) it
+without cloning the repository.
+"""
+
+from importlib.resources import files
+
+SKILL_FILE = files(__name__) / "SKILL.md"
+
+
+def read_skill() -> str:
+    """Return the packaged ``SKILL.md`` instructions as text."""
+    return SKILL_FILE.read_text(encoding="utf-8")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -165,3 +165,37 @@ def test_model_names_are_posix_on_every_platform():
     names = list_model_configs()
     assert "torchgeo/scalemae_large_fmow" in names
     assert not any("\\" in n for n in names)
+
+
+def test_skill_prints_instructions(capsys) -> None:
+    cli_main(["--skill"])
+    out = capsys.readouterr().out
+    assert out.startswith("---\nname: torchgeo-bench\n")
+    assert "torchgeo-bench run" in out
+    assert "torchgeo-bench download" in out
+
+
+def test_skill_does_not_import_torch() -> None:
+    """`--skill` must stay instant; it may not drag in the heavy runtime."""
+    import subprocess
+    import sys
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import sys; from torchgeo_bench.cli import main; main(['--skill']); "
+            "sys.stderr.write(str('torch' in sys.modules))",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert "name: torchgeo-bench" in proc.stdout
+    assert proc.stderr == "False"
+
+
+def test_no_command_still_errors(capsys) -> None:
+    with pytest.raises(SystemExit):
+        cli_main([])
+    assert "a command is required" in capsys.readouterr().err


### PR DESCRIPTION
`torchgeo-bench --skill` prints a packaged `SKILL.md` that tells an AI coding agent how to drive the benchmark: the three subcommands, flag/`key=value` override syntax, dataset names, where results land and how resume decides to skip, and the contracts for adding a model or dataset. Agents (and users) can redirect it into a skills directory, e.g. `torchgeo-bench --skill > .claude/skills/torchgeo-bench/SKILL.md`.

The subparser is no longer `required=True` so the flag stands alone; a bare `torchgeo-bench` still errors. The skill path imports nothing beyond the standard library, keeping CLI startup instant.