### PR TITLE
ci: test the cross product of Python versions and OSes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,10 +8,12 @@ on:
 
 jobs:
   test:
-    name: test (${{ matrix.os }})
+    name: test (${{ matrix.os }}, ${{ matrix.python-version }})
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.12", "3.13", "3.14"]
         include:
           - os: ubuntu-latest
             extras: --extra dev --extra id --extra olmoearth --extra sam3
@@ -32,7 +34,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: ${{ matrix.python-version }}
       - uses: astral-sh/setup-uv@v8.0.0
         with:
           enable-cache: true
@@ -43,7 +45,7 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: .venv
-          key: venv-${{ runner.os }}-py3.13-${{ hashFiles('uv.lock') }}-${{ matrix.cache-tag }}
+          key: venv-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('uv.lock') }}-${{ matrix.cache-tag }}
       - name: Install dependencies
         run: uv sync ${{ matrix.extras }} --frozen
       - name: Run tests


### PR DESCRIPTION
Addresses #263. The `test` job only ran on Python 3.13 (all three OSes were already covered, just not multiple Python versions on each). Expands the matrix to `[ubuntu-latest, macos-latest, windows-latest] × [3.12, 3.13, 3.14]` (`requires-python = ">=3.12"`, no upper bound), mirroring torchgeo's CI setup.

Left out torchgeo's `3.14t` (free-threaded) entry for now — that's a separate, riskier axis given uneven ecosystem support for free-threaded builds, worth its own pass rather than bundling into this matrix expansion.
