### PR TITLE
fix(results): de-duplicate rows and relabel OlmoEarth normalization on load

### DIFF
--- a/src/torchgeo_bench/results.py
+++ b/src/torchgeo_bench/results.py
@@ -24,6 +24,8 @@ import numpy as np
 import pandas as pd
 import torch
 
+from torchgeo_bench.resume import KEY_COLS, _canonical_key_cell
+
 logger = logging.getLogger(__name__)
 
 DEFAULT_RESULTS_DIR = "results/models"
@@ -33,6 +35,14 @@ DEFAULT_RESULTS_DIR = "results/models"
 # sweeps rewrite.
 DEFAULT_PROFILE_RESULTS_DIR = "results/profiles"
 DEFAULT_INTRINSIC_DIM_RESULTS_DIR = "results/intrinsic_dim"
+
+# The resume key minus ``config_hash`` (that column is exactly what fragments
+# legacy rows, written before it existed, from later hashed reruns of the same
+# measurement), plus ``metric_name`` (one run emits several metric rows under
+# the same resume key) and ``seed`` (absent from the resume key, but different
+# seeds are different measurements -- without it a multi-seed sweep would
+# collapse to a single arbitrary seed).
+DEDUP_KEY_COLS = tuple(c for c in KEY_COLS if c != "config_hash") + ("metric_name", "seed")
 
 _UNSAFE = re.compile(r"[^A-Za-z0-9_.-]+")
 
@@ -78,7 +88,48 @@ def load_results(
     if not frames:
         logger.warning("No results found under %s", directory)
         return pd.DataFrame()
-    return pd.concat(frames, ignore_index=True, sort=False)
+    df = pd.concat(frames, ignore_index=True, sort=False)
+    df = _relabel_olmoearth_normalization(df)
+    return _dedup_results(df)
+
+
+def _relabel_olmoearth_normalization(df: pd.DataFrame) -> pd.DataFrame:
+    """Relabel OlmoEarth rows whose ``normalization`` does not describe the run.
+
+    OlmoEarth sets ``handles_own_normalization = True`` and overrides
+    ``normalize_inputs`` to identity, so ``dataset.normalization`` never reaches
+    its inputs. Rows are nonetheless stamped with whatever the config asked for,
+    which makes ``bandspec_zscore`` and ``model_native`` runs of the same
+    evaluation look like two measurements when they are bit-identical.
+    """
+    if "name" not in df.columns or "normalization" not in df.columns:
+        return df
+    is_olmoearth = df["name"].astype(str).str.startswith("olmoearth")
+    is_zscore = df["normalization"].astype(str) == "bandspec_zscore"
+    df.loc[is_olmoearth & is_zscore, "normalization"] = "model_native"
+    return df
+
+
+def _dedup_results(df: pd.DataFrame) -> pd.DataFrame:
+    """Drop duplicate measurement rows left by the resume-hash gap.
+
+    ``config_hash`` was added after many rows were already written, and it also
+    covers settings that cannot change a metric (``num_workers``,
+    ``batch_size``, ``device``), so a rerun under a different one of those
+    misses the resume key and appends instead of skipping. Within each "same
+    measurement" group (:data:`DEDUP_KEY_COLS`), a hashed row wins over a
+    legacy unhashed one; among hashed rows the last appended wins.
+    """
+    missing = [c for c in DEDUP_KEY_COLS if c not in df.columns]
+    if missing or "config_hash" not in df.columns:
+        return df
+    has_hash = df["config_hash"].fillna("").astype(str).str.len() > 0
+    key = df[list(DEDUP_KEY_COLS)].apply(
+        lambda row: tuple(_canonical_key_cell(v) for v in row), axis=1
+    )
+    order = pd.DataFrame({"key": key, "has_hash": has_hash, "pos": range(len(df))})
+    keep = order.sort_values(["has_hash", "pos"]).groupby("key", sort=False).tail(1)["pos"]
+    return df.loc[sorted(keep)].reset_index(drop=True)
 
 
 def bootstrap_accuracy(

--- a/tests/test_results_dedup.py
+++ b/tests/test_results_dedup.py
@@ -1,0 +1,118 @@
+"""Tests for read-time results de-duplication and OlmoEarth relabelling."""
+
+import pandas as pd
+
+from torchgeo_bench.results import (
+    DEDUP_KEY_COLS,
+    _dedup_results,
+    _relabel_olmoearth_normalization,
+    load_results,
+)
+
+
+def _row(**overrides) -> dict:
+    row = dict.fromkeys(DEDUP_KEY_COLS, "x")
+    row.update(
+        {
+            "dataset": "benv2",
+            "method": "knn5",
+            "metric_name": "micro_mAP",
+            "model": "torchgeo_bench.models.TorchGeoDOFABench",
+            "name": "tgeo_dofa_large",
+            "normalization": "bandspec_zscore",
+            "image_size": 224,
+            "interpolation": "bilinear",
+            "partition": "default",
+            "bands": "rgb",
+            "num_classes": 19,
+            "config_hash": "",
+            "metric_value": 0.5,
+        }
+    )
+    row.update(overrides)
+    return row
+
+
+def test_hashed_row_wins_over_legacy_unhashed_row() -> None:
+    df = pd.DataFrame([_row(metric_value=0.1), _row(config_hash="abc", metric_value=0.2)])
+    out = _dedup_results(df)
+    assert len(out) == 1
+    assert out.iloc[0]["metric_value"] == 0.2
+
+
+def test_last_appended_wins_among_hashed_rows() -> None:
+    """A rerun under a perf-only config change appends a second hashed row."""
+    df = pd.DataFrame(
+        [
+            _row(config_hash="aaa", metric_value=0.679566),
+            _row(config_hash="bbb", metric_value=0.679501),
+        ]
+    )
+    out = _dedup_results(df)
+    assert len(out) == 1
+    assert out.iloc[0]["metric_value"] == 0.679501
+
+
+def test_distinct_measurements_are_kept() -> None:
+    df = pd.DataFrame([_row(), _row(method="linear"), _row(bands="all")])
+    assert len(_dedup_results(df)) == 3
+
+
+def test_different_seeds_are_distinct_measurements() -> None:
+    """Multi-seed sweeps must not collapse to a single arbitrary seed."""
+    df = pd.DataFrame(
+        [
+            _row(seed=0, config_hash="a", metric_value=0.81),
+            _row(seed=1, config_hash="b", metric_value=0.83),
+        ]
+    )
+    out = _dedup_results(df)
+    assert len(out) == 2
+    assert sorted(out["seed"]) == [0, 1]
+
+
+def test_metric_name_separates_rows_from_one_run() -> None:
+    """One run emits several metrics under the same resume key; keep them all."""
+    df = pd.DataFrame(
+        [_row(config_hash="a", metric_name=m) for m in ("id_TwoNN_train", "id_MLE_train")]
+    )
+    assert len(_dedup_results(df)) == 2
+
+
+def test_olmoearth_zscore_rows_are_relabelled_model_native() -> None:
+    df = pd.DataFrame([_row(name="olmoearth_v1_2_base", normalization="bandspec_zscore")])
+    assert _relabel_olmoearth_normalization(df).iloc[0]["normalization"] == "model_native"
+
+
+def test_non_olmoearth_rows_keep_their_normalization() -> None:
+    df = pd.DataFrame([_row(name="tgeo_dofa_large", normalization="bandspec_zscore")])
+    assert _relabel_olmoearth_normalization(df).iloc[0]["normalization"] == "bandspec_zscore"
+
+
+def test_relabel_collapses_olmoearth_duplicate_normalization_runs() -> None:
+    """OlmoEarth ignores dataset.normalization, so the two runs are one measurement."""
+    df = pd.DataFrame(
+        [
+            _row(name="olmoearth_v1_2_base", normalization="bandspec_zscore", config_hash="a"),
+            _row(name="olmoearth_v1_2_base", normalization="model_native", config_hash="b"),
+        ]
+    )
+    assert len(_dedup_results(_relabel_olmoearth_normalization(df))) == 1
+
+
+def test_transforms_are_noop_on_frames_missing_columns() -> None:
+    df = pd.DataFrame([{"dataset": "benv2", "metric_value": 1.0}])
+    assert len(_dedup_results(df)) == 1
+    assert len(_relabel_olmoearth_normalization(df)) == 1
+
+
+def test_load_results_applies_both_transforms(tmp_path) -> None:
+    pd.DataFrame(
+        [
+            _row(name="olmoearth_v1_2_base", normalization="bandspec_zscore", config_hash="a"),
+            _row(name="olmoearth_v1_2_base", normalization="model_native", config_hash="b"),
+        ]
+    ).to_csv(tmp_path / "olmoearth_v1_2_base.csv", index=False)
+    out = load_results(tmp_path)
+    assert len(out) == 1
+    assert out.iloc[0]["normalization"] == "model_native"


### PR DESCRIPTION
Ports the `_dedup_results` / `_relabel_olmoearth_normalization` logic out of #147 so it lands on `main` independently of that PR's leaderboard feature.

Applied at read time in `load_results()`. On the current `results/models/` tree this collapses **6,374 raw rows to 4,802** — ~25% of stored rows are duplicates.

**Why the duplicates exist.** `config_hash` is part of the resume key but was added after many rows were written, so a legacy unhashed row never matches a later rerun and `resume=true` appends instead of skipping. It's also over-specified: `dataset.num_workers`, `dataset.batch_size`, and `device` all feed the hash even though none can change a metric, so the same evaluation launched from a script with a different `num_workers` re-runs and appends. Hit this live today — a DOFA Large benv2 ID backfill under `--resume` appended two duplicate classification rows under a third distinct hash.

**Why OlmoEarth needs relabelling.** It sets `handles_own_normalization = True` and overrides `normalize_inputs` to identity, so `dataset.normalization` never reaches its inputs — but rows are stamped with whatever the config asked for. A `bandspec_zscore` and a `model_native` run of the same eval are bit-identical yet look like two measurements. Verified today: 16 OlmoEarth v1.2 × eurosat-spatial configs produced byte-identical metrics across both labels.

**Safety of the collapse**, checked against the real tree (1,495 duplicate groups):
- **0** groups where no row is hashed, so the arbitrary file-order tiebreak never fires — every group has a clear legacy-vs-hashed winner.
- 34 groups have >1 hashed row (tiebreak: most recent rerun); only 9 of those disagree on value.
- Value differences within a group are the expected legacy-vs-current-code gap, e.g. `imagestats` m-eurosat linear `0.881` (unhashed) → `0.860` (hashed) — dedup keeps the hashed one.

**One deviation from #147:** `seed` is added to `DEDUP_KEY_COLS`. It's absent from the resume key, so as written the dedup would silently collapse a multi-seed sweep (#173) down to one arbitrary seed. No-op on current data (6,374 → 4,802 either way), purely protective.

Not addressed here: the resume hash itself still covers performance-only settings. Fixing that changes the hash formula and invalidates every stored `config_hash`, forcing one more full-recompute wave — worth doing deliberately, not as a drive-by.