### PR TITLE
feat(cli): add --list-datasets and --model-help

### DIFF
--- a/docs/api/cli.rst
+++ b/docs/api/cli.rst
@@ -12,6 +12,9 @@ The ``torchgeo-bench`` console script exposes three subcommands:
     preset under :file:`conf/model/`) can be overridden with ``key=value``
     pairs, e.g. ``model=timm/resnet50 dataset.names=[m-eurosat]``. Output is
     quiet by default; pass ``-v``/``--verbose`` for INFO-level progress logs.
+    ``--list-models``/``--list-datasets`` list valid ``model=``/``dataset.names=``
+    values, and ``--model-help <name>`` prints that model config's YAML
+    (its available ``model.*`` overrides) without running anything.
 
 ``torchgeo-bench download {geobench_v1|geobench_v2|eurosat}``
     Downloads benchmark datasets into ``./data/`` (or a custom location with

--- a/src/torchgeo_bench/cli.py
+++ b/src/torchgeo_bench/cli.py
@@ -85,6 +85,15 @@ def _build_parser() -> argparse.ArgumentParser:
     run.add_argument(
         "--list-models", action="store_true", help="List available model configs and exit"
     )
+    run.add_argument(
+        "--list-datasets", action="store_true", help="List available dataset names and exit"
+    )
+    run.add_argument(
+        "--model-help",
+        metavar="MODEL",
+        default=None,
+        help="Print a model config's YAML (available key=value overrides) and exit",
+    )
     _add_override_arg(run)
     run.set_defaults(func=_cmd_run)
 
@@ -188,6 +197,19 @@ def _cmd_run(args: argparse.Namespace) -> None:
         from torchgeo_bench.config import list_model_configs
 
         print("\n".join(list_model_configs()))
+        return
+    if args.list_datasets:
+        from torchgeo_bench.datasets import list_datasets
+
+        print("\n".join(list_datasets()))
+        return
+    if args.model_help is not None:
+        from torchgeo_bench.config import model_config_path
+
+        try:
+            print(model_config_path(args.model_help).read_text(), end="")
+        except ValueError as err:
+            raise SystemExit(f"error: {err}") from err
         return
     cfg = _compose(args, config_name="config", default_model="rcf")
     if args.print_config:

--- a/src/torchgeo_bench/config.py
+++ b/src/torchgeo_bench/config.py
@@ -37,6 +37,13 @@ def list_model_configs() -> list[str]:
     )
 
 
+def model_config_path(name: str) -> Path:
+    """Return the YAML file backing ``model=<name>`` / ``--model <name>``."""
+    if name not in list_model_configs():
+        raise ValueError(f"Unknown model config '{name}'. {_closest_models(name)}")
+    return CONF_DIR / "model" / f"{name}.yaml"
+
+
 def _closest_models(name: str, n: int = 5) -> str:
     """Suggestion fragment naming the closest config names, or '' if none are close."""
     import difflib

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -54,6 +54,28 @@ def test_run_list_models(capsys) -> None:
     assert "torchgeo/scalemae_large_fmow" in out
 
 
+def test_run_list_datasets(capsys) -> None:
+    cli_main(["run", "--list-datasets"])
+    out = capsys.readouterr().out
+    assert "m-eurosat" in out
+
+
+def test_run_model_help(capsys) -> None:
+    cli_main(["run", "--model-help", "rcf"])
+    out = capsys.readouterr().out
+    assert "torchgeo_bench.models.RCFBench" in out
+
+
+def test_run_model_help_unknown_model_errors() -> None:
+    with pytest.raises(SystemExit, match="error: Unknown model config"):
+        cli_main(["run", "--model-help", "not-a-real-model"])
+
+
+def test_run_model_help_rejects_path_traversal() -> None:
+    with pytest.raises(SystemExit, match="error: Unknown model config"):
+        cli_main(["run", "--model-help", "../flops_config"])
+
+
 def test_download_invalid_target(capsys) -> None:
     with pytest.raises(SystemExit):
         cli_main(["download", "bogus"])


### PR DESCRIPTION
Addresses #255. torchgeo-bench had `--list-models` but nothing equivalent for datasets, and no way to see what `key=value` overrides a given model config accepts short of opening its YAML directly.

`--list-datasets` lists valid `dataset.names=` values (mirrors `--list-models`). `--model-help <name>` prints that model config's raw YAML — fields, defaults, inline comments — so overrides are discoverable from the CLI.

Not jsonargparse-style `--model.help ClassName` introspection, since torchgeo-bench uses plain OmegaConf composition rather than jsonargparse, but it answers "what key=value pairs are even possible" for a model without digging through the repo.
