### PR TITLE
Codecov: no more comments

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,3 @@
+comment: false
+github_checks:
+  annotations: false


### PR DESCRIPTION
Codecov comments on every PR, but there is already a CI check for codecov, so this just means more notifications. This borrows the codecov config from torchgeo.