### PR TITLE
refactor(runtime): remove defensive fallbacks

### DIFF
--- a/experiments/scripts/eurosat_family_dedup.py
+++ b/experiments/scripts/eurosat_family_dedup.py
@@ -75,11 +75,7 @@ def hash_dataset(dataset: str) -> pd.DataFrame:
             img = sample["image"]
             label = sample.get("label")
             label_val = int(label) if label is not None and np.ndim(label) == 0 else None
-            try:
-                ph = _phash_image(img)
-            except Exception as exc:
-                logger.warning("[%s/%s] hash failed for %d: %s", dataset, split, i, exc)
-                continue
+            ph = _phash_image(img)
             rows.append(
                 {
                     "dataset": dataset,
@@ -105,12 +101,7 @@ def main() -> None:
         format="%(asctime)s [%(levelname)s] %(message)s",
     )
 
-    frames = []
-    for d in args.datasets:
-        try:
-            frames.append(hash_dataset(d))
-        except Exception:
-            logger.exception("dataset %s failed", d)
+    frames = [hash_dataset(dataset) for dataset in args.datasets]
     if not frames:
         raise SystemExit("nothing hashed")
     df = pd.concat(frames, ignore_index=True)

--- a/experiments/scripts/render_flagged_gallery.py
+++ b/experiments/scripts/render_flagged_gallery.py
@@ -157,10 +157,7 @@ def main() -> None:
 
     for dataset, split, csv_path in pairs:
         out = args.out_dir / f"{dataset}_{split}.png"
-        try:
-            render_gallery(dataset, split, csv_path, out, args.top_k, args.cols)
-        except Exception:
-            logger.exception("[%s/%s] failed", dataset, split)
+        render_gallery(dataset, split, csv_path, out, args.top_k, args.cols)
 
 
 if __name__ == "__main__":

--- a/src/torchgeo_bench/__init__.py
+++ b/src/torchgeo_bench/__init__.py
@@ -4,12 +4,9 @@ Heavy submodules (torch, torchgeo, sklearn) load lazily so importing the
 package — and therefore CLI startup — stays fast.
 """
 
-from importlib.metadata import PackageNotFoundError, version
+from importlib.metadata import version
 
-try:
-    __version__ = version("torchgeo-bench")
-except PackageNotFoundError:  # editable / pre-install fallback
-    __version__ = "0.5.0"
+__version__ = version("torchgeo-bench")
 
 __author__ = "torchgeo-bench contributors"
 

--- a/src/torchgeo_bench/knn.py
+++ b/src/torchgeo_bench/knn.py
@@ -21,6 +21,7 @@ logging.getLogger("faiss.loader").setLevel(logging.WARNING)
 import faiss  # noqa: E402
 import numpy as np  # noqa: E402
 import torch  # noqa: E402
+from faissknn import FaissKNNClassifier, FaissKNNMultilabelClassifier  # noqa: E402
 
 if sys.platform == "darwin":
     faiss.omp_set_num_threads(1)
@@ -177,15 +178,6 @@ class KNNClassifier:
     # ---- GPU path (faissknn delegate) -------------------------------------
 
     def _fit_gpu(self, X: np.ndarray, y: np.ndarray) -> None:
-        try:
-            from faissknn import FaissKNNClassifier, FaissKNNMultilabelClassifier
-        except ImportError as exc:  # pragma: no cover — covered by env, not unit tests
-            raise ImportError(
-                f"KNNClassifier(device={self.device!r}): faissknn is not installed. "
-                "GPU KNN requires Linux x86_64, where it installs automatically; "
-                'otherwise request device="cpu".'
-            ) from exc
-
         if not gpu_faiss_available():
             raise RuntimeError(
                 f"KNNClassifier(device={self.device!r}): GPU-enabled FAISS is unavailable. "

--- a/tests/test_multilabel.py
+++ b/tests/test_multilabel.py
@@ -1,9 +1,6 @@
 """Tests for multi-label support and KNNClassifier."""
 
-import builtins
 import logging
-import sys
-from types import SimpleNamespace
 
 import numpy as np
 import pytest
@@ -107,14 +104,8 @@ class TestKNNClassifierSingleLabel:
                 del X, y
 
         monkeypatch.setattr(knn, "gpu_faiss_available", lambda: True)
-        monkeypatch.setitem(
-            sys.modules,
-            "faissknn",
-            SimpleNamespace(
-                FaissKNNClassifier=FakeFaissKNNClassifier,
-                FaissKNNMultilabelClassifier=FakeFaissKNNClassifier,
-            ),
-        )
+        monkeypatch.setattr(knn, "FaissKNNClassifier", FakeFaissKNNClassifier)
+        monkeypatch.setattr(knn, "FaissKNNMultilabelClassifier", FakeFaissKNNClassifier)
         X = np.zeros((3, 2), dtype=np.float32)
         y = np.array([0, 1, 2], dtype=np.int64)
 
@@ -295,22 +286,6 @@ class TestKNNGPUPath:
         clf.fit(d["x_train"], d["y_train"])
         assert isinstance(clf.predict(d["x_test"]), np.ndarray)
         assert isinstance(clf.predict_proba(d["x_test"]), np.ndarray)
-
-    def test_gpu_missing_faissknn_raises_instead_of_cpu_fallback(
-        self, singlelabel_data, monkeypatch
-    ):
-        real_import = builtins.__import__
-
-        def fake_import(name, *args, **kwargs):
-            if name == "faissknn":
-                raise ImportError("blocked for test")
-            return real_import(name, *args, **kwargs)
-
-        monkeypatch.setattr(builtins, "__import__", fake_import)
-        d = singlelabel_data
-        clf = KNNClassifier(n_neighbors=5, device="cuda")
-        with pytest.raises(ImportError, match='request device="cpu"'):
-            clf.fit(d["x_train"], d["y_train"])
 
     def test_explicit_gpu_with_cpu_faiss_raises_actionable_error(
         self, singlelabel_data, monkeypatch


### PR DESCRIPTION
Hard dependencies now import directly instead of carrying unreachable ImportError fallback paths, and package version lookup fails normally when the package is not installed. Dataset audit scripts no longer swallow arbitrary per-sample or per-dataset exceptions, so incomplete reports cannot look successful. KNN tests now patch the imported backend directly and remove the meaningless missing-hard-dependency case.