### PR TITLE
fix(main): stop rich's Datasets progress bar from corrupting nested tqdm bars

### DIFF
--- a/src/torchgeo_bench/main.py
+++ b/src/torchgeo_bench/main.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 import torch
 from omegaconf import DictConfig, OmegaConf
-from rich.progress import track
+from rich.progress import Progress, track
 from torch.utils.data import DataLoader
 
 from torchgeo_bench.calibration import (
@@ -742,339 +742,348 @@ def main(cfg: DictConfig) -> None:
     bands_value = _normalize_bands_value(getattr(cfg.dataset, "bands", "rgb"))
     config_hash = _resume_config_hash(cfg)
 
-    for ds_name in track(dataset_names, description="Datasets"):
-        try:
-            ds_cls = get_bench_dataset_class(ds_name)
-        except KeyError:
-            logger.warning(f"Skipping dataset {ds_name} (not in registry)")
-            continue
+    dataset_progress = Progress(redirect_stdout=False, redirect_stderr=False, auto_refresh=False)
+    dataset_progress.start()
+    try:
+        for ds_name in dataset_progress.track(dataset_names, description="Datasets"):
+            try:
+                ds_cls = get_bench_dataset_class(ds_name)
+            except KeyError:
+                logger.warning(f"Skipping dataset {ds_name} (not in registry)")
+                continue
 
-        model_cfg = resolve_model_config(cfg.model, ds_name)
+            model_cfg = resolve_model_config(cfg.model, ds_name)
 
-        effective_image_size = model_cfg.get("image_size", cfg.dataset.get("image_size"))
-        effective_interpolation = model_cfg.get(
-            "interpolation", cfg.dataset.get("interpolation", "bilinear")
-        )
-        model_res = model_cfg.get("res")
-        model_pool = model_cfg.get("pool")
-
-        config_tuple = tuple(
-            _canonical_key_cell(v)
-            for v in (
-                normalization,
-                effective_image_size,
-                effective_interpolation,
-                cfg.dataset.partition,
-                bands_value,
-                ds_cls.num_classes,
-                model_res,
-                model_pool,
-                config_hash,
+            effective_image_size = model_cfg.get("image_size", cfg.dataset.get("image_size"))
+            effective_interpolation = model_cfg.get(
+                "interpolation", cfg.dataset.get("interpolation", "bilinear")
             )
-        )
-        eval_cfg_merged = OmegaConf.merge(cfg.eval, model_eval or {})
-        knn_k = int(getattr(eval_cfg_merged, "knn_k", 5))
-        seg_method = f"seg-{eval_cfg_merged.segmentation.head_type}"
-        plan = _plan_dataset_run(
-            cfg=cfg,
-            ds_name=ds_name,
-            ds_cls=ds_cls,
-            knn_k=knn_k,
-            seg_method=seg_method,
-            config_tuple=config_tuple,
-            completed_runs=completed_runs,
-            completed_metrics=completed_metrics,
-        )
-        if plan.skip_dataset:
-            if cfg.verbose:
-                logger.info(f"[{ds_name}] Resume preflight: all requested work already complete")
-            continue
+            model_res = model_cfg.get("res")
+            model_pool = model_cfg.get("pool")
 
-        knn_device: str | None = None
-        if ds_cls.task != "segmentation" and not plan.skip_knn:
-            knn_device = resolve_knn_device(cfg.eval.get("knn_device"), cfg.device)
-
-        try:
-            result = get_datasets(
-                dataset_name=ds_name,
-                partition_name=cfg.dataset.partition,
-                batch_size=cfg.dataset.batch_size,
-                num_workers=int(cfg.dataset.get("num_workers", 8)),
-                return_val=True,
-                image_size=effective_image_size,
-                interpolation=effective_interpolation,
-                bands=getattr(cfg.dataset, "bands", "rgb"),
-                time_steps=cfg.dataset.get("time_steps", None),
-            )
-        except (FileNotFoundError, DatasetNotFoundError) as exc:
-            logger.warning(f"Skipping dataset {ds_name} (data not found: {exc})")
-            continue
-        train_dataset, train_loader, val_loader, test_loader = result
-
-        num_channels = train_dataset[0]["image"].shape[0]
-        is_segmentation = ds_cls.task == "segmentation"
-        num_classes = ds_cls.num_classes
-
-        # Build the BandSpec list that matches the actual loaded channels.
-        bench = ds_cls()
-        bands_resolved = (
-            tuple(bench.rgb_bands)
-            if cfg.dataset.bands == "rgb"
-            else None
-            if cfg.dataset.bands in ("all", None)
-            else tuple(cfg.dataset.bands)
-        )
-        bands_list = bench.select_band_specs(bands_resolved)
-        if len(bands_list) != num_channels:
-            raise ValueError(
-                f"BandSpec count {len(bands_list)} != tensor channel count {num_channels} "
-                f"for dataset {ds_name}; sample-level canonicalization may have changed shape."
-            )
-
-        # `bands` is passed as a kwarg (not via the config) so the BandSpec
-        # dataclasses reach the constructor intact.
-        instantiate_kwargs: dict = {
-            "bands": bands_list,
-            "normalization": normalization,
-        }
-        if model_cfg.get("mode", None) == "empirical":
-            # Empirical RCF whitens against real patches, so it needs the dataset.
-            instantiate_kwargs["dataset"] = train_dataset
-        # Interpolation belongs to the loader rather than the model constructor.
-        model_cfg.pop("interpolation", None)
-        model: BenchModel = instantiate(model_cfg, **instantiate_kwargs)
-        model.to(device).eval()
-
-        common_meta = {
-            "dataset": ds_name,
-            "seed": cfg.seed,
-            "model": model_cfg._target_,
-            "name": model_cfg.name,
-            "normalization": normalization,
-            "image_size": effective_image_size,
-            "interpolation": effective_interpolation,
-            "partition": cfg.dataset.partition,
-            "bands": bands_value,
-            "num_classes": num_classes,
-            "config_hash": config_hash,
-            "c_range_start": c_start,
-            "c_range_stop": c_stop,
-            "c_range_num": c_num,
-            "merge_val": cfg.eval.merge_val,
-            "bootstrap": cfg.eval.bootstrap,
-            "res": model_res,
-            "pool": model_pool,
-        }
-
-        if is_segmentation:
-            seg_cfg_merged = eval_cfg_merged.segmentation
-            save_viz = seg_cfg_merged.get("save_viz", False)
-            segmentation_meta = {**common_meta, "merge_val": False}
-            metrics, feat_dim, best_lr, best_bs, preds = evaluate_segmentation(
-                model,
-                train_loader,
-                val_loader,
-                test_loader,
-                eval_cfg_merged,
-                num_classes,
-                device,
-                seed=cfg.seed,
-                collect_preds=save_viz,
-                verbose=cfg.verbose,
-            )
-            all_rows.append(
-                metric_row(
-                    segmentation_meta,
-                    method=seg_method,
-                    metric_name="mIoU",
-                    metric_value=metrics.get("mIoU", float("nan")),
-                    ci_lower=metrics.get("ci_lower", float("nan")),
-                    ci_upper=metrics.get("ci_upper", float("nan")),
-                    feature_dim=feat_dim,
-                    n_counts={
-                        "train": len(train_dataset),
-                        "val": len(val_loader.dataset),
-                        "test": len(test_loader.dataset),
-                    },
-                    best_lr=best_lr,
-                    best_batch_size=best_bs,
-                    fw_iou=metrics.get("fw_IoU"),
-                    precision=metrics.get("precision"),
-                    recall=metrics.get("recall"),
-                    f1=metrics.get("f1"),
+            config_tuple = tuple(
+                _canonical_key_cell(v)
+                for v in (
+                    normalization,
+                    effective_image_size,
+                    effective_interpolation,
+                    cfg.dataset.partition,
+                    bands_value,
+                    ds_cls.num_classes,
+                    model_res,
+                    model_pool,
+                    config_hash,
                 )
             )
-            if save_viz and preds is not None:
-                from torchgeo_bench.segmentation_viz import (
-                    collect_viz_inputs,
-                    save_segmentation_viz,
-                )
+            eval_cfg_merged = OmegaConf.merge(cfg.eval, model_eval or {})
+            knn_k = int(getattr(eval_cfg_merged, "knn_k", 5))
+            seg_method = f"seg-{eval_cfg_merged.segmentation.head_type}"
+            plan = _plan_dataset_run(
+                cfg=cfg,
+                ds_name=ds_name,
+                ds_cls=ds_cls,
+                knn_k=knn_k,
+                seg_method=seg_method,
+                config_tuple=config_tuple,
+                completed_runs=completed_runs,
+                completed_metrics=completed_metrics,
+            )
+            if plan.skip_dataset:
+                if cfg.verbose:
+                    logger.info(
+                        f"[{ds_name}] Resume preflight: all requested work already complete"
+                    )
+                continue
 
-                rgb_indices = bench.rgb_indices or [0, 1, 2]
-                test_imgs_t, test_gts_t = collect_viz_inputs(test_loader)
-                ignore_idx = seg_cfg_merged.get("ignore_index", 255)
-                n_viz = seg_cfg_merged.get("n_viz_samples", 8)
-                viz_dir = seg_cfg_merged.get("viz_dir", "viz")
-                _class_names = list(getattr(train_dataset, "classes", None) or []) or None
-                save_segmentation_viz(
-                    out_dir=viz_dir,
-                    model_name=model_cfg.name,
+            knn_device: str | None = None
+            if ds_cls.task != "segmentation" and not plan.skip_knn:
+                knn_device = resolve_knn_device(cfg.eval.get("knn_device"), cfg.device)
+
+            try:
+                result = get_datasets(
                     dataset_name=ds_name,
-                    images=test_imgs_t,
-                    gt_masks=test_gts_t,
-                    pred_masks=preds,
-                    num_classes=num_classes,
-                    rgb_indices=rgb_indices,
-                    ignore_index=ignore_idx,
-                    n_samples=n_viz,
-                    class_names=_class_names,
+                    partition_name=cfg.dataset.partition,
+                    batch_size=cfg.dataset.batch_size,
+                    num_workers=int(cfg.dataset.get("num_workers", 8)),
+                    return_val=True,
+                    image_size=effective_image_size,
+                    interpolation=effective_interpolation,
+                    bands=getattr(cfg.dataset, "bands", "rgb"),
+                    time_steps=cfg.dataset.get("time_steps", None),
                 )
-        else:
-            # Classification (single-label or multi-label)
-            metric_name = plan.metric_name
-            x_train, y_train = embed_split(model, train_loader, device, verbose=cfg.verbose)
-            x_val, y_val = embed_split(model, val_loader, device, verbose=cfg.verbose)
-            x_test, y_test = embed_split(model, test_loader, device, verbose=cfg.verbose)
-            feature_dim = x_train.shape[1]
-            n_counts = {"train": len(x_train), "val": len(x_val), "test": len(x_test)}
+            except (FileNotFoundError, DatasetNotFoundError) as exc:
+                logger.warning(f"Skipping dataset {ds_name} (data not found: {exc})")
+                continue
+            train_dataset, train_loader, val_loader, test_loader = result
 
-            cal_cfg = cfg.eval.get("calibration", {}) or {}
-            cal_n_bins_knn = cal_cfg.get("n_bins_knn", None)
-            cal_n_bins_linear = int(cal_cfg.get("n_bins_linear", 15))
-            cal_temp_scale = bool(cal_cfg.get("temp_scale", True))
+            num_channels = train_dataset[0]["image"].shape[0]
+            is_segmentation = ds_cls.task == "segmentation"
+            num_classes = ds_cls.num_classes
 
-            if not plan.skip_knn:
-                assert knn_device is not None
-                knn_score, knn_lo, knn_hi, knn_cal, knn_n_bins = evaluate_knn(
-                    x_train,
-                    y_train,
-                    x_test,
-                    y_test,
-                    cfg.seed,
-                    cfg.eval.bootstrap,
+            # Build the BandSpec list that matches the actual loaded channels.
+            bench = ds_cls()
+            bands_resolved = (
+                tuple(bench.rgb_bands)
+                if cfg.dataset.bands == "rgb"
+                else None
+                if cfg.dataset.bands in ("all", None)
+                else tuple(cfg.dataset.bands)
+            )
+            bands_list = bench.select_band_specs(bands_resolved)
+            if len(bands_list) != num_channels:
+                raise ValueError(
+                    f"BandSpec count {len(bands_list)} != tensor channel count {num_channels} "
+                    f"for dataset {ds_name}; sample-level canonicalization may have changed shape."
+                )
+
+            # `bands` is passed as a kwarg (not via the config) so the BandSpec
+            # dataclasses reach the constructor intact.
+            instantiate_kwargs: dict = {
+                "bands": bands_list,
+                "normalization": normalization,
+            }
+            if model_cfg.get("mode", None) == "empirical":
+                # Empirical RCF whitens against real patches, so it needs the dataset.
+                instantiate_kwargs["dataset"] = train_dataset
+            # Interpolation belongs to the loader rather than the model constructor.
+            model_cfg.pop("interpolation", None)
+            model: BenchModel = instantiate(model_cfg, **instantiate_kwargs)
+            model.to(device).eval()
+
+            common_meta = {
+                "dataset": ds_name,
+                "seed": cfg.seed,
+                "model": model_cfg._target_,
+                "name": model_cfg.name,
+                "normalization": normalization,
+                "image_size": effective_image_size,
+                "interpolation": effective_interpolation,
+                "partition": cfg.dataset.partition,
+                "bands": bands_value,
+                "num_classes": num_classes,
+                "config_hash": config_hash,
+                "c_range_start": c_start,
+                "c_range_stop": c_stop,
+                "c_range_num": c_num,
+                "merge_val": cfg.eval.merge_val,
+                "bootstrap": cfg.eval.bootstrap,
+                "res": model_res,
+                "pool": model_pool,
+            }
+
+            if is_segmentation:
+                seg_cfg_merged = eval_cfg_merged.segmentation
+                save_viz = seg_cfg_merged.get("save_viz", False)
+                segmentation_meta = {**common_meta, "merge_val": False}
+                metrics, feat_dim, best_lr, best_bs, preds = evaluate_segmentation(
+                    model,
+                    train_loader,
+                    val_loader,
+                    test_loader,
+                    eval_cfg_merged,
+                    num_classes,
+                    device,
+                    seed=cfg.seed,
+                    collect_preds=save_viz,
                     verbose=cfg.verbose,
-                    device=knn_device,
-                    n_neighbors=knn_k,
-                    calibration_n_bins=cal_n_bins_knn,
                 )
                 all_rows.append(
                     metric_row(
-                        common_meta,
-                        method=f"knn{knn_k}",
-                        metric_name=metric_name,
-                        metric_value=knn_score,
-                        ci_lower=knn_lo,
-                        ci_upper=knn_hi,
-                        feature_dim=feature_dim,
-                        n_counts=n_counts,
-                        ece=knn_cal["ece"],
-                        rms_ce=knn_cal["rms_ce"],
-                        mce=knn_cal["mce"],
-                        calibration_n_bins=knn_n_bins,
+                        segmentation_meta,
+                        method=seg_method,
+                        metric_name="mIoU",
+                        metric_value=metrics.get("mIoU", float("nan")),
+                        ci_lower=metrics.get("ci_lower", float("nan")),
+                        ci_upper=metrics.get("ci_upper", float("nan")),
+                        feature_dim=feat_dim,
+                        n_counts={
+                            "train": len(train_dataset),
+                            "val": len(val_loader.dataset),
+                            "test": len(test_loader.dataset),
+                        },
+                        best_lr=best_lr,
+                        best_batch_size=best_bs,
+                        fw_iou=metrics.get("fw_IoU"),
+                        precision=metrics.get("precision"),
+                        recall=metrics.get("recall"),
+                        f1=metrics.get("f1"),
                     )
                 )
+                if save_viz and preds is not None:
+                    from torchgeo_bench.segmentation_viz import (
+                        collect_viz_inputs,
+                        save_segmentation_viz,
+                    )
 
-            if not plan.skip_linear:
-                try:
-                    lin_score, lin_lo, lin_hi, best_c, lin_cal, lin_cal_ts = evaluate_logistic(
+                    rgb_indices = bench.rgb_indices or [0, 1, 2]
+                    test_imgs_t, test_gts_t = collect_viz_inputs(test_loader)
+                    ignore_idx = seg_cfg_merged.get("ignore_index", 255)
+                    n_viz = seg_cfg_merged.get("n_viz_samples", 8)
+                    viz_dir = seg_cfg_merged.get("viz_dir", "viz")
+                    _class_names = list(getattr(train_dataset, "classes", None) or []) or None
+                    save_segmentation_viz(
+                        out_dir=viz_dir,
+                        model_name=model_cfg.name,
+                        dataset_name=ds_name,
+                        images=test_imgs_t,
+                        gt_masks=test_gts_t,
+                        pred_masks=preds,
+                        num_classes=num_classes,
+                        rgb_indices=rgb_indices,
+                        ignore_index=ignore_idx,
+                        n_samples=n_viz,
+                        class_names=_class_names,
+                    )
+            else:
+                # Classification (single-label or multi-label)
+                metric_name = plan.metric_name
+                x_train, y_train = embed_split(model, train_loader, device, verbose=cfg.verbose)
+                x_val, y_val = embed_split(model, val_loader, device, verbose=cfg.verbose)
+                x_test, y_test = embed_split(model, test_loader, device, verbose=cfg.verbose)
+                feature_dim = x_train.shape[1]
+                n_counts = {"train": len(x_train), "val": len(x_val), "test": len(x_test)}
+
+                cal_cfg = cfg.eval.get("calibration", {}) or {}
+                cal_n_bins_knn = cal_cfg.get("n_bins_knn", None)
+                cal_n_bins_linear = int(cal_cfg.get("n_bins_linear", 15))
+                cal_temp_scale = bool(cal_cfg.get("temp_scale", True))
+
+                if not plan.skip_knn:
+                    assert knn_device is not None
+                    knn_score, knn_lo, knn_hi, knn_cal, knn_n_bins = evaluate_knn(
                         x_train,
                         y_train,
-                        x_val,
-                        y_val,
                         x_test,
                         y_test,
-                        c_values_list,
                         cfg.seed,
                         cfg.eval.bootstrap,
-                        cfg.eval.merge_val,
-                        cfg.device,
-                        cfg.verbose,
-                        calibration_n_bins=cal_n_bins_linear,
-                        temp_scale=cal_temp_scale,
+                        verbose=cfg.verbose,
+                        device=knn_device,
+                        n_neighbors=knn_k,
+                        calibration_n_bins=cal_n_bins_knn,
                     )
-                except LinearProbeDivergedError as exc:
-                    # A handful of (backbone, dataset) pairings produce feature
-                    # magnitudes the probe can't fit at any C in the sweep. That's
-                    # a property of this one combination, not the rest of the
-                    # benchmark run, so skip just this row rather than losing
-                    # every other already-computed metric to an uncaught crash.
-                    logger.warning(
-                        f"[linear] model={common_meta.get('model')} "
-                        f"dataset={common_meta.get('dataset')} bands={common_meta.get('bands')} "
-                        f"norm={common_meta.get('normalization')}: skipping, no usable C found. "
-                        f"Diagnostic: {exc}"
-                    )
-                else:
                     all_rows.append(
                         metric_row(
                             common_meta,
-                            method="linear",
+                            method=f"knn{knn_k}",
                             metric_name=metric_name,
-                            metric_value=lin_score,
-                            ci_lower=lin_lo,
-                            ci_upper=lin_hi,
+                            metric_value=knn_score,
+                            ci_lower=knn_lo,
+                            ci_upper=knn_hi,
                             feature_dim=feature_dim,
                             n_counts=n_counts,
-                            best_c=best_c,
-                            ece=lin_cal["ece"],
-                            rms_ce=lin_cal["rms_ce"],
-                            mce=lin_cal["mce"],
-                            ece_ts=lin_cal_ts["ece_ts"],
-                            rms_ce_ts=lin_cal_ts["rms_ce_ts"],
-                            mce_ts=lin_cal_ts["mce_ts"],
-                            temperature=lin_cal_ts["temperature"],
-                            calibration_n_bins=cal_n_bins_linear,
+                            ece=knn_cal["ece"],
+                            rms_ce=knn_cal["rms_ce"],
+                            mce=knn_cal["mce"],
+                            calibration_n_bins=knn_n_bins,
                         )
                     )
-            if not plan.skip_id:
-                id_cfg = cfg.eval.intrinsic_dim
-                id_rows = evaluate_intrinsic_dim(
-                    splits={"train": x_train, "val": x_val, "test": x_test},
-                    estimators=list(id_cfg.estimators),
-                    selected_splits=list(id_cfg.splits),
-                    device=id_cfg.get("device", None) or cfg.device,
-                    max_samples=id_cfg.get("max_samples", None),
-                    seed=cfg.seed,
-                    common_meta=common_meta,
-                    feature_dim=feature_dim,
-                    n_counts=n_counts,
-                    verbose=cfg.verbose,
-                    only_metrics=plan.id_missing_metrics if cfg.resume else None,
-                )
-                if cfg.resume:
-                    id_rows = _filter_completed_metric_rows(id_rows, completed_metrics, key_cols)
-                id_out_rows.extend(id_rows)
 
-            if not plan.skip_profile:
-                profile_cfg = cfg.eval.profile
-                cpu_cfg = profile_cfg.get("cpu_throughput", {}) if profile_cfg else {}
-                profile_rows = evaluate_profile(
-                    model=model,
-                    sample_loader=train_loader,
-                    device=device,
-                    n_warmup=int(profile_cfg.get("n_warmup", 3)),
-                    n_measure=int(profile_cfg.get("n_measure", 20)),
-                    common_meta=common_meta,
-                    feature_dim=feature_dim,
-                    n_counts=n_counts,
-                    cpu_throughput_enabled=bool(cpu_cfg.get("enabled", False)),
-                    cpu_batch_size=int(cpu_cfg.get("batch_size", 8)),
-                    cpu_n_warmup=int(cpu_cfg.get("n_warmup", 1)),
-                    cpu_n_measure=int(cpu_cfg.get("n_measure", 5)),
-                    cpu_time_budget_s=float(cpu_cfg.get("time_budget_s", 300.0)),
-                )
-                if cfg.resume:
-                    profile_rows = _filter_completed_metric_rows(
-                        profile_rows, completed_metrics, key_cols
+                if not plan.skip_linear:
+                    try:
+                        lin_score, lin_lo, lin_hi, best_c, lin_cal, lin_cal_ts = evaluate_logistic(
+                            x_train,
+                            y_train,
+                            x_val,
+                            y_val,
+                            x_test,
+                            y_test,
+                            c_values_list,
+                            cfg.seed,
+                            cfg.eval.bootstrap,
+                            cfg.eval.merge_val,
+                            cfg.device,
+                            cfg.verbose,
+                            calibration_n_bins=cal_n_bins_linear,
+                            temp_scale=cal_temp_scale,
+                        )
+                    except LinearProbeDivergedError as exc:
+                        # A handful of (backbone, dataset) pairings produce feature
+                        # magnitudes the probe can't fit at any C in the sweep. That's
+                        # a property of this one combination, not the rest of the
+                        # benchmark run, so skip just this row rather than losing
+                        # every other already-computed metric to an uncaught crash.
+                        logger.warning(
+                            f"[linear] model={common_meta.get('model')} "
+                            f"dataset={common_meta.get('dataset')} bands={common_meta.get('bands')} "
+                            f"norm={common_meta.get('normalization')}: skipping, no usable C found. "
+                            f"Diagnostic: {exc}"
+                        )
+                    else:
+                        all_rows.append(
+                            metric_row(
+                                common_meta,
+                                method="linear",
+                                metric_name=metric_name,
+                                metric_value=lin_score,
+                                ci_lower=lin_lo,
+                                ci_upper=lin_hi,
+                                feature_dim=feature_dim,
+                                n_counts=n_counts,
+                                best_c=best_c,
+                                ece=lin_cal["ece"],
+                                rms_ce=lin_cal["rms_ce"],
+                                mce=lin_cal["mce"],
+                                ece_ts=lin_cal_ts["ece_ts"],
+                                rms_ce_ts=lin_cal_ts["rms_ce_ts"],
+                                mce_ts=lin_cal_ts["mce_ts"],
+                                temperature=lin_cal_ts["temperature"],
+                                calibration_n_bins=cal_n_bins_linear,
+                            )
+                        )
+                if not plan.skip_id:
+                    id_cfg = cfg.eval.intrinsic_dim
+                    id_rows = evaluate_intrinsic_dim(
+                        splits={"train": x_train, "val": x_val, "test": x_test},
+                        estimators=list(id_cfg.estimators),
+                        selected_splits=list(id_cfg.splits),
+                        device=id_cfg.get("device", None) or cfg.device,
+                        max_samples=id_cfg.get("max_samples", None),
+                        seed=cfg.seed,
+                        common_meta=common_meta,
+                        feature_dim=feature_dim,
+                        n_counts=n_counts,
+                        verbose=cfg.verbose,
+                        only_metrics=plan.id_missing_metrics if cfg.resume else None,
                     )
-                profile_out_rows.extend(profile_rows)
+                    if cfg.resume:
+                        id_rows = _filter_completed_metric_rows(
+                            id_rows, completed_metrics, key_cols
+                        )
+                    id_out_rows.extend(id_rows)
 
-        append_rows_atomic(output_path, all_rows)
-        all_rows.clear()
-        append_rows_atomic(intrinsic_dim_output_path, id_out_rows)
-        id_out_rows.clear()
-        append_rows_atomic(profile_output_path, profile_out_rows)
-        profile_out_rows.clear()
+                if not plan.skip_profile:
+                    profile_cfg = cfg.eval.profile
+                    cpu_cfg = profile_cfg.get("cpu_throughput", {}) if profile_cfg else {}
+                    profile_rows = evaluate_profile(
+                        model=model,
+                        sample_loader=train_loader,
+                        device=device,
+                        n_warmup=int(profile_cfg.get("n_warmup", 3)),
+                        n_measure=int(profile_cfg.get("n_measure", 20)),
+                        common_meta=common_meta,
+                        feature_dim=feature_dim,
+                        n_counts=n_counts,
+                        cpu_throughput_enabled=bool(cpu_cfg.get("enabled", False)),
+                        cpu_batch_size=int(cpu_cfg.get("batch_size", 8)),
+                        cpu_n_warmup=int(cpu_cfg.get("n_warmup", 1)),
+                        cpu_n_measure=int(cpu_cfg.get("n_measure", 5)),
+                        cpu_time_budget_s=float(cpu_cfg.get("time_budget_s", 300.0)),
+                    )
+                    if cfg.resume:
+                        profile_rows = _filter_completed_metric_rows(
+                            profile_rows, completed_metrics, key_cols
+                        )
+                    profile_out_rows.extend(profile_rows)
+
+            append_rows_atomic(output_path, all_rows)
+            all_rows.clear()
+            append_rows_atomic(intrinsic_dim_output_path, id_out_rows)
+            id_out_rows.clear()
+            append_rows_atomic(profile_output_path, profile_out_rows)
+            profile_out_rows.clear()
+    finally:
+        dataset_progress.stop()
 
     result_paths = ", ".join(sorted({output_path, intrinsic_dim_output_path, profile_output_path}))
     logger.info(f"Benchmark complete. Results appended to {result_paths}")


### PR DESCRIPTION
Fixes the actual root cause behind the download-bar half of #250 (see https://github.com/torchgeo/torchgeo-bench/issues/250#issuecomment-5454588028) — never was upstream torch.hub/tqdm, it's our own `rich` usage.

`main.py`'s per-dataset loop wraps `dataset_names` in `rich.progress.track(...)`, and model instantiation — which can trigger a `torch.hub` checkpoint download — happens inside that loop. `track()`'s `Progress` defaults to `redirect_stdout=True`/`redirect_stderr=True`, so on a real terminal it swaps `sys.stderr` for a `rich.file_proxy.FileProxy`. tqdm writing into that proxy instead of the real tty loses `\r`-based redraw (each refresh becomes its own printed line) and falls back to an ASCII bar, since `FileProxy.encoding` is `None` and tqdm's unicode check fails on that. On top of it, `Progress`'s default `auto_refresh=True` runs a background thread redrawing the "Datasets" line every 100ms, which fights tqdm for the same terminal line even with the redirect disabled.

Fix: construct `Progress` explicitly with `redirect_stdout=False, redirect_stderr=False, auto_refresh=False`, so it only redraws once per dataset iteration instead of continuously, and never touches tqdm's stream.

Same torch.hub download, before:
```
  0% 0.00/42.8M [00:00<?, ?B/s]
  0% 128k/42.8M [00:00<00:54, 950kB/s]
  7% 2.88M/42.8M [00:00<00:02, 15.1MB/s]
 73% 31.2M/42.8M [00:00<00:00, 134MB/s]
100% 42.8M/42.8M [00:00<00:00, 95.2MB/s]
```
and after:
```
100% 42.8M/42.8M [00:02<00:00, 16.7MB/s]
```
Verified under a real pty, not just piped output — the bug only shows up on an actual tty.
