### PR TITLE
fix(cli): default log level to WARNING unless --verbose

### DIFF
--- a/docs/api/cli.rst
+++ b/docs/api/cli.rst
@@ -10,7 +10,8 @@ The ``torchgeo-bench`` console script exposes three subcommands:
     ``--datasets``, ``--device``, ``--resume``, ...; see ``run --help``), and
     any value in :file:`src/torchgeo_bench/conf/config.yaml` (or any model
     preset under :file:`conf/model/`) can be overridden with ``key=value``
-    pairs, e.g. ``model=timm/resnet50 dataset.names=[m-eurosat]``.
+    pairs, e.g. ``model=timm/resnet50 dataset.names=[m-eurosat]``. Output is
+    quiet by default; pass ``-v``/``--verbose`` for INFO-level progress logs.
 
 ``torchgeo-bench download {geobench_v1|geobench_v2|eurosat}``
     Downloads benchmark datasets into ``./data/`` (or a custom location with

--- a/src/torchgeo_bench/cli.py
+++ b/src/torchgeo_bench/cli.py
@@ -117,13 +117,13 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _setup_logging() -> None:
+def _setup_logging(verbose: bool = False) -> None:
     import logging
 
     from rich.logging import RichHandler
 
     logging.basicConfig(
-        level=logging.INFO,
+        level=logging.INFO if verbose else logging.WARNING,
         format="%(message)s",
         datefmt="[%X]",
         handlers=[RichHandler(rich_tracebacks=True, markup=True)],
@@ -195,7 +195,7 @@ def _cmd_run(args: argparse.Namespace) -> None:
 
         print(OmegaConf.to_yaml(cfg), end="")
         return
-    _setup_logging()
+    _setup_logging(bool(cfg.verbose))
     from torchgeo_bench.main import main
 
     main(cfg)
@@ -208,7 +208,7 @@ def _cmd_flops(args: argparse.Namespace) -> None:
 
         print(OmegaConf.to_yaml(cfg), end="")
         return
-    _setup_logging()
+    _setup_logging(verbose=True)
     from torchgeo_bench.flops_pipeline import main
 
     main(cfg)
@@ -217,7 +217,7 @@ def _cmd_flops(args: argparse.Namespace) -> None:
 def _cmd_download(args: argparse.Namespace) -> None:
     from pathlib import Path
 
-    _setup_logging()
+    _setup_logging(verbose=True)
     from torchgeo_bench.download import (
         download_eurosat,
         download_geobench_v1,


### PR DESCRIPTION
Fixes #249. `torchgeo-bench run` always logged at INFO regardless of `--verbose`. Default is now WARNING unless `-v/--verbose` is passed.