### PR TITLE
fix(main): resolve device with CUDA-availability fallback

### DIFF
--- a/src/torchgeo_bench/flops_pipeline.py
+++ b/src/torchgeo_bench/flops_pipeline.py
@@ -33,6 +33,7 @@ from torchgeo_bench.model_profile import (
 )
 from torchgeo_bench.results import append_rows_atomic
 from torchgeo_bench.segmentation_task import build_seg_probe_and_solver
+from torchgeo_bench.utils import resolve_device
 
 warnings.filterwarnings("ignore", message="Dataset has no geotransform", category=UserWarning)
 
@@ -347,7 +348,7 @@ def main(cfg: DictConfig) -> None:
     output_path = str(cfg.output)
     os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
 
-    device = torch.device(str(cfg.device))
+    device = resolve_device(str(cfg.device))
     image_size = int(cfg.image_size)
     normalization = str(cfg.normalization)
     model_target = str(cfg.model._target_)

--- a/src/torchgeo_bench/main.py
+++ b/src/torchgeo_bench/main.py
@@ -58,7 +58,7 @@ from torchgeo_bench.resume import (  # noqa: F401  (re-exported for back-compat)
     _row_key,
     load_completed,
 )
-from torchgeo_bench.utils import extract_features
+from torchgeo_bench.utils import extract_features, resolve_device
 
 if TYPE_CHECKING:
     import torchgeo_bench.segmentation_task
@@ -696,7 +696,8 @@ def main(cfg: DictConfig) -> None:
     from torchgeo.datasets import DatasetNotFoundError
 
     dataset_names = _expand_dataset_list(cfg.dataset.names)
-    device = torch.device(cfg.device)
+    device = resolve_device(cfg.device)
+    cfg.device = str(device)
 
     output_path = _resolve_output_path(cfg)
     profile_output_path = _resolve_side_output_path(
@@ -1050,7 +1051,7 @@ def main(cfg: DictConfig) -> None:
                 profile_rows = evaluate_profile(
                     model=model,
                     sample_loader=train_loader,
-                    device=torch.device(cfg.device),
+                    device=device,
                     n_warmup=int(profile_cfg.get("n_warmup", 3)),
                     n_measure=int(profile_cfg.get("n_measure", 20)),
                     common_meta=common_meta,

--- a/src/torchgeo_bench/utils.py
+++ b/src/torchgeo_bench/utils.py
@@ -1,9 +1,22 @@
 """Feature extraction utilities for model benchmarking."""
 
+import logging
+
 import numpy as np
 import torch
 from rich.progress import track
 from torch.utils.data import DataLoader
+
+logger = logging.getLogger(__name__)
+
+
+def resolve_device(requested_device: str | torch.device) -> torch.device:
+    """Resolve a requested device, falling back to CPU if CUDA is unavailable."""
+    device = torch.device(requested_device)
+    if device.type == "cuda" and not torch.cuda.is_available():
+        logger.warning("CUDA requested but not available; falling back to CPU.")
+        return torch.device("cpu")
+    return device
 
 
 def extract_features(


### PR DESCRIPTION
Fixes #248. `cfg.device` defaults to `cuda:0` and was passed straight to `torch.device()`, so `torchgeo-bench run` crashed on machines without CUDA (e.g. macOS) even when the user tried `eval.knn_device=cpu`. Adds a `resolve_device` helper (mirrors the fallback already used in `linear.py`) and uses it for the model device in `main.py`/`flops_pipeline.py`; also fixes the KNN device-mismatch warning to report the actual resolved device instead of the raw unresolved config string.