### PR TITLE
fix(datasets): centralize safe V1 metadata loading

### DIFF
--- a/experiments/scripts/extract_dataset_geography.py
+++ b/experiments/scripts/extract_dataset_geography.py
@@ -19,8 +19,6 @@ Usage::
     python experiments/scripts/extract_dataset_geography.py --check
 """
 
-from __future__ import annotations
-
 import argparse
 import logging
 import os

--- a/experiments/scripts/repack_geobench_v1.py
+++ b/experiments/scripts/repack_geobench_v1.py
@@ -23,9 +23,9 @@ loader can read them without changes.
 """
 
 import argparse
+import ast
 import io
 import logging
-import pickle
 import shutil
 from pathlib import Path
 
@@ -33,24 +33,10 @@ import h5py
 import numpy as np
 import webdataset as wds
 
+from torchgeo_bench.datasets._metadata import unpickle_metadata
+
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 logger = logging.getLogger(__name__)
-
-
-class _StubUnpickler(pickle.Unpickler):
-    """Match GeoBenchv1._load_sample_metadata: stub geobench module classes."""
-
-    def find_class(self, module: str, name: str) -> type:  # type: ignore[override]
-        if module == "geobench.dataset":
-            return type(name, (), {})
-        return super().find_class(module, name)
-
-
-def _safe_unpickle(b: bytes) -> dict:
-    try:
-        return pickle.loads(b)
-    except (ModuleNotFoundError, AttributeError):
-        return _StubUnpickler(io.BytesIO(b)).load()
 
 
 def _read_sample(hdf5_path: Path) -> tuple[dict[str, np.ndarray], bytes]:
@@ -62,13 +48,15 @@ def _read_sample(hdf5_path: Path) -> tuple[dict[str, np.ndarray], bytes]:
 
 
 def _resolve_pickle_bytes(raw: object) -> bytes:
-    if isinstance(raw, bytes):
-        return raw
     if isinstance(raw, str):
         # The upstream V1 distribution stored the bytes as a Python repr
-        # of a bytestring (``"b'...'"``), so eval the string back.
-        return eval(raw)  # noqa: S307 — trusted dataset payload
-    raise TypeError(f"Unexpected pickle attr type: {type(raw)}")
+        # of a bytestring (``"b'...'"``).
+        raw = ast.literal_eval(raw)
+    elif not isinstance(raw, bytes) and hasattr(raw, "tobytes"):
+        raw = raw.tobytes()
+    if not isinstance(raw, bytes):
+        raise TypeError(f"Unexpected pickle attr type: {type(raw)}")
+    return raw
 
 
 def repack(dataset_dir: Path, out_dir: Path, shard_size: int = 1000) -> int:
@@ -154,11 +142,11 @@ def validate(dataset_dir: Path, out_dir: Path, n_samples: int = 50) -> None:
         if not parts:
             continue
         new_bands = dict(np.load(io.BytesIO(_read(parts["bands.npz"]))))
-        new_meta = _safe_unpickle(_read(parts["meta.pkl"]))
+        new_meta = unpickle_metadata(_read(parts["meta.pkl"]))
 
         # Reference HDF5
         ref_bands, ref_pkl = _read_sample(targets[sid])
-        ref_meta = _safe_unpickle(_resolve_pickle_bytes(ref_pkl))
+        ref_meta = unpickle_metadata(_resolve_pickle_bytes(ref_pkl))
 
         assert set(new_bands) == set(ref_bands), f"{sid}: band keys differ"
         for k in ref_bands:

--- a/src/torchgeo_bench/datasets/_metadata.py
+++ b/src/torchgeo_bench/datasets/_metadata.py
@@ -21,7 +21,4 @@ def unpickle_metadata(value: object) -> dict:
     if not isinstance(value, bytes):
         raise TypeError(f"Expected pickled metadata bytes, got {type(value).__name__}.")
 
-    try:
-        return pickle.loads(value)
-    except (ModuleNotFoundError, AttributeError):
-        return _StubUnpickler(io.BytesIO(value)).load()
+    return _StubUnpickler(io.BytesIO(value)).load()

--- a/src/torchgeo_bench/datasets/_v1_webdataset.py
+++ b/src/torchgeo_bench/datasets/_v1_webdataset.py
@@ -29,6 +29,7 @@ from typing import Literal
 
 import numpy as np
 import torch
+from huggingface_hub import snapshot_download
 from torch.utils.data import Dataset
 
 from ._metadata import unpickle_metadata
@@ -54,15 +55,6 @@ def ensure_sharded_root(
     target = Path(sharded_root) / dataset_name
     if target.exists() and any(target.glob("shard_*.tar")):
         return target
-
-    try:
-        from huggingface_hub import snapshot_download
-    except ImportError as e:
-        raise RuntimeError(
-            "huggingface_hub is required to auto-download the GeoBench V1 "
-            "WebDataset mirror.  Install via `pip install huggingface_hub`, "
-            "or set GEOBENCH_V1_NO_HF_DOWNLOAD=1 and provide the data manually."
-        ) from e
 
     sharded_root = Path(sharded_root)
     sharded_root.mkdir(parents=True, exist_ok=True)

--- a/src/torchgeo_bench/geography.py
+++ b/src/torchgeo_bench/geography.py
@@ -35,17 +35,17 @@ Extraction is deterministic: re-running against unchanged raw data reproduces
 byte-identical JSON.
 """
 
-from __future__ import annotations
-
 import glob
 import json
 import logging
 import os
+import pickle
 from collections import Counter
 from concurrent.futures import ProcessPoolExecutor
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, Self
+from urllib.error import URLError
 
 import numpy as np
 
@@ -121,7 +121,7 @@ class GeoRecord:
         return asdict(self)
 
     @classmethod
-    def from_json(cls, data: dict) -> GeoRecord:
+    def from_json(cls, data: dict) -> Self:
         """Rebuild a record from its stored form, ignoring unknown keys."""
         known = set(cls.__dataclass_fields__)
         return cls(**{k: v for k, v in data.items() if k in known})
@@ -171,12 +171,12 @@ def _v1_origin(path: str) -> tuple[float | None, float | None, str]:
     """
     import h5py
 
-    from .datasets._v1_webdataset import _safe_unpickle
+    from .datasets._metadata import unpickle_metadata
 
     try:
         with h5py.File(path, "r") as f:
-            meta = _safe_unpickle(eval(f.attrs["pickle"]))  # noqa: S307 - geobench's own format
-    except Exception as exc:  # noqa: BLE001 - surfaced via the failure-rate gate
+            meta = unpickle_metadata(f.attrs["pickle"])
+    except (EOFError, KeyError, OSError, TypeError, ValueError, pickle.UnpicklingError) as exc:
         return None, None, f"ERR {type(exc).__name__}: {exc}"
 
     for key, entry in meta.items():
@@ -259,7 +259,7 @@ def _natural_earth_countries() -> str | None:
         return shpreader.natural_earth(
             resolution="110m", category="cultural", name="admin_0_countries"
         )
-    except Exception as exc:  # noqa: BLE001 - continents are optional enrichment
+    except (OSError, URLError) as exc:
         logger.warning("natural_earth lookup failed, skipping continents: %s", exc)
         return None
 

--- a/tests/test_geography.py
+++ b/tests/test_geography.py
@@ -12,8 +12,12 @@ dataset silently disappearing from the map.
 """
 
 import json
+import pickle
 
+import h5py
+import numpy as np
 import pytest
+from affine import Affine
 
 from torchgeo_bench.datasets import list_datasets
 from torchgeo_bench.geography import (
@@ -22,6 +26,7 @@ from torchgeo_bench.geography import (
     NO_GEO,
     STORE_DIR,
     GeoRecord,
+    _v1_origin,
     list_geography,
     missing_datasets,
 )
@@ -152,3 +157,17 @@ def test_stored_files_are_canonical_json() -> None:
         assert raw == json.dumps(json.loads(raw), sort_keys=True, separators=(",", ":")), (
             f"{path.name} is not canonical; regenerate it with the extractor"
         )
+
+
+def test_v1_origin_reads_pickled_metadata_without_eval(tmp_path) -> None:
+    path = tmp_path / "sample.hdf5"
+    metadata = {
+        "04 - Red": {
+            "transform": Affine.translation(12.5, 48.25),
+            "crs": "EPSG:4326",
+        }
+    }
+    with h5py.File(path, "w") as file:
+        file.attrs["pickle"] = np.void(pickle.dumps(metadata))
+
+    assert _v1_origin(str(path)) == (12.5, 48.25, "EPSG:4326")


### PR DESCRIPTION
Uses the shared restricted unpickler for GeoBench V1 metadata everywhere, removes duplicate deserialization code and string eval, and adds path-specific coverage for HDF5 origin extraction. Hard Hugging Face Hub imports now fail normally instead of being wrapped as an optional dependency, and geography only catches expected file/metadata/download failures.