### PR TITLE
docs: document explicit CLI

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/add_model.md
+++ b/.github/PULL_REQUEST_TEMPLATE/add_model.md
@@ -16,7 +16,7 @@ Docs:
 |-------|-------|
 | **Model name** | <!-- e.g. `new_model` as it appears in the results CSV --> |
 | **Class** | <!-- e.g. `torchgeo_bench.models.NewModel` --> |
-| **Hydra config** | <!-- e.g. `src/torchgeo_bench/conf/model/new_model.yaml` --> |
+| **Model preset** | <!-- e.g. `src/torchgeo_bench/conf/model/new_model.yaml` --> |
 | **Pretraining data** | <!-- e.g. Sentinel-2 global, fMoW, ImageNet, etc. --> |
 | **Sensor coverage** | <!-- e.g. S2 RGB, S2 all-bands, NAIP RGB, multi-sensor --> |
 | **Weights URL** | <!-- Hugging Face Hub repo, release asset, or equivalent public URL --> |
@@ -29,7 +29,7 @@ Follow the Stage 2 guide: [Contribute a model](https://torchgeo.org/torchgeo-ben
 
 - [ ] Class inherits `BenchModel` and implements `_forward_patch_features(images) -> (B, K)`.
 - [ ] Class is exported from `src/torchgeo_bench/models/__init__.py` and listed in `__all__`.
-- [ ] Hydra config exists at `src/torchgeo_bench/conf/model/<name>.yaml` with the correct `_target_`.
+- [ ] Model preset exists at `src/torchgeo_bench/conf/model/<name>.yaml` with the correct `_target_`.
 - [ ] Model weights are publicly accessible without authentication.
 - [ ] Optional dependencies are declared under `[project.optional-dependencies]` in `pyproject.toml`, if needed.
 - [ ] Tests cover all added code in `tests/test_<model>.py`.
@@ -56,15 +56,15 @@ uv run torchgeo-bench download geobench_v2
 uv run torchgeo-bench download eurosat
 ```
 
-Run `torchgeo-bench` with only this model selected. Use `resume=true` so an
-interrupted run can continue without duplicating completed rows. Set `device`
-explicitly so maintainers rerun on the same CPU/GPU path.
+Run `torchgeo-bench` with only this model selected. Use `--resume` so an
+interrupted run can continue without duplicating completed rows. Set
+`--device` explicitly so maintainers rerun on the same CPU/GPU path.
 
 ```bash
-uv run torchgeo-bench run model=<model_config_name> \
-  dataset.names=all \
-  resume=true \
-  device=<cuda:0|cpu>
+uv run torchgeo-bench run --model <model_config_name> \
+  --datasets all \
+  --resume \
+  --device <cuda:0|cpu>
 ```
 
 If a dataset cannot run because the model does not support that sensor or
@@ -94,10 +94,10 @@ Maintainers should be able to check out this PR and rerun the exact benchmark.
 ```bash
 git checkout <this-branch>
 uv sync --extra dev
-uv run torchgeo-bench run model=<model_config_name> \
-  dataset.names=all \
-  resume=true \
-  device=<cuda:0|cpu>
+uv run torchgeo-bench run --model <model_config_name> \
+  --datasets all \
+  --resume \
+  --device <cuda:0|cpu>
 ```
 
 Hardware and software used for submitted results:

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -13,13 +13,14 @@ For deeper context see [`AGENTS.md`](../AGENTS.md) (style + dataset list) and
 The Python package lives at **`src/torchgeo_bench/`**. Important pieces:
 
 - `cli.py` / `__main__.py` / `main.py` — `torchgeo-bench` console entry point.
-  `cli.py` calls Hydra's `main()` directly in-process (no subprocess); it also
-  hosts the `torchgeo-bench download {geobench_v1|geobench_v2|eurosat}`
-  subcommand.
+  `cli.py` is a plain `argparse` parser with subcommands (`run`, `profile`,
+  `intrinsic-dim`, `coord`, `flops`, `download`); it dispatches in-process (no
+  subprocess) and hosts the `torchgeo-bench download
+  {geobench_v1|geobench_v2|eurosat|resisc45}` subcommand.
 - `download.py` — fetches GeoBench V1 / V2 from Hugging Face via
   `snapshot_download`, plus a torchgeo-backed `download_eurosat` helper.
-- `conf/` — **Hydra configs are packaged inside the source tree**
-  (`src/torchgeo_bench/conf/{config.yaml, model/}`). Add new model configs
+- `conf/` — **model presets are packaged inside the source tree**
+  (`src/torchgeo_bench/conf/model/`). Add new model configs
   here. There is no `conf/dataset/` directory — every dataset's metadata
   (bands, normalization stats, num_classes, splits) lives in its Python
   wrapper class.
@@ -27,7 +28,7 @@ The Python package lives at **`src/torchgeo_bench/`**. Important pieces:
   implement `forward_patch_features(images, bboxes=None) -> (B, K)`**;
   `forward()` aliases it.
 - `models/{bench_models,timm,torchgeo_models,olmoearth}.py` — concrete model
-  wrappers registered via Hydra `_target_:` strings.
+  wrappers registered via `_target_:` strings in their preset YAML.
 - `datasets/` — per-dataset wrappers plus three family base classes:
   `_V1Dataset` (in `geobench_v1.py`), `_V2Dataset` (in `geobench_v2.py`), and
   the standalone `EuroSAT` (in `eurosat.py`). Each per-dataset file just
@@ -57,7 +58,7 @@ commands** (or use `conda run -n torchgeo-bench …`). The `Makefile` targets
 ```bash
 conda activate torchgeo-bench                                       # do this first
 conda run -n torchgeo-bench uv sync --extra dev                     # install deps + dev tools
-conda run -n torchgeo-bench torchgeo-bench run model=timm/resnet50 dataset.names=[m-eurosat]
+conda run -n torchgeo-bench torchgeo-bench run --model timm/resnet50 --datasets m-eurosat
 conda run -n torchgeo-bench pytest                                  # full suite (skips `slow` by default)
 conda run -n torchgeo-bench pytest tests/test_geobench_dataset.py -v  # one file
 conda run -n torchgeo-bench pytest tests/test_geobench_dataset.py::TestClass::test_method -v
@@ -84,20 +85,22 @@ Download with `torchgeo-bench download {geobench_v1|geobench_v2|eurosat}`.
 
 ## Architecture (the parts you can't see from one file)
 
-1. **Hydra-driven entry point.** `torchgeo-bench run …` mutates `sys.argv` and
-   calls the `@hydra.main`-decorated function in-process (no subprocess
-   re-launch). Hydra resolves `src/torchgeo_bench/conf/config.yaml`. The
-   default model is `rcf`. Override anything from the CLI: `model=timm/resnet50`,
-   `dataset.names=[m-eurosat]`, `eval.bootstrap=100`, `device=cuda:1`,
-   `resume=true`.
+1. **argparse-driven entry point.** `torchgeo-bench run …` parses flags with a
+   plain `argparse` parser (`cli.py`) and composes settings in-process:
+   built-in defaults -> optional `--config PATH` YAML (uncommon settings) ->
+   selected model preset YAML -> explicit CLI flags (flags win). There is no
+   `key=value` override syntax. The default model is `rcf`. Common settings
+   are flags: `--model timm/resnet50`, `--datasets m-eurosat`,
+   `--bootstrap 100`, `--device cuda:1`, `--resume`.
 2. **Per-dataset model reinitialization.** Models are instantiated once per
-   dataset because `num_channels` varies (RGB vs multispectral). The Hydra
-   `model:` config is a partial; `main.py` injects the right `num_channels`
-   when calling `instantiate(...)`.
+   dataset because `num_channels` varies (RGB vs multispectral). The
+   `model:` config is a partial dict; `main.py` injects the right
+   `num_channels` when calling `instantiate(...)`.
 3. **Classification path** (KNN-5 + linear probe): extract train/val/test
    embeddings once → KNN-5 with FAISS + bootstrap CIs → L-BFGS logistic
    regression sweep over `c_range` (log-spaced), pick best on val, refit on
-   train+val if `eval.merge_val=true`, evaluate on test with bootstrap CIs.
+   train+val if `--merge-val` (default true), evaluate on test with bootstrap
+   CIs.
 4. **Segmentation path** (`seg-linear` / `seg-conv_block`): `SegmentationProbe`
    registers forward hooks on configured backbone layers, reshapes features
    (2-D/3-D ViT/4-D), upsamples bilinearly, applies BN+1×1 conv head (or a
@@ -111,7 +114,7 @@ Download with `torchgeo-bench download {geobench_v1|geobench_v2|eurosat}`.
    dataset name with hyphens → underscores. Class attributes carry every piece
    of metadata: `name`, `task`, `num_classes`, `multilabel`, `bands` (list of
    `BandSpec`), `rgb_bands`, `split_sizes`. Dispatch happens via
-   `_REGISTRY` in `datasets/loading.py`. `dataset.names=all` expands via
+   `_REGISTRY` in `datasets/loading.py`. `--datasets all` expands via
    `list_datasets()`.
 6. **Dataset taxonomy.** Authoritative facts:
    - V1 (`m-` prefix by convention): `m-eurosat` (10), `m-forestnet` (12),
@@ -130,8 +133,8 @@ Download with `torchgeo-bench download {geobench_v1|geobench_v2|eurosat}`.
      / band counts.
 7. **`num_channels = len(bands)`**, so a model wrapper that hard-codes
    channel counts will break on multi-sensor datasets like `treesatai` (19),
-   `pastis` (16), or `m-so2sat` (18). When `dataset.bands=rgb`, the runner
-   picks `rgb_bands` by short name — those names differ across V1/V2
+   `pastis` (16), or `m-so2sat` (18). When `--bands rgb` (the default), the
+   runner picks `rgb_bands` by short name — those names differ across V1/V2
    (`red,green,blue` vs `b04,b03,b02` vs `gray` for caffe, `vv,vh` for
    kuro_siwo).
 8. **Multilabel path.** When a dataset's wrapper sets `multilabel = True`
@@ -148,7 +151,7 @@ Download with `torchgeo-bench download {geobench_v1|geobench_v2|eurosat}`.
     remap upstream sample keys (collapsing temporal dims, picking
     `image_b` over `image_a`, etc.). The default is a no-op.
 11. **Resume + atomic writes.** Results append to a single CSV with `fcntl`
-    advisory locking so parallel jobs are safe. With `resume=true`, the
+    advisory locking so parallel jobs are safe. With `--resume`, the
     script reads the CSV and skips any
     `(dataset, method, model, name, normalization, image_size, interpolation, partition)`
     tuple already present.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Guidelines for AI coding agents working in the torchgeo-bench repository.
 
 ## Project Overview
 
-**torchgeo-bench** is a Python benchmarking framework for evaluating geospatial foundation models on GeoBench datasets (V1 and V2). Uses PyTorch and an OmegaConf-based config system (see `config.py` — replaces Hydra, same `model=…`/`key=value` override syntax), and provides KNN-5, Linear Probing, and Segmentation (mIoU) evaluation with bootstrapped confidence intervals.
+**torchgeo-bench** is a Python benchmarking framework for evaluating geospatial foundation models on GeoBench datasets (V1 and V2). Uses PyTorch and a plain argparse CLI (see `cli.py`/`config.py`; common settings are flags like `--model`/`--datasets`, uncommon settings go in an optional `--config PATH` YAML), and provides KNN-5, Linear Probing, and Segmentation (mIoU) evaluation with bootstrapped confidence intervals.
 
 ### Key Features
 - **Resume Mode**: Skip already-computed experiments when interrupted/restarted
@@ -17,7 +17,7 @@ Guidelines for AI coding agents working in the torchgeo-bench repository.
 src/torchgeo_bench/        # Main source package (importable as torchgeo_bench)
   ├── cli.py               # CLI entry point (torchgeo-bench command: run/flops/download)
   ├── main.py              # Benchmark runner (classification + segmentation)
-  ├── config.py            # OmegaConf config composition + _target_ instantiation
+  ├── config.py            # Settings composition (defaults -> --config YAML -> model preset -> flags) + _target_ instantiation
   ├── resume.py            # config_hash-based resume/skip logic
   ├── results.py            # EvaluationResult schema + atomic per-model CSV writes
   ├── download.py          # Dataset downloads (geobench_v1/v2 + torchgeo eurosat)
@@ -158,22 +158,22 @@ torchgeo-bench download resisc45                          # torchgeo RESISC45 ->
 
 ```bash
 # Basic usage
-torchgeo-bench run model=timm/resnet50 dataset.names=[m-eurosat]
+torchgeo-bench run --model timm/resnet50 --datasets m-eurosat
 
 # Quick eval (skip linear probing, minimal bootstrap)
-torchgeo-bench run eval.skip_linear=true eval.bootstrap=100
+torchgeo-bench run --skip-linear --bootstrap 100
 
 # Resume a previously interrupted run (skips completed experiments)
-torchgeo-bench run resume=true
+torchgeo-bench run --resume
 
 # Evaluate segmentation datasets (V2)
-torchgeo-bench run dataset.names=[burn_scars,pastis,flair2]
+torchgeo-bench run --datasets burn_scars,pastis,flair2
 
 # Select specific GPU device
-torchgeo-bench run device=cuda:1
+torchgeo-bench run --device cuda:1
 
 # Measure per-sample compute cost (GFLOPs, params, throughput) -> results/compute_cost.csv
-torchgeo-bench flops model=timm/resnet50
+torchgeo-bench flops --model timm/resnet50
 ```
 
 ## Results Layout & Resume
@@ -181,10 +181,11 @@ torchgeo-bench flops model=timm/resnet50
 - Each model writes to its own `results/models/<model name>.csv` (not one
   shared file), so re-running one model only touches that file. Rows are
   appended, never rewritten in place.
-- `resume=true` skips a (dataset, method, bands, normalization, ...) combo
+- `--resume` skips a (dataset, method, bands, normalization, ...) combo
   only if an existing row's `config_hash` matches the current run's config.
-  Changing any hashed config field (including additive passes like
-  `eval.profile`/`eval.intrinsic_dim`) invalidates the match and reruns.
+  Changing any hashed config field (including additive passes run via the
+  `torchgeo-bench profile` / `torchgeo-bench intrinsic-dim` subcommands)
+  invalidates the match and reruns.
 - One-time, hardware-dependent measurements (`torchgeo-bench flops`,
   intrinsic-dimension probes) live in their own side files —
   `results/compute_cost.csv` and `results/intrinsic_dim/<model name>.csv` —
@@ -355,9 +356,9 @@ class TestGeoBenchDatasetBasics:
 
 Core (see `pyproject.toml` for the authoritative list): `torch>=2`, `torchvision>=0.15`,
 `numpy>=1.24`, `scikit-learn>=1.3`, `timm>=0.9`, `torchgeo>=0.9`, `torchmetrics>=1.4`,
-`omegaconf>=2.3`, `h5py>=3.8`, `faissknn` (CPU or CUDA variant, picked by platform),
+`pyyaml>=6`, `h5py>=3.8`, `faissknn` (CPU or CUDA variant, picked by platform),
 `huggingface-hub>=0.20`, `geobenchv2>=0.9`, `pandas>=2`, `pyarrow>=14`, `safetensors>=0.4`,
-`filelock>=3.12`, `rich>=13`.
+`filelock>=3.12`.
 
 Optional extras (`pip install 'torchgeo-bench[extra]'`, or `[all]` for everything):
 `cleanlab`, `coordbench`, `dev`, `docs`, `id` (intrinsic-dimension estimators),

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 A lightweight benchmarking framework for evaluating **frozen** geospatial
 foundation models on GeoBench V1/V2 and location encoders on CoordBench. Plug
 in a backbone or coordinate encoder and run consistent downstream probes through
-OmegaConf configs.
+a plain CLI (flags win over an optional YAML file of uncommon settings).
 
 - **Frozen-backbone evaluation** — KNN-5, L-BFGS logistic regression, and
   linear / conv / FPN / DPT segmentation probes.
@@ -16,9 +16,9 @@ OmegaConf configs.
   full multispectral / multi-modal stacks.
 - **CoordBench built in** — coordinate-only regression and classification with
   random, spatial-block, and official holdouts.
-- **Config-driven** — sweep models, datasets, partitions, image sizes, and
-  bands without code changes.
-- **Resumable** — `resume=true` skips already-computed `(dataset, method, model, …)` rows. Atomic CSV appends are safe across parallel jobs.
+- **CLI-driven** — sweep models, datasets, partitions, image sizes, and
+  bands with flags, no code changes.
+- **Resumable** — `--resume` skips already-computed `(dataset, method, model, …)` rows. Atomic CSV appends are safe across parallel jobs.
 - **Bring your own model** — copy
   [`contrib_template.py`](src/torchgeo_bench/models/contrib_template.py),
   implement `_forward_patch_features`, and add a one-file model config.
@@ -71,7 +71,7 @@ for all options.
 torchgeo-bench run
 
 # A single dataset with a pretrained ImageNet ResNet-50
-torchgeo-bench run model=timm/resnet50 dataset.names=[m-eurosat]
+torchgeo-bench run --model timm/resnet50 --datasets m-eurosat
 ```
 
 The default device is `cuda:0`. On a machine without a working CUDA GPU (or if
@@ -79,21 +79,22 @@ a GPU run crashes — see [troubleshooting](https://torchgeo.org/torchgeo-bench/
 fall back to CPU:
 
 ```bash
-torchgeo-bench run dataset.names=[m-eurosat] device=cpu
+torchgeo-bench run --datasets m-eurosat --device cpu
 ```
 
 Results are appended to `results/models/<model name>.csv`, which **ship pre-populated
 with reference results** — to start from a clean slate, write to your own file
-with `output=results/my_run.csv`. Re-run with `resume=true` to skip
+with `--output results/my_run.csv`. Re-run with `--resume` to skip
 already-completed rows. One-time profile/intrinsic-dim measurements go to their
-own `results/profiles/` and `results/intrinsic_dim/` files instead, so routine
-metrics reruns don't touch them.
+own `results/profiles/` and `results/intrinsic_dim/` files instead (via the
+dedicated `torchgeo-bench profile` / `torchgeo-bench intrinsic-dim`
+subcommands), so routine metrics reruns don't touch them.
 
 ## CoordBench — location encoders
 
-`mode=coord` swaps the image pipeline for a **coordinate-only** track: point
-`(lon, lat)` in, a downstream label out. Benchmarks are streamed directly from
-the unified [`taylor-geospatial/coordbench`](https://huggingface.co/datasets/taylor-geospatial/coordbench)
+`torchgeo-bench coord` swaps the image pipeline for a **coordinate-only**
+track: point `(lon, lat)` in, a downstream label out. Benchmarks are streamed
+directly from the unified [`taylor-geospatial/coordbench`](https://huggingface.co/datasets/taylor-geospatial/coordbench)
 HuggingFace dataset (PDFM, SatCLIP, SustainBench, CDC PLACES, MOSAIKS/USAVars,
 the DeepMind/AlphaEarth suite, and more — no local download). A frozen encoder
 is probed with **KNN** and a **ridge linear** head under **random** or
@@ -101,18 +102,18 @@ is probed with **KNN** and a **ridge linear** head under **random** or
 
 ```bash
 # MIND location encoder on the whole suite, random + spatial CV
-torchgeo-bench run mode=coord model=mind coord.split=both
+torchgeo-bench coord --model mind --split both
 
 # One family, linear probe only, trivial sin/cos baseline
-torchgeo-bench run mode=coord model=sincos coord.names=pdfm coord.methods=[linear]
+torchgeo-bench coord --model sincos --names pdfm --methods linear
 ```
 
-`model=mind` and `model=mind-small` ([MIND](https://huggingface.co/isaaccorley/MIND),
-distilled from AlphaEarth/Climplicit/GeoCLIP/SINR) and `model=sincos` work with
-the base install. The other pretrained encoders (SatCLIP / GeoCLIP / Climplicit /
-SINR, via `rshf`) need the `coordbench` extra:
+`--model mind` and `--model mind-small` ([MIND](https://huggingface.co/isaaccorley/MIND),
+distilled from AlphaEarth/Climplicit/GeoCLIP/SINR) and `--model sincos` work
+with the base install. The other pretrained encoders (SatCLIP / GeoCLIP /
+Climplicit / SINR, via `rshf`) need the `coordbench` extra:
 `pip install "torchgeo-bench[coordbench]"`,
-then `model=climplicit` (etc.). Results land in
+then `--model climplicit` (etc.). Results land in
 `results/coordbench_results.csv`. Add your own encoder by subclassing
 `LocationEncoder` (implement `_encode`) and pointing a `model` config's
 `_target_` at it. See the

--- a/docs/api/cli.rst
+++ b/docs/api/cli.rst
@@ -3,27 +3,45 @@ Command-line interface
 
 .. module:: torchgeo_bench.cli
 
-The ``torchgeo-bench`` console script exposes three subcommands:
+The ``torchgeo-bench`` console script exposes six subcommands:
 
-``torchgeo-bench run [flags] [key=value ...]``
-    Runs the benchmark pipeline. Common settings have flags (``--model``,
-    ``--datasets``, ``--device``, ``--resume``, ...; see ``run --help``), and
-    any value in :file:`src/torchgeo_bench/conf/config.yaml` (or any model
-    preset under :file:`conf/model/`) can be overridden with ``key=value``
-    pairs, e.g. ``model=timm/resnet50 dataset.names=[m-eurosat]``. Output is
-    quiet by default; pass ``-v``/``--verbose`` for INFO-level progress logs.
-    ``--list-models``/``--list-datasets`` list valid ``model=``/``dataset.names=``
-    values, and ``--model-help <name>`` prints that model config's YAML
-    (its available ``model.*`` overrides) without running anything.
+``torchgeo-bench run [flags]``
+    Runs the benchmark pipeline. Common settings are plain flags (``--model``,
+    ``--datasets``, ``--device``, ``--resume``, ...; see ``run --help`` for
+    the full list). Anything uncommon goes in a YAML file passed via
+    ``--config PATH``, merged under the built-in defaults but under explicit
+    CLI flags (flags always win); there is no ``key=value`` override syntax.
+    Output is quiet by default; pass ``-v``/``--verbose`` for INFO-level
+    progress logs. ``--list-models``/``--list-datasets`` list valid
+    ``--model``/``--datasets`` values, ``--model-help <name>`` prints that
+    model preset's YAML (its available ``model.*`` settings) without running
+    anything, and ``--print-config`` prints the fully merged settings and
+    exits.
 
-``torchgeo-bench download {geobench_v1|geobench_v2|eurosat}``
+``torchgeo-bench profile [flags]``
+    A thin alias over ``run`` (same flags) that additionally enables the
+    compute-profile pass (throughput/latency/params), written to
+    ``results/profiles/``.
+
+``torchgeo-bench intrinsic-dim [flags]``
+    A thin alias over ``run`` (same flags) that additionally enables the
+    intrinsic-dimension pass, written to ``results/intrinsic_dim/``.
+
+``torchgeo-bench coord [flags]``
+    Runs the CoordBench location-encoder track (``--model``, ``--names``,
+    ``--methods``, ``--split``, ``--folds``, ...; see ``coord --help``).
+
+``torchgeo-bench flops [flags]``
+    Measures per-sample backbone, head, and probe compute (``--model``,
+    ``--device``, ``--output``).
+
+``torchgeo-bench download {geobench_v1|geobench_v2|eurosat|resisc45}``
     Downloads benchmark datasets into ``./data/`` (or a custom location with
     ``--output-dir``). For GeoBench V1 and V2, individual datasets can be
     selected with ``--datasets a,b,c``.
 
-``torchgeo-bench flops [flags] [key=value ...]``
-    Measures per-sample backbone, head, and probe compute. Overrides are
-    composed from :file:`src/torchgeo_bench/conf/flops_config.yaml`.
+Every subcommand above except ``download`` accepts ``--config PATH`` (a YAML
+file of uncommon settings) and ``--print-config``.
 
 Config composition
 ------------------

--- a/docs/user/changelog.rst
+++ b/docs/user/changelog.rst
@@ -14,6 +14,17 @@ Added
 * ``scripts/compute_band_statistics.py`` computes the per-band ``BandSpec``
   statistics a new dataset needs, from its train split only.
 
+Changed
+^^^^^^^
+
+* Replaced the OmegaConf/Hydra ``key=value`` override syntax with a plain
+  ``argparse`` CLI: common settings are now flags (``--model``, ``--datasets``,
+  ``--bootstrap``, ``--resume``, ...; run ``torchgeo-bench run --help``), and
+  uncommon settings go in a YAML file passed via ``--config PATH``. CoordBench
+  moved from ``run mode=coord`` to its own ``torchgeo-bench coord`` subcommand;
+  the intrinsic-dimension and compute-profile passes moved to dedicated
+  ``torchgeo-bench intrinsic-dim`` / ``torchgeo-bench profile`` subcommands.
+
 0.5.0 (2026-08-10)
 ------------------
 
@@ -37,7 +48,7 @@ Changed
 * Image-benchmark result rows now record ``num_classes`` and include it in the
   resume key. Rows from an older label schema cannot be silently reused.
 * Linux x86_64 installs use the CUDA FAISS backend; other platforms use CPU
-  FAISS. CoordBench KNN remains CPU by default unless ``coord.knn_device`` is
+  FAISS. CoordBench KNN remains CPU by default unless ``--knn-device`` is
   overridden.
 * SpaceNet2 and SpaceNet7 now use their native two-class building masks instead
   of GeoBench's unused third background class.

--- a/docs/user/configuration.rst
+++ b/docs/user/configuration.rst
@@ -1,33 +1,39 @@
 Configuration
 =============
 
-``torchgeo-bench`` is configured with `OmegaConf <https://omegaconf.readthedocs.io>`_
-YAML files.  The primary config lives at :file:`src/torchgeo_bench/conf/config.yaml`
-and is composed with a model preset selected from
-:file:`src/torchgeo_bench/conf/model/`.
+``torchgeo-bench`` is configured with a plain ``argparse`` CLI. Settings are
+composed in this order (each stage overrides the previous one):
 
-Every value in the config can be overridden on the command line using
-dotted-path ``key=value`` syntax (common settings also have flags — see
-``torchgeo-bench run --help``):
+#. built-in Python defaults (``torchgeo_bench.settings``),
+#. an optional ``--config PATH`` YAML file of uncommon settings,
+#. the selected model preset YAML (``--model``, from
+   :file:`src/torchgeo_bench/conf/model/`), and
+#. explicit CLI flags, which always win.
+
+There is no dotted-path ``key=value`` override syntax. Common settings have
+their own flags (see ``torchgeo-bench run --help``); anything else goes in
+the ``--config`` YAML:
 
 .. code-block:: console
 
    $ torchgeo-bench run \
-       model=timm/resnet50 \
-       dataset.names=[m-eurosat] \
-       eval.bootstrap=100 \
-       eval.skip_linear=true \
-       device=cuda:1
+       --model timm/resnet50 \
+       --datasets m-eurosat \
+       --bootstrap 100 \
+       --skip-linear \
+       --device cuda:1
 
-Config tree
------------
+Use ``--print-config`` to print the fully merged settings (in the same YAML
+shape ``--config`` expects) and exit without running anything.
 
-The packaged config tree is shipped inside the wheel:
+Model preset tree
+------------------
+
+The packaged preset tree is shipped inside the wheel:
 
 .. code-block:: text
 
    src/torchgeo_bench/conf/
-   ├── config.yaml          # primary config (defaults below)
    └── model/
        ├── rcf.yaml
        ├── imagestats.yaml
@@ -40,114 +46,92 @@ The packaged config tree is shipped inside the wheel:
        └── torchgeo/
            └── ...          # SSL backbones, ScaleMAE, DOFA, Satlas, EarthLoc, ...
 
-See :doc:`models` for an operator-facing tour of the available presets.
+Each preset is a YAML file with a ``_target_`` (a dotted import path) plus
+constructor kwargs; ``--model-help <name>`` prints one without running
+anything. See :doc:`models` for an operator-facing tour of the available
+presets.
 
-Top-level options
------------------
+Common flags (``torchgeo-bench run``)
+--------------------------------------
 
 ============================  ==================================================
-Key                           Meaning
+Flag                          Meaning
 ============================  ==================================================
-``seed``                      Global RNG seed (numpy + torch).
-``device``                    PyTorch device string (e.g. ``cuda:0``, ``cpu``).
-``mode``                      ``image`` for GeoBench or ``coord`` for CoordBench.
-``output``                    Image-benchmark results CSV; CoordBench uses ``coord.output``.
-``verbose``                   Toggle progress logging.
-``resume``                    Skip already-computed ``(dataset, method, model, config)`` combos.
+``-m``, ``--model``           Model preset, e.g. ``timm/resnet50`` (default ``rcf``).
+``-d``, ``--datasets``        Comma-separated dataset names, or ``all``.
+``--device``                  PyTorch device string (e.g. ``cuda:0``, ``cpu``; default: auto).
+``-o``, ``--output``          Results CSV path (default: ``results/models/<model name>.csv``).
+``--resume``                  Skip already-computed ``(dataset, method, model, config)`` combos.
+``--seed``                    Global RNG seed (numpy + torch).
+``-v``, ``--verbose``         Toggle INFO-level progress logging.
 ============================  ==================================================
 
-``dataset`` block
------------------
-
-.. code-block:: yaml
-
-   dataset:
-     names: all                    # or a list, e.g. [m-eurosat, m-pv4ger]
-     partition: default            # alternative GeoBench V1 partitions when supported
-     batch_size: 64
-     bands: rgb                    # rgb | all | [red, green, blue, nir]
-     image_size: 224               # null disables resizing
-     interpolation: bilinear       # bilinear | bicubic | nearest
+``torchgeo-bench run`` (and the ``profile``/``intrinsic-dim`` aliases) also
+accept ``--partition``, ``--bands``, ``--batch-size``, ``--num-workers``,
+``--image-size``, ``--time-steps``, ``--interpolation``, ``--normalization``,
+``--skip-linear``, ``--bootstrap``, ``--merge-val``/``--no-merge-val``,
+``--knn-device``, ``--seg-head``, ``--seg-epochs``, ``--seg-lr``,
+``--seg-scheduler``, ``--seg-batch-size``, ``--seg-cache``/``--no-seg-cache``,
+``--seg-cache-dtype``, ``--use-cls-token``/``--no-use-cls-token``,
+``--model-input-normalization``, and ``--model-name``. Run
+``torchgeo-bench run --help`` for the authoritative list with defaults.
 
 See :doc:`datasets` for the full list of available dataset names and band
 selection semantics.
 
-``eval`` block
---------------
+Uncommon settings (``--config`` YAML)
+--------------------------------------
+
+Settings without their own flag are set via a YAML file passed to
+``--config``, merged under the built-in defaults but under the model preset
+and any explicit flags. Its shape mirrors ``--print-config`` output, for
+example:
 
 .. code-block:: yaml
 
    eval:
-     bootstrap: 200                # bootstrap resamples for KNN/linear/segmentation CIs
      c_range: [-6, 4, 40]          # log10 sweep start, stop, num samples for linear probe
-     merge_val: true               # merge train+val before training the final logistic head
-     skip_linear: false            # skip the (slower) linear probe entirely
-     knn_device: null              # inherit device; fall back to CPU if FAISS lacks GPU support
-
      calibration:
-       n_bins_knn: null             # null = knn_k + 1
+       n_bins_knn: null            # null = knn_k + 1
        n_bins_linear: 15
-       temp_scale: false            # requires merge_val=false (held-out validation logits)
-
-     intrinsic_dim:                # optional ID metrics on extracted embeddings
-       enabled: false
-       estimators: [TwoNN, MLE, lPCA]
-       splits: [train]
-       max_samples: 10000
-       device: null                # null = auto (cuda if available)
-
-     segmentation:                 # used only for segmentation datasets
-       head_type: fpn              # linear | fpn | dpt | conv-block
-       layers: []                  # backbone layers to extract; [] = use defaults
-       lr: 1e-3
-       epochs: 10
+       temp_scale: false           # requires --no-merge-val (held-out validation logits)
+     segmentation:
        criterion:
          _target_: torch.nn.CrossEntropyLoss
          ignore_index: 255
-       lr_scheduler: cosine
-       cache_features: true
-       cache_dtype: float16
-       save_viz: false
+       save_viz: true
        viz_dir: viz
        n_viz_samples: 8
 
+The additive intrinsic-dimension and compute-profile passes are run via the
+dedicated ``torchgeo-bench intrinsic-dim`` / ``torchgeo-bench profile``
+subcommands (which set ``eval.intrinsic_dim.enabled`` /
+``eval.profile.enabled`` for you); their own sub-settings (estimators,
+splits, warmup/measure counts, ...) are set the same way, through
+``--config``.
+
 .. seealso::
 
-   :doc:`segmentation-layers` lists the verified ``layers`` values for
-   every supported timm backbone family, with spatial sizes and notes on
-   stages that share resolution (common in EfficientNet / MobileNet).
+   :doc:`segmentation-layers` lists the verified ``--seg-head``-compatible
+   layer names for every supported timm backbone family, with spatial sizes
+   and notes on stages that share resolution (common in EfficientNet /
+   MobileNet).
 
 Refer to :doc:`/api/eval` for the runtime functions that consume each
-sub-block.
+setting.
 
-``coord`` block
----------------
+CoordBench
+----------
 
-The coordinate-only track is selected with ``mode=coord`` and a compatible
-location-encoder model preset:
+The coordinate-only track is a dedicated subcommand,
+``torchgeo-bench coord``, with its own flags (``--model``, ``--names``,
+``--methods``, ``--split``, ``--folds``, ``--cell-deg``, ``--knn-k``,
+``--knn-device``, ``--output``, ``--resume``, ``--seed``, ``--config``,
+``--print-config``):
 
-.. code-block:: yaml
+.. code-block:: console
 
-   mode: coord
-   model: sincos
-   coord:
-     output: results/coordbench_results.csv
-     names: all                 # family names or individual benchmarks
-     methods: [knn, linear]     # KNN applies to classification only
-     split: random              # random | spatial | both
-     folds: 5
-     cell_deg: 10.0
-     knn_k: 5
-     knn_device: cpu
+   $ torchgeo-bench coord --model sincos --names all --methods knn,linear --split random
 
 See :doc:`coordbench` for benchmark families, included encoders, split
 semantics, and a custom-encoder example.
-
-``model`` block
----------------
-
-The default ``model: rcf`` selects Random Convolutional Features.  Browse
-:file:`src/torchgeo_bench/conf/model/` for the full list of presets.  Each
-preset can ship its own ``eval`` overrides (for example, segmentation
-backbones often pin ``head_type: fpn`` and bump the learning rate); these
-are merged on top of the global ``eval`` block per dataset.

--- a/docs/user/contribute_dataset.rst
+++ b/docs/user/contribute_dataset.rst
@@ -79,7 +79,7 @@ Required class-level attributes:
   silently reports the wrong number.
 * ``supports_partitions`` — ``True`` only for V1 GeoBench datasets, which ship
   partition JSON files.  When ``False``, ``get_datasets`` warns and ignores a
-  non-default ``dataset.partition``.
+  non-default ``--partition``.
 
 The ``get_dataset`` method takes ``split`` (``"train"``, ``"val"``, or
 ``"test"``) plus the keyword-only arguments ``partition``, ``bands`` (the
@@ -171,10 +171,11 @@ its ``(submodule, class_name)``:
 
 This is the step that actually makes the dataset available — it backs
 ``get_bench_dataset_class``, :func:`~torchgeo_bench.datasets.list_datasets`,
-and the CLI.  There is no per-dataset Hydra config; datasets are selected by
-name on the command line. The registry is kept as module/class-name strings
-rather than imported classes so that importing ``loading`` stays cheap;
-``get_bench_dataset_class`` imports only the one module it needs.
+and the CLI.  There is no per-dataset config file; datasets are selected by
+name on the command line (``--datasets``). The registry is kept as
+module/class-name strings rather than imported classes so that importing
+``loading`` stays cheap; ``get_bench_dataset_class`` imports only the one
+module it needs.
 
 **2. Export the class** from :file:`src/torchgeo_bench/datasets/__init__.py`
 by adding an ``__all__`` entry and a matching ``_LAZY_CLASSES`` mapping:

--- a/docs/user/contribute_model.rst
+++ b/docs/user/contribute_model.rst
@@ -179,17 +179,17 @@ coverage and write the results to :file:`results/contributed/<model_name>.csv`:
 
 .. code-block:: console
 
-   $ torchgeo-bench run model=new_model \
-       dataset.names=[m-eurosat,m-so2sat,m-bigearthnet,m-brick-kiln,m-forestnet,m-pv4ger] \
-       output=results/contributed/new_model.csv
+   $ torchgeo-bench run --model new_model \
+       --datasets m-eurosat,m-so2sat,m-bigearthnet,m-brick-kiln,m-forestnet,m-pv4ger \
+       --output results/contributed/new_model.csv
 
 For V2 datasets:
 
 .. code-block:: console
 
-   $ torchgeo-bench run model=new_model \
-       dataset.names=[benv2,treesatai,so2sat,forestnet] \
-       output=results/contributed/new_model.csv resume=true
+   $ torchgeo-bench run --model new_model \
+       --datasets benv2,treesatai,so2sat,forestnet \
+       --output results/contributed/new_model.csv --resume
 
 The CSV schema is identical to the per-model results files — see
 :doc:`results-format` for the full column reference.

--- a/docs/user/coordbench.rst
+++ b/docs/user/coordbench.rst
@@ -19,17 +19,17 @@ small CPU example evaluates one regression benchmark with two random folds:
 
 .. code-block:: console
 
-   $ torchgeo-bench run \
-       mode=coord \
-       model=sincos \
-       coord.names=california_housing \
-       coord.methods=[linear] \
-       coord.folds=2 \
-       device=cpu \
-       coord.output=results/coordbench_quickstart.csv
+   $ torchgeo-bench coord \
+       --model sincos \
+       --names california_housing \
+       --methods linear \
+       --folds 2 \
+       --device cpu \
+       --output results/coordbench_quickstart.csv
 
-Results are appended to ``coord.output``. Set ``resume=true`` to skip rows that
-already match ``(dataset, task, method, model, split)``.
+Results are appended to ``--output`` (default: ``results/coordbench_results.csv``).
+Pass ``--resume`` to skip rows that already match
+``(dataset, task, method, model, split)``.
 
 Included encoders
 -----------------
@@ -57,11 +57,10 @@ spatial-block cross-validation:
 
 .. code-block:: console
 
-   $ torchgeo-bench run \
-       mode=coord \
-       model=satclip \
-       coord.names=satclip \
-       coord.split=both
+   $ torchgeo-bench coord \
+       --model satclip \
+       --names satclip \
+       --split both
 
 Benchmarks and probes
 ---------------------
@@ -74,31 +73,22 @@ name, or an individual benchmark name. Available families are ``pdfm``,
 
 Classification tasks report accuracy and support ``knn`` and ``linear``.
 Regression tasks report R2 and use ``linear``; requested KNN rows are skipped
-because this track does not define a KNN regressor. ``coord.split`` controls the
+because this track does not define a KNN regressor. ``--split`` controls the
 holdout:
 
 ``random``
    Seeded k-fold cross-validation.
 ``spatial``
-   K-fold cross-validation over geographic grid cells. ``coord.cell_deg`` sets
+   K-fold cross-validation over geographic grid cells. ``--cell-deg`` sets
    the cell width in degrees.
 ``both``
    Run both cross-validation protocols. Benchmarks with an official test mask
    use that fixed holdout once instead.
 
-The full block is:
-
-.. code-block:: yaml
-
-   coord:
-     output: results/coordbench_results.csv
-     names: all
-     methods: [knn, linear]
-     split: random
-     folds: 5
-     cell_deg: 10.0
-     knn_k: 5
-     knn_device: cpu
+``torchgeo-bench coord --help`` lists every flag with its default
+(``--output``, ``--names``, ``--methods``, ``--split``, ``--folds``,
+``--cell-deg``, ``--knn-k``, ``--knn-device``, plus the common ``--model``,
+``--device``, ``--resume``, ``--seed``, ``--config``, ``--print-config``).
 
 Add a location encoder
 ----------------------
@@ -108,27 +98,33 @@ and implements ``_encode(lon, lat, year)``. The method receives one batch of
 NumPy arrays and returns a finite ``(N, D)`` feature matrix.
 
 The repository includes a complete Fourier-feature example in
-:file:`examples/coordbench_location_encoder.py`. Run it from the repository
-root by replacing the built-in ``sincos`` target through a config override:
+:file:`examples/coordbench_location_encoder.py`. There is no ``key=value``
+override for an arbitrary ``_target_``, so trying it out means adding a small
+preset YAML that points at the example class, e.g.
+:file:`src/torchgeo_bench/conf/model/fourier.yaml`:
+
+.. code-block:: yaml
+
+   _target_: examples.coordbench_location_encoder.FourierLocationEncoder
+   name: fourier
+   num_frequencies: 8
+
+then running it from the repository root with ``--model fourier``:
 
 .. code-block:: console
 
-   $ PYTHONPATH=. uv run torchgeo-bench run \
-       mode=coord \
-       model=sincos \
-       model._target_=examples.coordbench_location_encoder.FourierLocationEncoder \
-       model.name=fourier \
-       +model.num_frequencies=8 \
-       coord.names=california_housing \
-       coord.methods=[linear] \
-       coord.folds=2 \
-       device=cpu \
-       coord.output=results/fourier_coordbench.csv
+   $ PYTHONPATH=. uv run torchgeo-bench coord \
+       --model fourier \
+       --names california_housing \
+       --methods linear \
+       --folds 2 \
+       --device cpu \
+       --output results/fourier_coordbench.csv
 
 For a reusable integration, place the class in an installed package and add a
-model YAML under :file:`src/torchgeo_bench/conf/model/` with its fully qualified
-``_target_``. See :doc:`/api/coordbench` for the public classes and probe
-functions.
+model preset under :file:`src/torchgeo_bench/conf/model/` with its fully
+qualified ``_target_``. See :doc:`/api/coordbench` for the public classes and
+probe functions.
 
 Aggregate results
 -----------------

--- a/docs/user/datasets.rst
+++ b/docs/user/datasets.rst
@@ -201,9 +201,9 @@ registered dataset:
 
 .. code-block:: console
 
-   $ torchgeo-bench run dataset.names=[m-eurosat]
-   $ torchgeo-bench run dataset.names=[burn_scars,pastis,flair2]
-   $ torchgeo-bench run dataset.names=all
+   $ torchgeo-bench run --datasets m-eurosat
+   $ torchgeo-bench run --datasets burn_scars,pastis,flair2
+   $ torchgeo-bench run --datasets all
 
 Bands selection
 ---------------
@@ -211,22 +211,22 @@ Bands selection
 Each dataset declares an ordered list of :class:`~torchgeo_bench.datasets.BandSpec`
 objects.  Three modes are supported:
 
-* ``dataset.bands=rgb`` *(default)* — only the bands listed in
+* ``--bands rgb`` *(default)* — only the bands listed in
   :attr:`~torchgeo_bench.datasets.BenchDataset.rgb_bands`.
-* ``dataset.bands=all`` — every band the dataset exposes.
-* ``dataset.bands=[red,green,blue,nir]`` — an explicit subset.
+* ``--bands all`` — every band the dataset exposes.
+* ``--bands red,green,blue,nir`` — an explicit subset.
 
 The runner derives ``num_channels`` from the loaded tensor and constructs
 the matching ``list[BandSpec]`` so the model wrapper can size its input
 layer and per-channel normalization correctly.  The selected ``bands``
 value is recorded in the results CSV so multiple runs writing to the same
-file (and ``resume=true``) keep RGB and multispectral results
+file (and ``--resume``) keep RGB and multispectral results
 distinguishable.
 
 .. code-block:: console
 
    $ # All 13 Sentinel-2 bands on EuroSAT with a pretrained timm ResNet-18
-   $ torchgeo-bench run model=timm/resnet18 dataset.names=[m-eurosat] dataset.bands=all
+   $ torchgeo-bench run --model timm/resnet18 --datasets m-eurosat --bands all
 
 Multi-modality (V2)
 -------------------
@@ -236,7 +236,7 @@ S1, ``pastis`` = S2 + S1, ``kuro_siwo`` = SAR + DEM).  Their wrappers
 set ``band_order_strategy = "by_sensor"`` and the V2 base class groups
 ``BandSpec`` entries by sensor before passing them to the upstream
 ``geobench_v2`` loader.  End users do not need to do anything special —
-set ``dataset.bands=all`` (or an explicit subset) and the right
+set ``--bands all`` (or an explicit subset) and the right
 per-modality tensors are concatenated into a single ``image`` key.
 
 Model compatibility
@@ -257,14 +257,14 @@ Model compatibility
 Data partitions (V1 only)
 -------------------------
 
-V1 datasets honour the ``dataset.partition`` argument (which selects one
+V1 datasets honour the ``--partition`` flag (which selects one
 of the partition JSON files distributed with each dataset).  V2 datasets
 ignore it.
 
 .. code-block:: console
 
    $ # Train on 1% of the V1 training split, write to a separate CSV
-   $ torchgeo-bench run dataset.partition=0.01x_train output=results/1pct.csv
+   $ torchgeo-bench run --partition 0.01x_train --output results/1pct.csv
 
 Common partition values: ``default``, ``0.01x_train``, ``0.02x_train``,
 ``0.05x_train``, ``0.10x_train``, ``0.20x_train``, ``0.50x_train``,

--- a/docs/user/eval_own_model.rst
+++ b/docs/user/eval_own_model.rst
@@ -190,38 +190,38 @@ parent directory to ``PYTHONPATH`` before running:
 Run the benchmark
 -----------------
 
-Pass your config name as ``model=new_model`` and any combination of dataset
+Pass your preset name as ``--model new_model`` and any combination of dataset
 names to the ``run`` subcommand (see :doc:`datasets` for the full list of
 available names):
 
 .. code-block:: console
 
-   $ torchgeo-bench run model=new_model dataset.names=[m-eurosat]
-   $ torchgeo-bench run model=new_model \
-       dataset.names=[m-eurosat,m-bigearthnet,benv2,burn_scars]
+   $ torchgeo-bench run --model new_model --datasets m-eurosat
+   $ torchgeo-bench run --model new_model \
+       --datasets m-eurosat,m-bigearthnet,benv2,burn_scars
 
 Skip the (slow) linear probe and reduce bootstrap samples for a quick trial:
 
 .. code-block:: console
 
-   $ torchgeo-bench run model=new_model dataset.names=[m-eurosat] \
-       eval.skip_linear=true eval.bootstrap=100
+   $ torchgeo-bench run --model new_model --datasets m-eurosat \
+       --skip-linear --bootstrap 100
 
 To write results to a dedicated file instead of the shared
-the per-model file, pass ``output=``:
+the per-model file, pass ``--output``:
 
 .. code-block:: console
 
-   $ torchgeo-bench run model=new_model \
-       dataset.names=[m-eurosat,m-so2sat] \
-       output=results/new_model_results.csv
+   $ torchgeo-bench run --model new_model \
+       --datasets m-eurosat,m-so2sat \
+       --output results/new_model_results.csv
 
-The ``resume=true`` flag respects whatever ``output=`` is set to, so an
+The ``--resume`` flag respects whatever ``--output`` is set to, so an
 interrupted run can be continued against the same file:
 
 .. code-block:: console
 
-   $ torchgeo-bench run model=new_model output=results/new_model_results.csv resume=true
+   $ torchgeo-bench run --model new_model --output results/new_model_results.csv --resume
 
 .. _eval-results:
 
@@ -229,11 +229,12 @@ Results
 -------
 
 Results are written to ``results/models/<model name>.csv`` by default (or to
-the path set via ``output=``, see above). Profile and intrinsic-dim rows --
-one-time model+hardware measurements enabled by ``eval.profile.enabled`` /
-``eval.intrinsic_dim.enabled`` -- go to their own
+the path set via ``--output``, see above). Profile and intrinsic-dim rows --
+one-time model+hardware measurements produced by the dedicated
+``torchgeo-bench profile`` / ``torchgeo-bench intrinsic-dim`` subcommands --
+go to their own
 ``results/profiles/<model name>.csv`` and
 ``results/intrinsic_dim/<model name>.csv`` files instead, so a routine
-metrics rerun never touches them. Setting ``output=`` explicitly sends
+metrics rerun never touches them. Passing ``--output`` explicitly sends
 every row type to that one file.
 For the full column reference and how to read the CSV, see :doc:`results-format`.

--- a/docs/user/glossary.rst
+++ b/docs/user/glossary.rst
@@ -19,7 +19,7 @@ Glossary
 
    bootstrap
        Resampling technique used to estimate a confidence interval
-       around a metric.  ``eval.bootstrap`` controls the number of
+       around a metric.  ``--bootstrap`` controls the number of
        resamples; per-dataset CIs are reported as ``(ci_lower, ci_upper)``
        in the results CSV.
 
@@ -33,16 +33,11 @@ Glossary
        directory per dataset under ``data/geobenchv2/``.  V2 datasets
        use no prefix (``benv2``, ``treesatai``, ``pastis``, ...).
 
-   OmegaConf
-       The YAML configuration library used to compose model and run
-       configs.  See :doc:`configuration` for the override syntax and
-       https://omegaconf.readthedocs.io for the full documentation.
-
    intrinsic dimension
        The geometric / statistical dimension of a manifold of feature
        embeddings, estimated by methods such as TwoNN, MLE, or lPCA.
-       Optional in ``torchgeo-bench`` via ``eval.intrinsic_dim`` and the
-       ``[id]`` extra; see :mod:`torchgeo_bench.intrinsic_dim`.
+       Run via the ``torchgeo-bench intrinsic-dim`` subcommand (the
+       ``[id]`` extra); see :mod:`torchgeo_bench.intrinsic_dim`.
 
    KNN-5
        5-nearest-neighbour classifier evaluated on backbone-extracted
@@ -50,8 +45,9 @@ Glossary
 
    linear probe
        Logistic regression trained on frozen backbone features. We sweep
-       ``C`` over ``eval.c_range`` and report the best test-set
-       performance with ``best_c``. Method label: ``linear``.
+       ``C`` over a log-spaced range (set via ``--config``'s
+       ``eval.c_range``) and report the best test-set performance with
+       ``best_c``. Method label: ``linear``.
 
    mIoU
        Mean Intersection-over-Union, the primary metric for segmentation
@@ -59,6 +55,6 @@ Glossary
        :func:`~torchgeo_bench.main.evaluate_segmentation`.
 
    resume mode
-       When ``resume=true``, the runner skips any
+       When ``--resume`` is passed, the runner skips any
        ``(dataset, method, model, config)`` combination already present
        in the output CSV.  See :doc:`results-format` for the exact key.

--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -84,5 +84,5 @@ Extra             Pulls in
 
 Datasets are not installed by these extras — see :doc:`datasets` for how to
 download GeoBench V1 / V2 with the bundled ``torchgeo-bench download`` command.
-CoordBench tables stream from Hugging Face when ``mode=coord``; see
+CoordBench tables stream from Hugging Face when using ``torchgeo-bench coord``; see
 :doc:`coordbench`.

--- a/docs/user/methodology.rst
+++ b/docs/user/methodology.rst
@@ -36,7 +36,8 @@ evaluation path is taken:
 
 Optionally, intrinsic-dimension metrics
 (:doc:`/api/intrinsic_dim`) can be emitted alongside the standard
-classification rows when ``eval.intrinsic_dim.enabled=true``.
+classification rows by running the ``torchgeo-bench intrinsic-dim``
+subcommand, which sets the internal ``eval.intrinsic_dim.enabled`` setting.
 
 Feature extraction (classification)
 -----------------------------------
@@ -60,7 +61,8 @@ reused by both KNN and the linear probe.
 Feature-spectrum diagnostics
 ----------------------------
 
-When ``eval.intrinsic_dim.enabled=true``, each selected split also emits five
+When running via ``torchgeo-bench intrinsic-dim`` (which sets the internal
+``eval.intrinsic_dim.enabled`` setting), each selected split also emits five
 scale-invariant diagnostics from the **centered** embedding matrix.  Let
 ``s_i`` be its singular values and let
 
@@ -117,8 +119,8 @@ Procedure
 3. Predict labels for every test sample.
 4. Compute test-set accuracy (or micro-mAP for multilabel datasets).
 5. Compute **95% bootstrap confidence intervals**
-   (``eval.bootstrap`` resamples, default ``200``) by resampling test
-   predictions with replacement.
+   (``eval.bootstrap`` resamples, ``--bootstrap`` flag, default ``200``) by
+   resampling test predictions with replacement.
 
 Key details
 ^^^^^^^^^^^
@@ -142,10 +144,11 @@ Procedure
 1. Extract train, validation, and test embeddings.
 2. **Hyperparameter sweep:** train one logistic regression per ``C``
    value in a log-spaced grid
-   (``eval.c_range``, default 40 values from 10⁻⁶ to 10⁴).
+   (``eval.c_range``, set via ``--config``, default 40 values from 10⁻⁶ to 10⁴).
    Each model is evaluated on the validation set to pick the best ``C``.
 3. **Final model:** retrain with the chosen ``C``, optionally on
-   ``train ∪ val`` (``eval.merge_val=true``, the default).
+   ``train ∪ val`` (``eval.merge_val``, ``--merge-val``/``--no-merge-val``
+   flag, ``true`` by default).
 4. Evaluate on the test set; report accuracy / micro-mAP with 95%
    bootstrap confidence intervals.
 
@@ -174,19 +177,23 @@ Hyperparameters
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 25 50
+   :widths: 25 25 15 35
 
-   * - Parameter
+   * - Setting
      - Default
+     - CLI flag
      - Description
    * - ``eval.c_range``
      - ``[-6, 4, 40]``
+     - *(--config only)*
      - log₁₀ start, stop, and number of ``C`` values
    * - ``eval.merge_val``
      - ``true``
+     - ``--merge-val``/``--no-merge-val``
      - merge train + val for final model training
    * - ``eval.bootstrap``
      - ``200``
+     - ``--bootstrap``
      - bootstrap resamples for the confidence interval
 
 Segmentation probes
@@ -214,7 +221,7 @@ Linear segmentation probe
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Method name:** ``seg-linear``
-(``eval.segmentation.head_type=linear``).
+(``eval.segmentation.head_type``, ``--seg-head linear``).
 A lightweight per-pixel linear classifier per layer, with multi-layer
 fusion via learned scalar weights.
 
@@ -228,7 +235,7 @@ Convolutional probe
 ^^^^^^^^^^^^^^^^^^^
 
 **Method name:** ``seg-conv_block``
-(``eval.segmentation.head_type=conv_block``).
+(``eval.segmentation.head_type``, ``--seg-head conv_block``).
 Slightly more expressive: projects and fuses multi-scale features
 before classification, testing whether the backbone captures
 complementary information at different depths.
@@ -244,7 +251,7 @@ complementary information at different depths.
 FPN probe
 ^^^^^^^^^
 
-**Method name:** ``seg-fpn`` (``eval.segmentation.head_type=fpn``).
+**Method name:** ``seg-fpn`` (``eval.segmentation.head_type``, ``--seg-head fpn``).
 A Feature-Pyramid-Network-style top-down decoder that fuses multi-scale
 maps in coarse-to-fine order — matching common dense-prediction
 literature.
@@ -263,7 +270,7 @@ literature.
 DPT probe
 ^^^^^^^^^
 
-**Method name:** ``seg-dpt`` (``eval.segmentation.head_type=dpt``).
+**Method name:** ``seg-dpt`` (``eval.segmentation.head_type``, ``--seg-head dpt``).
 A DPT-style reassemble + fusion-transformer decoder
 (:class:`~torchgeo_bench.models.DPTHead`).  Requires exactly four
 backbone layers in coarse-to-fine order; otherwise structurally
@@ -276,7 +283,7 @@ Training & evaluation (all heads)
 * **Loss:** ``CrossEntropyLoss(ignore_index=255)`` so unlabeled pixels
   are excluded from both loss and metric computation.
 * **Schedule:** cosine decay to 1e-6 by default
-  (``eval.segmentation.lr_scheduler``); ``none`` disables.
+  (``eval.segmentation.lr_scheduler``, ``--seg-scheduler``); ``none`` disables.
 * **Metric:** mean Intersection-over-Union (mIoU) via
   ``torchmetrics.MulticlassJaccardIndex``.  Frequency-weighted IoU plus
   macro precision / recall / F1 are also reported in the result row
@@ -289,8 +296,10 @@ Segmentation knobs
 ------------------
 
 All keys live under ``eval.segmentation`` in
-:file:`src/torchgeo_bench/conf/config.yaml` (global defaults) or under a
-model preset's ``eval`` block (per-model override).
+``torchgeo_bench.settings`` (global defaults, most exposed via
+``--seg-*`` flags on ``run``/``profile``/``intrinsic-dim`` -- see
+``torchgeo-bench run --help``) or under a model preset's ``eval`` block
+(per-model override).
 
 Head type
 ^^^^^^^^^
@@ -317,32 +326,41 @@ Training knobs
 
 .. list-table::
    :header-rows: 1
-   :widths: 22 18 60
+   :widths: 18 15 18 49
 
    * - Option
      - Default
+     - CLI flag
      - Description
    * - ``layers``
      - *(per model)*
+     - *(--config only)*
      - Backbone layer names to hook.  For FPN / DPT, deepest layer first.
    * - ``epochs``
      - ``10``
+     - ``--seg-epochs``
      - Training epochs for the probe head.
    * - ``lr``
      - ``1e-3``
+     - ``--seg-lr``
      - Initial learning rate (AdamW).
    * - ``lr_scheduler``
      - ``cosine``
+     - ``--seg-scheduler``
      - ``cosine`` (CosineAnnealingLR to 1e-6) or ``none`` (constant).
    * - ``criterion``
      - ``torch.nn.CrossEntropyLoss``
+     - *(--config only)*
      - Instantiable loss criterion; provide an alternative via the
-       config ``criterion`` block.
+       ``--config`` YAML's ``criterion`` block.
    * - ``hidden_dim``
      - ``256``
-     - Projection dimension for ``conv_block`` / ``fpn`` / ``dpt`` heads.
+     - *(not configurable)*
+     - Projection dimension for ``conv_block`` / ``fpn`` / ``dpt`` heads;
+       currently hardcoded in :class:`~torchgeo_bench.segmentation_probe.SegmentationProbe`.
    * - ``batch_size``
      - ``64``
+     - ``--seg-batch-size``
      - Batch size when training the probe head.
 
 Feature caching
@@ -350,13 +368,15 @@ Feature caching
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 18 57
+   :widths: 20 15 18 47
 
    * - Option
      - Default
+     - CLI flag
      - Description
    * - ``cache_features``
      - ``true``
+     - ``--seg-cache``/``--no-seg-cache``
      - Pre-extract backbone features once per split into RAM.  Stored
        layer-first as contiguous ``(N, C, H, W)`` ``float16`` tensors
        (:class:`~torchgeo_bench.segmentation_probe.CachedFeaturesDataset`).
@@ -364,6 +384,7 @@ Feature caching
        re-runs across epochs — the dominant speedup.
    * - ``cache_dtype``
      - ``float16``
+     - ``--seg-cache-dtype``
      - Storage dtype for cached features.  ``float16`` halves RAM;
        autocast upcasts during the head forward pass.
 
@@ -374,34 +395,41 @@ All evaluation paths share these settings:
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 18 57
+   :widths: 20 15 18 47
 
    * - Setting
      - Default
+     - CLI flag
      - Description
    * - ``seed``
      - ``0``
+     - ``--seed``
      - Random seed for reproducibility (numpy + torch).
    * - ``device``
-     - ``cuda:0``
-     - PyTorch device.
+     - ``auto``
+     - ``--device``
+     - PyTorch device; auto picks ``cuda`` if available, else ``cpu``.
    * - ``dataset.batch_size``
      - ``64``
+     - ``--batch-size``
      - Batch size for data loading.
    * - ``dataset.image_size``
      - ``224``
-     - Resize input images (``null`` = preserve native size).
+     - ``--image-size``
+     - Resize input images (``null``/omitted = preserve native size).
    * - ``dataset.interpolation``
      - ``bilinear``
+     - ``--interpolation``
      - Resize interpolation method.
    * - ``resume``
      - ``false``
+     - ``--resume``
      - Skip already-computed
        ``(dataset, method, model, …)`` combinations.
 
 Resume mode and output schema
 -----------------------------
 
-When ``resume=true`` the runner reads the existing CSV at startup and
-skips any combination already present.  See :doc:`results-format` for
+When ``--resume`` is passed the runner reads the existing CSV at startup
+and skips any combination already present.  See :doc:`results-format` for
 the full key, the column schema, and the atomic-append guarantee.

--- a/docs/user/models.rst
+++ b/docs/user/models.rst
@@ -12,8 +12,9 @@ Available presets
 -----------------
 
 Every preset under :file:`src/torchgeo_bench/conf/model/` becomes a
-``model=…`` selector for the ``run`` subcommand.  A preset's ``_target_``
-field resolves to a class re-exported from :mod:`torchgeo_bench.models`.
+``--model``/``-m`` selector for the ``run`` subcommand.  A preset's
+``_target_`` field resolves to a class re-exported from
+:mod:`torchgeo_bench.models`.
 
 Random Convolutional Features (RCF)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -23,8 +24,11 @@ features in the spirit of MOSAIKS.
 
 .. code-block:: console
 
-   $ torchgeo-bench run model=rcf
-   $ torchgeo-bench run model=rcf model.mode=empirical model.features=1024
+   $ torchgeo-bench run --model rcf
+
+Fields with no dedicated CLI flag (like RCF's ``mode``/``features``) are
+set by copying :file:`conf/model/rcf.yaml` to a new preset name and editing
+it -- there is no ``key=value`` override for arbitrary model kwargs.
 
 Image statistics baseline
 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -34,7 +38,7 @@ returns per-channel mean / std as the feature vector.
 
 .. code-block:: console
 
-   $ torchgeo-bench run model=imagestats
+   $ torchgeo-bench run --model imagestats
 
 timm — ImageNet-pretrained CNNs and ViTs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -46,18 +50,18 @@ ViT / DeiT / Swin variants live under :file:`timm/vit/`.
 
 .. code-block:: console
 
-   $ torchgeo-bench run model=timm/resnet50
-   $ torchgeo-bench run model=timm/convnext_base dataset.names=[m-eurosat]
-   $ torchgeo-bench run model=timm/vit/vit_base_patch16_224 dataset.image_size=224
-   $ torchgeo-bench run model=timm/vit/swin_base_patch4_window7_224 eval.skip_linear=true
+   $ torchgeo-bench run --model timm/resnet50
+   $ torchgeo-bench run --model timm/convnext_base --datasets m-eurosat
+   $ torchgeo-bench run --model timm/vit/vit_base_patch16_224 --image-size 224
+   $ torchgeo-bench run --model timm/vit/swin_base_patch4_window7_224 --skip-linear
 
 ViT-style backbones expect a fixed spatial resolution.  Set
-``dataset.image_size=224`` (``bilinear`` by default; switch to
-``bicubic`` / ``nearest`` via ``dataset.interpolation``) to resize the
+``--image-size 224`` (``bilinear`` by default; switch to
+``bicubic`` / ``nearest`` via ``--interpolation``) to resize the
 dataset tiles for any model.
 
 timm models rebuild their input convolution for any number of channels —
-they work with ``dataset.bands=all`` out of the box (pretrained
+they work with ``--bands all`` out of the box (pretrained
 3-channel weights are averaged / replicated as needed).
 
 .. warning::
@@ -82,22 +86,22 @@ RGB-only self-supervised checkpoints from torchgeo's model hub.
 .. code-block:: console
 
    $ # Sentinel-2 RGB SSL
-   $ torchgeo-bench run model=torchgeo/resnet50_s2rgb_moco
-   $ torchgeo-bench run model=torchgeo/resnet18_s2rgb_seco
-   $ torchgeo-bench run model=torchgeo/resnet50_fmow_gassl
+   $ torchgeo-bench run --model torchgeo/resnet50_s2rgb_moco
+   $ torchgeo-bench run --model torchgeo/resnet18_s2rgb_seco
+   $ torchgeo-bench run --model torchgeo/resnet50_fmow_gassl
 
    $ # ScaleMAE on fMoW RGB
-   $ torchgeo-bench run model=torchgeo/scalemae_large_fmow
+   $ torchgeo-bench run --model torchgeo/scalemae_large_fmow
 
    $ # DOFA — band-agnostic (currently configured for Sentinel-2 RGB wavelengths)
-   $ torchgeo-bench run model=torchgeo/dofa_base
+   $ torchgeo-bench run --model torchgeo/dofa_base
 
    $ # Satlas Swin-V2 (NAIP / Sentinel-2 RGB)
-   $ torchgeo-bench run model=torchgeo/swinv2b_naip_satlas_mi
-   $ torchgeo-bench run model=torchgeo/swinv2b_s2rgb_satlas_mi
+   $ torchgeo-bench run --model torchgeo/swinv2b_naip_satlas_mi
+   $ torchgeo-bench run --model torchgeo/swinv2b_s2rgb_satlas_mi
 
    $ # EarthLoc place-recognition descriptor
-   $ torchgeo-bench run model=torchgeo/earthloc_s2_resnet50
+   $ torchgeo-bench run --model torchgeo/earthloc_s2_resnet50
 
 OlmoEarth (AI2)
 ^^^^^^^^^^^^^^^
@@ -110,19 +114,19 @@ optional ``olmoearth`` extra:
    $ pip install 'torchgeo-bench[olmoearth]'
 
    $ # OlmoEarth v1 (Nano / Tiny / Base / Large)
-   $ torchgeo-bench run model=olmoearth_nano
-   $ torchgeo-bench run model=olmoearth_base
-   $ torchgeo-bench run model=olmoearth_large dataset.bands=all
+   $ torchgeo-bench run --model olmoearth_nano
+   $ torchgeo-bench run --model olmoearth_base
+   $ torchgeo-bench run --model olmoearth_large --bands all
 
    $ # OlmoEarth v1.1 (Nano / Tiny / Base)
-   $ torchgeo-bench run model=olmoearth_v1_1_nano
-   $ torchgeo-bench run model=olmoearth_v1_1_tiny
-   $ torchgeo-bench run model=olmoearth_v1_1_base
+   $ torchgeo-bench run --model olmoearth_v1_1_nano
+   $ torchgeo-bench run --model olmoearth_v1_1_tiny
+   $ torchgeo-bench run --model olmoearth_v1_1_base
 
    $ # OlmoEarth v1.2 (Nano / Tiny / Small / Base)
-   $ torchgeo-bench run model=olmoearth_v1_2_nano
-   $ torchgeo-bench run model=olmoearth_v1_2_small
-   $ torchgeo-bench run model=olmoearth_v1_2_base
+   $ torchgeo-bench run --model olmoearth_v1_2_nano
+   $ torchgeo-bench run --model olmoearth_v1_2_small
+   $ torchgeo-bench run --model olmoearth_v1_2_base
 
 OlmoEarth v1.1 uses a **linear patch embedding** (vs. convolutional in v1),
 a single bandset per modality, and updated masking/loss functions, yielding a
@@ -185,7 +189,7 @@ The ``version`` parameter selects the weight family:
 
 .. note::
 
-   Input normalization is selected globally with ``dataset.normalization``
+   Input normalization is selected globally with ``--normalization``
    (default ``bandspec_zscore``).  Each model receives that strategy through
    :class:`~torchgeo_bench.models.BenchModel`; use ``model_native`` for
    wrappers that declare pretrained input units / statistics, or ``identity``
@@ -196,20 +200,21 @@ The ``version`` parameter selects the weight family:
    DN) can't match.  OlmoEarth therefore selects normalization per sensor
    (``norm_from_pretrained="auto"``, the default): Landsat is normalized with
    dataset-specific ``BandSpec`` stats while Sentinel-2 / SAR use the
-   pretrained normalizer.  Pass ``model.norm_from_pretrained=true`` (or
-   ``false``) to force one path for all sensors.
+   pretrained normalizer.  ``norm_from_pretrained`` has no dedicated CLI
+   flag; to force one path for all sensors, copy the relevant OlmoEarth
+   preset YAML to a new name and set ``norm_from_pretrained: true`` (or
+   ``false``) in the copy.
 
 .. note::
 
-   **Per-model input resolution.**  A model config may set ``image_size`` to
-   override the global ``dataset.image_size`` (default ``224``).  OlmoEarth is
-   resolution-flexible, so its configs set ``image_size: null`` to evaluate at
+   **Per-model input resolution.**  A model preset may set ``image_size`` to
+   override the global default (``--image-size``, ``224``).  OlmoEarth is
+   resolution-flexible, so its presets set ``image_size: null`` to evaluate at
    each dataset's **native** resolution rather than upsampling to 224×224
    (matching the reference OlmoEarth evals).  Models that omit the field
-   inherit ``dataset.image_size``.  To force a specific size for a run, pass
-   ``model.image_size=<int>`` (or ``~model.image_size`` to fall back to the
-   dataset default).  The effective size is recorded in the results CSV and
-   in the resume cache key.
+   inherit the ``--image-size`` value.  To force a specific size for a run,
+   pass ``--image-size <int>`` on the command line.  The effective size is
+   recorded in the results CSV and in the resume cache key.
 
 SAM 3 vision encoder
 ^^^^^^^^^^^^^^^^^^^^
@@ -220,7 +225,7 @@ SAM 3 vision encoder
 .. code-block:: console
 
    $ pip install 'torchgeo-bench[sam3]'
-   $ torchgeo-bench run model=sam3_encoder dataset.bands=[red,green,blue]
+   $ torchgeo-bench run --model sam3_encoder --bands red,green,blue
 
 Adding a new model
 ------------------

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -11,7 +11,7 @@ Prerequisites
 * At least one GeoBench dataset under ``./data/``.  The lightest path is to
   skip the bulk download entirely and let the **single-dataset auto-download**
   run: the first time you benchmark a V1 dataset (e.g.
-  ``dataset.names=[m-eurosat]``) only that dataset is pulled.
+  ``--datasets m-eurosat``) only that dataset is pulled.
 
 Download data
 -------------
@@ -44,30 +44,31 @@ KNN-5 + linear probing + 200 bootstrap resamples:
 
 .. code-block:: console
 
-   $ torchgeo-bench run dataset.names=[m-eurosat]
+   $ torchgeo-bench run --datasets m-eurosat
 
 Use a different backbone preset (anything in :file:`src/torchgeo_bench/conf/model/`):
 
 .. code-block:: console
 
-   $ torchgeo-bench run model=timm/resnet50 dataset.names=[m-eurosat,m-pv4ger]
+   $ torchgeo-bench run --model timm/resnet50 --datasets m-eurosat,m-pv4ger
 
 Skip the (slow) linear probe and reduce bootstrap noise to iterate quickly:
 
 .. code-block:: console
 
-   $ torchgeo-bench run eval.skip_linear=true eval.bootstrap=100
+   $ torchgeo-bench run --skip-linear --bootstrap 100
 
-The default device is ``cuda:0``.  On a machine without a working CUDA GPU
-(or if a GPU run crashes — see :doc:`troubleshooting`), add ``device=cpu``:
+The default device is auto-detected (``cuda`` if available, else ``cpu``).
+On a machine without a working CUDA GPU (or if a GPU run crashes — see
+:doc:`troubleshooting`), force CPU with ``--device cpu``:
 
 .. code-block:: console
 
-   $ torchgeo-bench run dataset.names=[m-eurosat] device=cpu
+   $ torchgeo-bench run --datasets m-eurosat --device cpu
 
 When the selected FAISS backend has no GPU resources, the runner evaluates KNN
 on CPU while keeping feature extraction on the configured accelerator. It logs
-this fallback; use ``eval.knn_device=cpu`` to select it explicitly.
+this fallback; use ``--knn-device cpu`` to select it explicitly.
 
 Benchmark a location encoder
 ----------------------------
@@ -77,9 +78,9 @@ location baseline on a single regression benchmark with:
 
 .. code-block:: console
 
-   $ torchgeo-bench run mode=coord model=sincos \
-       coord.names=california_housing coord.methods=[linear] \
-       coord.folds=2 device=cpu
+   $ torchgeo-bench coord --model sincos \
+       --names california_housing --methods linear \
+       --folds 2 --device cpu
 
 See :doc:`coordbench` for the pretrained MIND, SatCLIP, GeoCLIP, Climplicit,
 and SINR presets, spatial cross-validation, output schema, and a complete
@@ -88,13 +89,13 @@ custom-encoder example.
 Resume mode
 -----------
 
-If a previous run was interrupted, ``resume=true`` skips any
+If a previous run was interrupted, ``--resume`` skips any
 ``(dataset, method, model, config)`` combination that already exists in the
 output CSV:
 
 .. code-block:: console
 
-   $ torchgeo-bench run resume=true
+   $ torchgeo-bench run --resume
 
 See :doc:`results-format` for the exact key schema used by resume mode.
 
@@ -103,10 +104,11 @@ Inspect the results
 
 By default results land in ``results/models/<model name>.csv``.  Those files **ship
 pre-populated** with reference results, so to start from a clean slate write to
-your own file with ``output=results/my_run.csv``.  Profile/intrinsic-dim
+your own file with ``--output results/my_run.csv``.  Profile/intrinsic-dim
 measurements go to their own ``results/profiles/`` and
-``results/intrinsic_dim/`` files -- see :doc:`results-format` for why they're
-split out.  Each row is a flat
+``results/intrinsic_dim/`` files (produced by the ``torchgeo-bench profile`` /
+``torchgeo-bench intrinsic-dim`` subcommands) -- see :doc:`results-format` for
+why they're split out.  Each row is a flat
 :class:`~torchgeo_bench.main.EvaluationResult`, so you can read it directly with
 pandas:
 

--- a/docs/user/results-format.rst
+++ b/docs/user/results-format.rst
@@ -41,7 +41,8 @@ Sample rows
 
 Datasets emit unnormalized tensors; each model wrapper normalises inside
 :meth:`~torchgeo_bench.models.BenchModel.normalize_inputs` according to
-the strategy selected by ``cfg.dataset.normalization``.  Allowed values:
+the strategy selected by ``--normalization`` (``cfg.dataset.normalization``
+internally).  Allowed values:
 
 .. list-table::
    :header-rows: 1
@@ -74,10 +75,12 @@ Method values
 ``linear``         L-BFGS logistic regression with C-sweep on the validation set. -> ``results/models/``
 ``intrinsic_dim``  Optional intrinsic-dimension metrics on extracted embeddings (requires
                    the ``[id]`` extra) plus dependency-free centered feature-spectrum
-                   diagnostics. Both are emitted when
-                   ``eval.intrinsic_dim.enabled=true``; set ``estimators=[]`` for
+                   diagnostics. Both are emitted when running via the
+                   ``torchgeo-bench intrinsic-dim`` subcommand (internally
+                   ``eval.intrinsic_dim.enabled=true``); set ``estimators=[]`` for
                    spectrum-only output without ``torchid``. -> ``results/intrinsic_dim/``
-``profile``        Optional throughput/latency/param-count measurement (requires
+``profile``        Optional throughput/latency/param-count measurement, produced by the
+                   ``torchgeo-bench profile`` subcommand (internally
                    ``eval.profile.enabled=true``). -> ``results/profiles/``
 ``seg-<head>``     Segmentation probe with the configured head (``linear`` / ``conv_block`` /
                    ``fpn`` / ``dpt``). -> ``results/models/``
@@ -137,7 +140,7 @@ per GPU or per dataset) at the same output file without corrupting it.
 Resume mode
 -----------
 
-When ``resume=true``, the runner reads the existing CSV(s) at startup and
+When ``--resume`` is passed, the runner reads the existing CSV(s) at startup and
 skips any combination that already has a matching row.  Since profile and
 intrinsic-dim rows may live in their own files (see above), resume reads
 all three files -- ``results/models/<name>.csv``,
@@ -150,8 +153,8 @@ all three files -- ``results/models/<name>.csv``,
     normalization, image_size, interpolation, partition, bands, num_classes)
 
 Note that ``method`` is per-method (``knn5`` / ``linear`` /
-``intrinsic_dim`` / ``seg-<head_type>``), so re-running with
-``eval.skip_linear=false`` after a ``skip_linear=true`` run will fill in
+``intrinsic_dim`` / ``seg-<head_type>``), so re-running without
+``--skip-linear`` after a ``--skip-linear`` run will fill in
 just the linear-probe rows.
 
 Rows written before version 0.5.0 do not have ``num_classes`` and are treated

--- a/docs/user/troubleshooting.rst
+++ b/docs/user/troubleshooting.rst
@@ -30,26 +30,27 @@ CUDA out of memory
 
 .. code-block:: console
 
-   $ torchgeo-bench run dataset.batch_size=32
+   $ torchgeo-bench run --batch-size 32
    $ # or run on CPU
-   $ torchgeo-bench run device=cpu
+   $ torchgeo-bench run --device cpu
 
 For segmentation, also try
 
 .. code-block:: console
 
    $ torchgeo-bench run \
-       eval.segmentation.cache_dtype=float32 \
-       eval.segmentation.cache_features=false
+       --seg-cache-dtype float32 \
+       --no-seg-cache
 
 if RAM (rather than GPU memory) is the bottleneck.
 
 GPU run crashes immediately
 ---------------------------
 
-The default config is ``device: cuda:0``, so the first documented run uses the
-GPU.  ``uv sync`` installs the latest ``torch``, whose bundled CUDA and kernel
-architectures may not match your GPU or driver.  Two distinct failures:
+The default device is auto-detected and picks the first CUDA GPU when one is
+available, so the first documented run uses the GPU.  ``uv sync`` installs
+the latest ``torch``, whose bundled CUDA and kernel architectures may not
+match your GPU or driver.  Two distinct failures:
 
 * ``RuntimeError: The NVIDIA driver on your system is too old`` — the installed
   ``torch`` was built against a newer CUDA than your driver supports.
@@ -64,7 +65,7 @@ Either way you can fall back to CPU (slower, but always works):
 
 .. code-block:: console
 
-   $ torchgeo-bench run dataset.names=[m-eurosat] device=cpu
+   $ torchgeo-bench run --datasets m-eurosat --device cpu
 
 CPU is fine for the small V1 splits, but large V2 datasets (e.g. ``benv2`` /
 BigEarthNet) can take far longer — prefer a working GPU for those.
@@ -74,7 +75,7 @@ BigEarthNet) can take far longer — prefer a working GPU for those.
 
 A known V2 issue: ``geobench_v2.rearrange_bands`` expects modality keys
 (``'s2'``, ``'s1'``, …) that aren't present when a flat band list is
-requested.  Workaround: use ``dataset.bands=all`` for affected V2
+requested.  Workaround: use ``--bands all`` for affected V2
 datasets.
 
 ``eurosat-spatial`` reports ``Dataset not found``
@@ -91,7 +92,7 @@ V1 slow tests skip after the auto-download
 ------------------------------------------
 
 The per-dataset auto-download (triggered by running a V1 dataset such as
-``dataset.names=[m-eurosat]``) writes the webdataset layout under
+``--datasets m-eurosat``) writes the webdataset layout under
 ``data/classification_v1.0_wds/``.  The V1 *slow* integration tests instead
 read the legacy HDF5 layout under ``data/classification_v1.0/`` and skip if only
 the ``_wds`` data is present.  Fetch the legacy bundle with


### PR DESCRIPTION
Stacked on #301. Rewrites the README, user/API docs, repository instructions, and add-model template for the argparse subcommands, explicit flags, and optional --config YAML files. Runnable Hydra/OmegaConf examples are removed, while internal setting names remain documented where they explain result provenance and methodology.