### PR TITLE
fix(main): always show per-split embedding progress

### DIFF
--- a/src/torchgeo_bench/main.py
+++ b/src/torchgeo_bench/main.py
@@ -90,10 +90,17 @@ def _expand_dataset_list(names: str | Sequence[str]) -> list[str]:
 
 
 def embed_split(
-    model: BenchModel, dataloader: DataLoader, device: torch.device, verbose: bool
+    model: BenchModel,
+    dataloader: DataLoader,
+    device: torch.device,
+    verbose: bool,
+    split: str = "",
 ) -> tuple[np.ndarray, np.ndarray]:
     """Extract feature embeddings and labels from a data split."""
-    return extract_features(model, dataloader, device, transforms=None, verbose=verbose)
+    description = f"Extracting ({split})" if split else "Extracting"
+    return extract_features(
+        model, dataloader, device, transforms=None, verbose=verbose, description=description
+    )
 
 
 def evaluate_knn(
@@ -937,9 +944,11 @@ def main(cfg: DictConfig) -> None:
             else:
                 # Classification (single-label or multi-label)
                 metric_name = plan.metric_name
-                x_train, y_train = embed_split(model, train_loader, device, verbose=cfg.verbose)
-                x_val, y_val = embed_split(model, val_loader, device, verbose=cfg.verbose)
-                x_test, y_test = embed_split(model, test_loader, device, verbose=cfg.verbose)
+                x_train, y_train = embed_split(
+                    model, train_loader, device, verbose=True, split="train"
+                )
+                x_val, y_val = embed_split(model, val_loader, device, verbose=True, split="val")
+                x_test, y_test = embed_split(model, test_loader, device, verbose=True, split="test")
                 feature_dim = x_train.shape[1]
                 n_counts = {"train": len(x_train), "val": len(x_val), "test": len(x_test)}
 

--- a/src/torchgeo_bench/utils.py
+++ b/src/torchgeo_bench/utils.py
@@ -25,6 +25,7 @@ def extract_features(
     device: str | torch.device,
     transforms: object | None = None,
     verbose: bool = True,
+    description: str = "Extracting",
 ) -> tuple[np.ndarray, np.ndarray]:
     """Extract feature embeddings and labels from a dataloader.
 
@@ -34,6 +35,7 @@ def extract_features(
         device: Device to run inference on.
         transforms: Optional transform applied to images before the model.
         verbose: Whether to display a progress bar.
+        description: Progress bar label.
 
     Returns:
         Tuple of (features, labels) as NumPy arrays.
@@ -42,9 +44,7 @@ def extract_features(
     y_all = []
 
     iterator = (
-        track(dataloader, total=len(dataloader), description="Extracting")
-        if verbose
-        else dataloader
+        track(dataloader, total=len(dataloader), description=description) if verbose else dataloader
     )
 
     for batch in iterator:


### PR DESCRIPTION
Addresses the training-progress half of #250. With `verbose=false` (the default), the outer per-dataset progress bar was the only visible progress — for a single-dataset run that meant it sat at 0% through the whole embed+KNN+linear-probe pass and jumped straight to 100%, because feature extraction, the actual iterative work, had its own bar gated behind `--verbose`.

KNN and the LBFGS-solved logistic probe are one-shot fits with no sub-progress of their own, so the fix is surfacing progress for the part of the pipeline that is iterative and usually dominates wall-clock: per-batch feature extraction. That bar now shows unconditionally, independent of `--verbose` (which only controls log level, per #249), labeled by split — `Extracting (train)`/`(val)`/`(test)`.

The upstream torch.hub download bar, the other half of #250, isn't something torchgeo-bench can fix on its own — see the issue thread, and #276 for the part that actually was ours.
