### PR TITLE
fix(loading): make resize transform picklable for spawned workers

### DIFF
--- a/src/torchgeo_bench/datasets/geobench_v2.py
+++ b/src/torchgeo_bench/datasets/geobench_v2.py
@@ -49,6 +49,31 @@ def list_v2_datasets() -> list[str]:
     return sorted(_V2_REGISTRY)
 
 
+class _ChainedTransform:
+    """Canonicalize an upstream V2 sample, then apply the framework transform."""
+
+    def __init__(self, canonicalize: Callable[[dict], dict], transform: Callable | None) -> None:
+        self.canonicalize = canonicalize
+        self.transform = transform
+
+    def __call__(self, sample: dict) -> dict:
+        sample = self.canonicalize(sample)
+        if self.transform is None:
+            return sample
+        if "image" in sample:
+            return self.transform(sample)
+        image_keys = [k for k in sample if k.startswith("image_")]
+        for index, key in enumerate(image_keys):
+            wrapped = {"image": sample[key]}
+            if index == 0 and "mask" in sample:
+                wrapped["mask"] = sample["mask"]
+            wrapped = self.transform(wrapped)
+            sample[key] = wrapped["image"]
+            if "mask" in wrapped:
+                sample["mask"] = wrapped["mask"]
+        return sample
+
+
 class GeoBenchv2(Dataset):
     """Thin :class:`Dataset` adapter around any GeoBench V2 upstream class.
 
@@ -172,28 +197,6 @@ class _V2Dataset(BenchDataset):
         """
         del partition
         band_order = self.build_band_order(bands)
-        canonicalize = self.canonicalize_sample
-
-        def chained(sample: dict) -> dict:
-            sample = canonicalize(sample)  # rename image_b → "image" first
-            if transform is not None:
-                if "image" in sample:
-                    sample = transform(sample)  # _resize now finds "image" safely
-                else:
-                    # treesatai applies its transforms on the per-modality dict
-                    # (image_aerial / image_s2 / image_s1) *before* stacking, so
-                    # the framework's resize transform must operate on each
-                    # modality independently here.
-                    image_keys = [k for k in sample if k.startswith("image_")]
-                    for index, key in enumerate(image_keys):
-                        wrapped = {"image": sample[key]}
-                        if index == 0 and "mask" in sample:
-                            wrapped["mask"] = sample["mask"]
-                        wrapped = transform(wrapped)
-                        sample[key] = wrapped["image"]
-                        if "mask" in wrapped:
-                            sample["mask"] = wrapped["mask"]
-            return sample
 
         kwargs: dict[str, object] = {
             "data_normalizer": nn.Identity,
@@ -211,7 +214,7 @@ class _V2Dataset(BenchDataset):
             dataset_name=self.name,
             split=split,
             band_order=band_order,
-            transforms=chained,
+            transforms=_ChainedTransform(self.canonicalize_sample, transform),
             **kwargs,
         )
 

--- a/src/torchgeo_bench/datasets/loading.py
+++ b/src/torchgeo_bench/datasets/loading.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING
 from .base import BenchDataset
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterable
+    from collections.abc import Iterable
 
     import torch
     from torch.utils.data import DataLoader, Dataset
@@ -93,23 +93,24 @@ def list_datasets() -> list[str]:
     return sorted(_REGISTRY_SPEC)
 
 
-def _make_resize_transform(
-    image_size: int | None,
-    interpolation: str,
-) -> Callable[[dict], dict] | None:
-    """Build a sample-level transform that resizes ``image`` (and ``mask``)."""
-    if image_size is None:
-        return None
+class _ResizeTransform:
+    """Sample-level transform that resizes ``image`` (and ``mask``)."""
 
     valid_modes = ("area", "bicubic", "bilinear", "nearest")
-    if interpolation not in valid_modes:
-        raise ValueError(f"interpolation must be one of {valid_modes}, got {interpolation!r}.")
-    interp_mode = interpolation
-    align_corners = False if interp_mode in ("bicubic", "bilinear") else None
 
-    import torch.nn.functional as F
+    def __init__(self, image_size: int, interp_mode: str) -> None:
+        if interp_mode not in self.valid_modes:
+            raise ValueError(
+                f"interpolation must be one of {self.valid_modes}, got {interp_mode!r}."
+            )
+        self.image_size = image_size
+        self.interp_mode = interp_mode
+        self.align_corners = False if interp_mode in ("bicubic", "bilinear") else None
 
-    def _resize(sample: dict) -> dict:
+    def __call__(self, sample: dict) -> dict:
+        import torch.nn.functional as F
+
+        image_size = self.image_size
         img: torch.Tensor = sample["image"]
         h, w = img.shape[-2], img.shape[-1]
         if h != image_size or w != image_size:
@@ -118,8 +119,8 @@ def _make_resize_transform(
             img = F.interpolate(
                 resize_input,
                 size=(image_size, image_size),
-                mode=interp_mode,
-                align_corners=align_corners,
+                mode=self.interp_mode,
+                align_corners=self.align_corners,
             )
             if squeeze_batch:
                 img = img.squeeze(0)
@@ -147,8 +148,6 @@ def _make_resize_transform(
                 mask = mask.long()
                 sample["mask"] = mask
         return sample
-
-    return _resize
 
 
 def _make_loader(ds: Dataset, *, batch_size: int, shuffle: bool, num_workers: int) -> DataLoader:
@@ -227,7 +226,7 @@ def get_datasets(
     else:
         bands_tuple = tuple(bands)
 
-    transform = _make_resize_transform(image_size, interpolation)
+    transform = _ResizeTransform(image_size, interpolation) if image_size is not None else None
     train_partition = partition_name if bench.supports_partitions else "default"
 
     common: dict = {"bands": bands_tuple, "transform": transform}

--- a/tests/test_silent_bug_regressions.py
+++ b/tests/test_silent_bug_regressions.py
@@ -7,7 +7,7 @@ from torch.utils.data import DataLoader
 
 from torchgeo_bench.datasets.base import BandSpec
 from torchgeo_bench.datasets.caffe import CaFFe
-from torchgeo_bench.datasets.loading import _make_resize_transform
+from torchgeo_bench.datasets.loading import _ResizeTransform
 from torchgeo_bench.models import InputUnit
 from torchgeo_bench.models._input_units import detect_input_unit
 from torchgeo_bench.utils import extract_features
@@ -34,11 +34,11 @@ def test_extract_features_preserves_batch_dimension_for_head_global_pool() -> No
 
 def test_invalid_interpolation_raises_instead_of_falling_back() -> None:
     with pytest.raises(ValueError, match="interpolation must be one of"):
-        _make_resize_transform(224, "bilnear")
+        _ResizeTransform(224, "bilnear")
 
 
 def test_area_interpolation_resizes_to_requested_grid() -> None:
-    transform = _make_resize_transform(2, "area")
+    transform = _ResizeTransform(2, "area")
     assert transform is not None
 
     image = torch.arange(16, dtype=torch.float32).reshape(1, 4, 4)
@@ -50,7 +50,7 @@ def test_area_interpolation_resizes_to_requested_grid() -> None:
 
 
 def test_resize_handles_temporal_images_and_singleton_channel_masks() -> None:
-    transform = _make_resize_transform(4, "bilinear")
+    transform = _ResizeTransform(4, "bilinear")
     assert transform is not None
 
     sample = {


### PR DESCRIPTION
Fixes #254. The dataset resize transform was a closure, which isn't picklable — DataLoader workers under the `spawn`/`forkserver` start methods (default on macOS, and on Python 3.14+ elsewhere) failed to start when `dataset.image_size` was set. Converted to a plain class instance instead.