### PR TITLE
refactor(cli): lazy-load command implementations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
   "geobenchv2>=0.9",
   "h5py>=3.8",
   "huggingface-hub>=0.20",
+  "lazy-loader>=0.4",
   "numpy>=1.24",
   "omegaconf>=2.3",
   "pandas>=2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,6 +178,7 @@ lint.per-file-ignores."experiments/scripts/**/*.py" = [ "D" ]
 lint.per-file-ignores."projects/cleanlab/**/*.py" = [ "D" ]
 lint.per-file-ignores."projects/cleanlab/tests/**/*.py" = [ "ARG", "D" ]
 lint.per-file-ignores."src/torchgeo_bench/cli.py" = [ "T201" ]  # CLI payloads go to stdout
+lint.per-file-ignores."src/torchgeo_bench/commands/**/*.py" = [ "T201" ]
 lint.per-file-ignores."tests/**/*.py" = [ "ARG", "D" ]
 lint.flake8-tidy-imports.banned-api."__future__.annotations".msg = "Use ordinary annotations or quoted forward references."
 lint.flake8-tidy-imports.banned-api."contextlib.suppress".msg = "Let errors propagate or use an explicit except clause with a reason."

--- a/src/torchgeo_bench/cli.py
+++ b/src/torchgeo_bench/cli.py
@@ -94,7 +94,7 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Print a model config's YAML (available key=value overrides) and exit",
     )
     _add_override_arg(run)
-    run.set_defaults(func=_cmd_run)
+    run.set_defaults(func='run')
 
     flops = sub.add_parser("flops", help="Measure per-sample compute cost (GFLOPs)")
     flops.add_argument(
@@ -106,7 +106,7 @@ def _build_parser() -> argparse.ArgumentParser:
         "--print-config", action="store_true", help="Print the merged config and exit"
     )
     _add_override_arg(flops)
-    flops.set_defaults(func=_cmd_flops)
+    flops.set_defaults(func='flops')
 
     download = sub.add_parser("download", help="Download benchmark datasets")
     download.add_argument(
@@ -120,7 +120,7 @@ def _build_parser() -> argparse.ArgumentParser:
     download.add_argument(
         "--datasets", default=None, help="(GeoBench only) comma-separated dataset names"
     )
-    download.set_defaults(func=_cmd_download)
+    download.set_defaults(func='download')
 
     return parser
 
@@ -191,81 +191,6 @@ def _compose(args: argparse.Namespace, *, config_name: str, default_model: str |
         raise SystemExit(f"error: {err}") from err
 
 
-def _cmd_run(args: argparse.Namespace) -> None:
-    if args.list_models:
-        from torchgeo_bench.config import list_model_configs
-
-        print("\n".join(list_model_configs()))
-        return
-    if args.list_datasets:
-        from torchgeo_bench.datasets import list_datasets
-
-        print("\n".join(list_datasets()))
-        return
-    if args.model_help is not None:
-        from torchgeo_bench.config import model_config_path
-
-        try:
-            print(model_config_path(args.model_help).read_text(), end="")
-        except ValueError as err:  # allow-except: report an unknown model to the CLI user
-            raise SystemExit(f"error: {err}") from err
-        return
-    cfg = _compose(args, config_name="config", default_model="rcf")
-    if args.print_config:
-        from omegaconf import OmegaConf
-
-        print(OmegaConf.to_yaml(cfg), end="")
-        return
-    _setup_logging(verbose=bool(cfg.verbose))
-    from torchgeo_bench.main import main
-
-    main(cfg)
-
-
-def _cmd_flops(args: argparse.Namespace) -> None:
-    cfg = _compose(args, config_name="flops_config", default_model=None)
-    if args.print_config:
-        from omegaconf import OmegaConf
-
-        print(OmegaConf.to_yaml(cfg), end="")
-        return
-    _setup_logging(verbose=True)
-    from torchgeo_bench.flops_pipeline import main
-
-    main(cfg)
-
-
-def _cmd_download(args: argparse.Namespace) -> None:
-    from pathlib import Path
-
-    _setup_logging(verbose=True)
-    from torchgeo_bench.download import (
-        download_eurosat,
-        download_geobench_v1,
-        download_geobench_v2,
-        download_resisc45,
-    )
-
-    names = None
-    if args.datasets is not None:
-        names = [n.strip() for n in args.datasets.split(",") if n.strip()]
-        if not names:
-            raise SystemExit("error: --datasets must contain at least one dataset name")
-
-    output_dir = Path(args.output_dir)
-    if args.target == "geobench_v1":
-        download_geobench_v1(output_dir, datasets=names)
-    elif args.target == "geobench_v2":
-        download_geobench_v2(output_dir, datasets=names)
-    else:
-        if names is not None:
-            raise SystemExit("error: --datasets is only supported for GeoBench downloads")
-        if args.target == "eurosat":
-            download_eurosat(output_dir)
-        else:
-            download_resisc45(output_dir)
-
-
 def main(argv: list[str] | None = None) -> None:
     """Entry point for the ``torchgeo-bench`` console script."""
     parser = _build_parser()
@@ -279,7 +204,9 @@ def main(argv: list[str] | None = None) -> None:
         ):
             parser.error(f"unrecognized arguments: {' '.join(extras)}")
         args.overrides.extend(extras)
-    args.func(args)
+    from torchgeo_bench import commands
+
+    getattr(commands, args.func)(args)
 
 
 if __name__ == "__main__":

--- a/src/torchgeo_bench/cli.py
+++ b/src/torchgeo_bench/cli.py
@@ -94,7 +94,7 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Print a model config's YAML (available key=value overrides) and exit",
     )
     _add_override_arg(run)
-    run.set_defaults(func='run')
+    run.set_defaults(func="run")
 
     flops = sub.add_parser("flops", help="Measure per-sample compute cost (GFLOPs)")
     flops.add_argument(
@@ -106,7 +106,7 @@ def _build_parser() -> argparse.ArgumentParser:
         "--print-config", action="store_true", help="Print the merged config and exit"
     )
     _add_override_arg(flops)
-    flops.set_defaults(func='flops')
+    flops.set_defaults(func="flops")
 
     download = sub.add_parser("download", help="Download benchmark datasets")
     download.add_argument(
@@ -120,75 +120,9 @@ def _build_parser() -> argparse.ArgumentParser:
     download.add_argument(
         "--datasets", default=None, help="(GeoBench only) comma-separated dataset names"
     )
-    download.set_defaults(func='download')
+    download.set_defaults(func="download")
 
     return parser
-
-
-def _setup_logging(*, verbose: bool = False) -> None:
-    logging.basicConfig(
-        level=logging.INFO if verbose else logging.WARNING,
-        format="%(levelname)s: %(message)s",
-    )
-
-
-def input_overrides(args: argparse.Namespace) -> list[str]:
-    """Translate dataset input flags into config overrides."""
-    overrides = []
-    if getattr(args, "partition", None) is not None:
-        overrides.append(f"dataset.partition={args.partition}")
-    if getattr(args, "bands", None) is not None:
-        bands = args.bands if args.bands in ("rgb", "all") else f"[{args.bands}]"
-        overrides.append(f"dataset.bands={bands}")
-    if getattr(args, "batch_size", None) is not None:
-        overrides.append(f"dataset.batch_size={args.batch_size}")
-    if getattr(args, "image_size", None) is not None:
-        overrides.append(f"dataset.image_size={args.image_size}")
-    if getattr(args, "normalization", None) is not None:
-        overrides.append(f"dataset.normalization={args.normalization}")
-    return overrides
-
-
-def _flag_overrides(args: argparse.Namespace) -> list[str]:
-    overrides = []
-    if args.model is not None:
-        overrides.append(f"model={args.model}")
-    if getattr(args, "datasets", None) is not None:
-        names = args.datasets if args.datasets == "all" else f"[{args.datasets}]"
-        overrides.append(f"dataset.names={names}")
-    if args.device is not None:
-        overrides.append(f"device={args.device}")
-    if args.output is not None:
-        overrides.append(f"output={args.output}")
-    if getattr(args, "resume", False):
-        overrides.append("resume=true")
-    if getattr(args, "seed", None) is not None:
-        overrides.append(f"seed={args.seed}")
-    overrides.extend(input_overrides(args))
-    if getattr(args, "skip_linear", False):
-        overrides.append("eval.skip_linear=true")
-    if getattr(args, "bootstrap", None) is not None:
-        overrides.append(f"eval.bootstrap={args.bootstrap}")
-    if getattr(args, "verbose", False):
-        overrides.append("verbose=true")
-    return overrides
-
-
-def _compose(args: argparse.Namespace, *, config_name: str, default_model: str | None):
-    from omegaconf.errors import OmegaConfBaseException
-
-    from torchgeo_bench.config import compose_config
-
-    try:
-        return compose_config(
-            [*args.overrides, *_flag_overrides(args)],
-            config_name=config_name,
-            default_model=default_model,
-        )
-    except OmegaConfBaseException as err:  # allow-except: show a concise CLI configuration error
-        raise SystemExit(f"error: bad config override: {err}") from err
-    except ValueError as err:  # allow-except: show a concise CLI configuration error
-        raise SystemExit(f"error: {err}") from err
 
 
 def main(argv: list[str] | None = None) -> None:

--- a/src/torchgeo_bench/cli.py
+++ b/src/torchgeo_bench/cli.py
@@ -6,7 +6,6 @@ Load command dependencies lazily so ``--help`` stays fast.
 """
 
 import argparse
-import logging
 
 _RUN_EPILOG = """\
 examples:

--- a/src/torchgeo_bench/commands/__init__.py
+++ b/src/torchgeo_bench/commands/__init__.py
@@ -1,0 +1,5 @@
+"""Lazy command handlers for the command line interface."""
+
+import lazy_loader as lazy
+
+__getattr__, __dir__, __all__ = lazy.attach_stub(__name__, __file__)

--- a/src/torchgeo_bench/commands/__init__.py
+++ b/src/torchgeo_bench/commands/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) TorchGeo Contributors. All rights reserved.
+# Licensed under the MIT License.
+
 """Lazy command handlers for the command line interface."""
 
 import lazy_loader as lazy

--- a/src/torchgeo_bench/commands/__init__.pyi
+++ b/src/torchgeo_bench/commands/__init__.pyi
@@ -1,9 +1,5 @@
-# Re-exported imports are consumed by ``lazy_loader.attach_stub`` at runtime.
-# Ruff cannot see that the stub is an import table rather than executable code.
-# ruff: noqa: F401
-
-from ._download import download
-from ._flops import flops
-from ._run import run
+from ._download import download as download
+from ._flops import flops as flops
+from ._run import run as run
 
 __all__: tuple[str, ...]

--- a/src/torchgeo_bench/commands/__init__.pyi
+++ b/src/torchgeo_bench/commands/__init__.pyi
@@ -1,5 +1,8 @@
 from ._download import download as download
+from ._download_runtime import download_module as download_module
 from ._flops import flops as flops
+from ._flops_runtime import run_flops as run_flops
 from ._run import run as run
+from ._run_runtime import run_benchmark as run_benchmark
 
 __all__: tuple[str, ...]

--- a/src/torchgeo_bench/commands/__init__.pyi
+++ b/src/torchgeo_bench/commands/__init__.pyi
@@ -1,0 +1,5 @@
+from ._download import download
+from ._flops import flops
+from ._run import run
+
+__all__: tuple[str, ...]

--- a/src/torchgeo_bench/commands/__init__.pyi
+++ b/src/torchgeo_bench/commands/__init__.pyi
@@ -1,3 +1,7 @@
+# Re-exported imports are consumed by ``lazy_loader.attach_stub`` at runtime.
+# Ruff cannot see that the stub is an import table rather than executable code.
+# ruff: noqa: F401
+
 from ._download import download
 from ._flops import flops
 from ._run import run

--- a/src/torchgeo_bench/commands/_common.py
+++ b/src/torchgeo_bench/commands/_common.py
@@ -57,4 +57,4 @@ def compose(args: argparse.Namespace, *, config_name: str, default_model: str | 
             default_model=default_model,
         )
     except (OmegaConfBaseException, ValueError) as err:
-        raise SystemExit(f"error: {err}") from err
+        raise SystemExit(f"error: bad config override: {err}") from err

--- a/src/torchgeo_bench/commands/_common.py
+++ b/src/torchgeo_bench/commands/_common.py
@@ -1,0 +1,60 @@
+"""Lightweight helpers shared by command handlers."""
+
+import argparse
+import logging
+
+
+def setup_logging(*, verbose: bool = False) -> None:
+    """Configure command logging without importing benchmark modules."""
+    logging.basicConfig(
+        level=logging.INFO if verbose else logging.WARNING,
+        format="%(levelname)s: %(message)s",
+    )
+
+
+def flag_overrides(args: argparse.Namespace) -> list[str]:
+    """Translate convenience flags into config overrides."""
+    overrides: list[str] = []
+    for attr, key in [
+        ("model", "model"),
+        ("device", "device"),
+        ("output", "output"),
+        ("seed", "seed"),
+        ("partition", "dataset.partition"),
+        ("batch_size", "dataset.batch_size"),
+        ("image_size", "dataset.image_size"),
+        ("normalization", "dataset.normalization"),
+        ("bootstrap", "eval.bootstrap"),
+    ]:
+        value = getattr(args, attr, None)
+        if value is not None:
+            overrides.append(f"{key}={value}")
+    datasets = getattr(args, "datasets", None)
+    if datasets is not None:
+        overrides.append(f"dataset.names={'all' if datasets == 'all' else f'[{datasets}]'}")
+    bands = getattr(args, "bands", None)
+    if bands is not None:
+        overrides.append(f"dataset.bands={bands if bands in ('rgb', 'all') else f'[{bands}]'}")
+    if getattr(args, "resume", False):
+        overrides.append("resume=true")
+    if getattr(args, "skip_linear", False):
+        overrides.append("eval.skip_linear=true")
+    if getattr(args, "verbose", False):
+        overrides.append("verbose=true")
+    return overrides
+
+
+def compose(args: argparse.Namespace, *, config_name: str, default_model: str | None):
+    """Compose a config from positional overrides and convenience flags."""
+    from omegaconf.errors import OmegaConfBaseException
+
+    from torchgeo_bench.config import compose_config
+
+    try:
+        return compose_config(
+            [*args.overrides, *flag_overrides(args)],
+            config_name=config_name,
+            default_model=default_model,
+        )
+    except (OmegaConfBaseException, ValueError) as err:
+        raise SystemExit(f"error: {err}") from err

--- a/src/torchgeo_bench/commands/_common.py
+++ b/src/torchgeo_bench/commands/_common.py
@@ -1,7 +1,11 @@
+# Copyright (c) TorchGeo Contributors. All rights reserved.
+# Licensed under the MIT License.
+
 """Lightweight helpers shared by command handlers."""
 
 import argparse
 import logging
+from typing import Any
 
 
 def setup_logging(*, verbose: bool = False) -> None:
@@ -16,35 +20,41 @@ def flag_overrides(args: argparse.Namespace) -> list[str]:
     """Translate convenience flags into config overrides."""
     overrides: list[str] = []
     for attr, key in [
-        ("model", "model"),
-        ("device", "device"),
-        ("output", "output"),
-        ("seed", "seed"),
-        ("partition", "dataset.partition"),
-        ("batch_size", "dataset.batch_size"),
-        ("image_size", "dataset.image_size"),
-        ("normalization", "dataset.normalization"),
-        ("bootstrap", "eval.bootstrap"),
+        ('model', 'model'),
+        ('device', 'device'),
+        ('output', 'output'),
+        ('seed', 'seed'),
+        ('partition', 'dataset.partition'),
+        ('batch_size', 'dataset.batch_size'),
+        ('image_size', 'dataset.image_size'),
+        ('normalization', 'dataset.normalization'),
+        ('bootstrap', 'eval.bootstrap'),
     ]:
         value = getattr(args, attr, None)
         if value is not None:
-            overrides.append(f"{key}={value}")
-    datasets = getattr(args, "datasets", None)
+            overrides.append(f'{key}={value}')
+    datasets = getattr(args, 'datasets', None)
     if datasets is not None:
-        overrides.append(f"dataset.names={'all' if datasets == 'all' else f'[{datasets}]'}")
-    bands = getattr(args, "bands", None)
+        overrides.append(
+            f'dataset.names={"all" if datasets == "all" else f"[{datasets}]"}'
+        )
+    bands = getattr(args, 'bands', None)
     if bands is not None:
-        overrides.append(f"dataset.bands={bands if bands in ('rgb', 'all') else f'[{bands}]'}")
-    if getattr(args, "resume", False):
-        overrides.append("resume=true")
-    if getattr(args, "skip_linear", False):
-        overrides.append("eval.skip_linear=true")
-    if getattr(args, "verbose", False):
-        overrides.append("verbose=true")
+        overrides.append(
+            f'dataset.bands={bands if bands in ("rgb", "all") else f"[{bands}]"}'
+        )
+    if getattr(args, 'resume', False):
+        overrides.append('resume=true')
+    if getattr(args, 'skip_linear', False):
+        overrides.append('eval.skip_linear=true')
+    if getattr(args, 'verbose', False):
+        overrides.append('verbose=true')
     return overrides
 
 
-def compose(args: argparse.Namespace, *, config_name: str, default_model: str | None):
+def compose(
+    args: argparse.Namespace, *, config_name: str, default_model: str | None
+) -> Any:
     """Compose a config from positional overrides and convenience flags."""
     from omegaconf.errors import OmegaConfBaseException
 
@@ -57,4 +67,4 @@ def compose(args: argparse.Namespace, *, config_name: str, default_model: str | 
             default_model=default_model,
         )
     except (OmegaConfBaseException, ValueError) as err:
-        raise SystemExit(f"error: bad config override: {err}") from err
+        raise SystemExit(f'error: bad config override: {err}') from err

--- a/src/torchgeo_bench/commands/_common.py
+++ b/src/torchgeo_bench/commands/_common.py
@@ -5,7 +5,11 @@
 
 import argparse
 import logging
-from typing import Any
+
+from omegaconf import DictConfig
+from omegaconf.errors import OmegaConfBaseException
+
+from ..config import compose_config
 
 
 def setup_logging(*, verbose: bool = False) -> None:
@@ -20,51 +24,43 @@ def flag_overrides(args: argparse.Namespace) -> list[str]:
     """Translate convenience flags into config overrides."""
     overrides: list[str] = []
     for attr, key in [
-        ('model', 'model'),
-        ('device', 'device'),
-        ('output', 'output'),
-        ('seed', 'seed'),
-        ('partition', 'dataset.partition'),
-        ('batch_size', 'dataset.batch_size'),
-        ('image_size', 'dataset.image_size'),
-        ('normalization', 'dataset.normalization'),
-        ('bootstrap', 'eval.bootstrap'),
+        ("model", "model"),
+        ("device", "device"),
+        ("output", "output"),
+        ("seed", "seed"),
+        ("partition", "dataset.partition"),
+        ("batch_size", "dataset.batch_size"),
+        ("image_size", "dataset.image_size"),
+        ("normalization", "dataset.normalization"),
+        ("bootstrap", "eval.bootstrap"),
     ]:
         value = getattr(args, attr, None)
         if value is not None:
-            overrides.append(f'{key}={value}')
-    datasets = getattr(args, 'datasets', None)
+            overrides.append(f"{key}={value}")
+    datasets = getattr(args, "datasets", None)
     if datasets is not None:
-        overrides.append(
-            f'dataset.names={"all" if datasets == "all" else f"[{datasets}]"}'
-        )
-    bands = getattr(args, 'bands', None)
+        overrides.append(f"dataset.names={'all' if datasets == 'all' else f'[{datasets}]'}")
+    bands = getattr(args, "bands", None)
     if bands is not None:
-        overrides.append(
-            f'dataset.bands={bands if bands in ("rgb", "all") else f"[{bands}]"}'
-        )
-    if getattr(args, 'resume', False):
-        overrides.append('resume=true')
-    if getattr(args, 'skip_linear', False):
-        overrides.append('eval.skip_linear=true')
-    if getattr(args, 'verbose', False):
-        overrides.append('verbose=true')
+        overrides.append(f"dataset.bands={bands if bands in ('rgb', 'all') else f'[{bands}]'}")
+    if getattr(args, "resume", False):
+        overrides.append("resume=true")
+    if getattr(args, "skip_linear", False):
+        overrides.append("eval.skip_linear=true")
+    if getattr(args, "verbose", False):
+        overrides.append("verbose=true")
     return overrides
 
 
-def compose(
-    args: argparse.Namespace, *, config_name: str, default_model: str | None
-) -> Any:
+def compose(args: argparse.Namespace, *, config_name: str, default_model: str | None) -> DictConfig:
     """Compose a config from positional overrides and convenience flags."""
-    from omegaconf.errors import OmegaConfBaseException
-
-    from torchgeo_bench.config import compose_config
-
     try:
         return compose_config(
             [*args.overrides, *flag_overrides(args)],
             config_name=config_name,
             default_model=default_model,
         )
-    except (OmegaConfBaseException, ValueError) as err:
-        raise SystemExit(f'error: bad config override: {err}') from err
+    except OmegaConfBaseException as err:  # allow-except: show a concise CLI configuration error
+        raise SystemExit(f"error: bad config override: {err}") from err
+    except ValueError as err:  # allow-except: show a concise CLI configuration error
+        raise SystemExit(f"error: {err}") from err

--- a/src/torchgeo_bench/commands/_download.py
+++ b/src/torchgeo_bench/commands/_download.py
@@ -3,33 +3,33 @@
 import argparse
 from pathlib import Path
 
-from torchgeo_bench.cli import _setup_logging
+from torchgeo_bench.commands._common import setup_logging
 
 
 def download(args: argparse.Namespace) -> None:
     """Download one of the supported dataset collections."""
-    from torchgeo_bench.download import (
+    from torchgeo_bench.commands._download_runtime import (
         download_eurosat,
         download_geobench_v1,
         download_geobench_v2,
         download_resisc45,
     )
 
-    _setup_logging(verbose=True)
+    setup_logging(verbose=True)
     names = None
     if args.datasets is not None:
-        names = [name.strip() for name in args.datasets.split(',') if name.strip()]
+        names = [name.strip() for name in args.datasets.split(",") if name.strip()]
         if not names:
-            raise SystemExit('error: --datasets must contain at least one dataset name')
+            raise SystemExit("error: --datasets must contain at least one dataset name")
     output_dir = Path(args.output_dir)
-    if args.target == 'geobench_v1':
+    if args.target == "geobench_v1":
         download_geobench_v1(output_dir, datasets=names)
-    elif args.target == 'geobench_v2':
+    elif args.target == "geobench_v2":
         download_geobench_v2(output_dir, datasets=names)
     else:
         if names is not None:
-            raise SystemExit('error: --datasets is only supported for GeoBench downloads')
-        if args.target == 'eurosat':
+            raise SystemExit("error: --datasets is only supported for GeoBench downloads")
+        if args.target == "eurosat":
             download_eurosat(output_dir)
         else:
             download_resisc45(output_dir)

--- a/src/torchgeo_bench/commands/_download.py
+++ b/src/torchgeo_bench/commands/_download.py
@@ -8,12 +8,7 @@ from torchgeo_bench.commands._common import setup_logging
 
 def download(args: argparse.Namespace) -> None:
     """Download one of the supported dataset collections."""
-    from torchgeo_bench.commands._download_runtime import (
-        download_eurosat,
-        download_geobench_v1,
-        download_geobench_v2,
-        download_resisc45,
-    )
+    from torchgeo_bench.commands._download_runtime import download_module
 
     setup_logging(verbose=True)
     names = None
@@ -23,13 +18,13 @@ def download(args: argparse.Namespace) -> None:
             raise SystemExit("error: --datasets must contain at least one dataset name")
     output_dir = Path(args.output_dir)
     if args.target == "geobench_v1":
-        download_geobench_v1(output_dir, datasets=names)
+        download_module.download_geobench_v1(output_dir, datasets=names)
     elif args.target == "geobench_v2":
-        download_geobench_v2(output_dir, datasets=names)
+        download_module.download_geobench_v2(output_dir, datasets=names)
     else:
         if names is not None:
             raise SystemExit("error: --datasets is only supported for GeoBench downloads")
         if args.target == "eurosat":
-            download_eurosat(output_dir)
+            download_module.download_eurosat(output_dir)
         else:
-            download_resisc45(output_dir)
+            download_module.download_resisc45(output_dir)

--- a/src/torchgeo_bench/commands/_download.py
+++ b/src/torchgeo_bench/commands/_download.py
@@ -6,13 +6,12 @@
 import argparse
 from pathlib import Path
 
+from .. import commands
 from ._common import setup_logging
 
 
 def download(args: argparse.Namespace) -> None:
     """Download one of the supported dataset collections."""
-    from torchgeo_bench.commands._download_runtime import download_module
-
     setup_logging(verbose=True)
     names = None
     if args.datasets is not None:
@@ -21,15 +20,15 @@ def download(args: argparse.Namespace) -> None:
             raise SystemExit('error: --datasets must contain at least one dataset name')
     output_dir = Path(args.output_dir)
     if args.target == 'geobench_v1':
-        download_module.download_geobench_v1(output_dir, datasets=names)
+        commands.download_module.download_geobench_v1(output_dir, datasets=names)
     elif args.target == 'geobench_v2':
-        download_module.download_geobench_v2(output_dir, datasets=names)
+        commands.download_module.download_geobench_v2(output_dir, datasets=names)
     else:
         if names is not None:
             raise SystemExit(
                 'error: --datasets is only supported for GeoBench downloads'
             )
         if args.target == 'eurosat':
-            download_module.download_eurosat(output_dir)
+            commands.download_module.download_eurosat(output_dir)
         else:
-            download_module.download_resisc45(output_dir)
+            commands.download_module.download_resisc45(output_dir)

--- a/src/torchgeo_bench/commands/_download.py
+++ b/src/torchgeo_bench/commands/_download.py
@@ -1,0 +1,35 @@
+"""Download command handler."""
+
+import argparse
+from pathlib import Path
+
+from torchgeo_bench.cli import _setup_logging
+
+
+def download(args: argparse.Namespace) -> None:
+    """Download one of the supported dataset collections."""
+    from torchgeo_bench.download import (
+        download_eurosat,
+        download_geobench_v1,
+        download_geobench_v2,
+        download_resisc45,
+    )
+
+    _setup_logging(verbose=True)
+    names = None
+    if args.datasets is not None:
+        names = [name.strip() for name in args.datasets.split(',') if name.strip()]
+        if not names:
+            raise SystemExit('error: --datasets must contain at least one dataset name')
+    output_dir = Path(args.output_dir)
+    if args.target == 'geobench_v1':
+        download_geobench_v1(output_dir, datasets=names)
+    elif args.target == 'geobench_v2':
+        download_geobench_v2(output_dir, datasets=names)
+    else:
+        if names is not None:
+            raise SystemExit('error: --datasets is only supported for GeoBench downloads')
+        if args.target == 'eurosat':
+            download_eurosat(output_dir)
+        else:
+            download_resisc45(output_dir)

--- a/src/torchgeo_bench/commands/_download.py
+++ b/src/torchgeo_bench/commands/_download.py
@@ -1,9 +1,12 @@
+# Copyright (c) TorchGeo Contributors. All rights reserved.
+# Licensed under the MIT License.
+
 """Download command handler."""
 
 import argparse
 from pathlib import Path
 
-from torchgeo_bench.commands._common import setup_logging
+from ._common import setup_logging
 
 
 def download(args: argparse.Namespace) -> None:
@@ -13,18 +16,20 @@ def download(args: argparse.Namespace) -> None:
     setup_logging(verbose=True)
     names = None
     if args.datasets is not None:
-        names = [name.strip() for name in args.datasets.split(",") if name.strip()]
+        names = [name.strip() for name in args.datasets.split(',') if name.strip()]
         if not names:
-            raise SystemExit("error: --datasets must contain at least one dataset name")
+            raise SystemExit('error: --datasets must contain at least one dataset name')
     output_dir = Path(args.output_dir)
-    if args.target == "geobench_v1":
+    if args.target == 'geobench_v1':
         download_module.download_geobench_v1(output_dir, datasets=names)
-    elif args.target == "geobench_v2":
+    elif args.target == 'geobench_v2':
         download_module.download_geobench_v2(output_dir, datasets=names)
     else:
         if names is not None:
-            raise SystemExit("error: --datasets is only supported for GeoBench downloads")
-        if args.target == "eurosat":
+            raise SystemExit(
+                'error: --datasets is only supported for GeoBench downloads'
+            )
+        if args.target == 'eurosat':
             download_module.download_eurosat(output_dir)
         else:
             download_module.download_resisc45(output_dir)

--- a/src/torchgeo_bench/commands/_download.py
+++ b/src/torchgeo_bench/commands/_download.py
@@ -15,20 +15,18 @@ def download(args: argparse.Namespace) -> None:
     setup_logging(verbose=True)
     names = None
     if args.datasets is not None:
-        names = [name.strip() for name in args.datasets.split(',') if name.strip()]
+        names = [name.strip() for name in args.datasets.split(",") if name.strip()]
         if not names:
-            raise SystemExit('error: --datasets must contain at least one dataset name')
+            raise SystemExit("error: --datasets must contain at least one dataset name")
     output_dir = Path(args.output_dir)
-    if args.target == 'geobench_v1':
+    if args.target == "geobench_v1":
         commands.download_module.download_geobench_v1(output_dir, datasets=names)
-    elif args.target == 'geobench_v2':
+    elif args.target == "geobench_v2":
         commands.download_module.download_geobench_v2(output_dir, datasets=names)
     else:
         if names is not None:
-            raise SystemExit(
-                'error: --datasets is only supported for GeoBench downloads'
-            )
-        if args.target == 'eurosat':
+            raise SystemExit("error: --datasets is only supported for GeoBench downloads")
+        if args.target == "eurosat":
             commands.download_module.download_eurosat(output_dir)
         else:
             commands.download_module.download_resisc45(output_dir)

--- a/src/torchgeo_bench/commands/_download_runtime.py
+++ b/src/torchgeo_bench/commands/_download_runtime.py
@@ -1,0 +1,10 @@
+"""Heavy runtime for dataset downloads."""
+
+from torchgeo_bench.download import (
+    download_eurosat,
+    download_geobench_v1,
+    download_geobench_v2,
+    download_resisc45,
+)
+
+__all__ = ("download_eurosat", "download_geobench_v1", "download_geobench_v2", "download_resisc45")

--- a/src/torchgeo_bench/commands/_download_runtime.py
+++ b/src/torchgeo_bench/commands/_download_runtime.py
@@ -1,10 +1,5 @@
 """Heavy runtime for dataset downloads."""
 
-from torchgeo_bench.download import (
-    download_eurosat,
-    download_geobench_v1,
-    download_geobench_v2,
-    download_resisc45,
-)
+import importlib
 
-__all__ = ("download_eurosat", "download_geobench_v1", "download_geobench_v2", "download_resisc45")
+download_module = importlib.import_module("torchgeo_bench.download")

--- a/src/torchgeo_bench/commands/_download_runtime.py
+++ b/src/torchgeo_bench/commands/_download_runtime.py
@@ -1,5 +1,8 @@
+# Copyright (c) TorchGeo Contributors. All rights reserved.
+# Licensed under the MIT License.
+
 """Heavy runtime for dataset downloads."""
 
 import importlib
 
-download_module = importlib.import_module("torchgeo_bench.download")
+download_module = importlib.import_module('torchgeo_bench.download')

--- a/src/torchgeo_bench/commands/_download_runtime.py
+++ b/src/torchgeo_bench/commands/_download_runtime.py
@@ -5,4 +5,4 @@
 
 import importlib
 
-download_module = importlib.import_module('torchgeo_bench.download')
+download_module = importlib.import_module("torchgeo_bench.download")

--- a/src/torchgeo_bench/commands/_flops.py
+++ b/src/torchgeo_bench/commands/_flops.py
@@ -1,0 +1,19 @@
+"""Flops command handler."""
+
+import argparse
+
+from torchgeo_bench.cli import _compose, _setup_logging
+
+
+def flops(args: argparse.Namespace) -> None:
+    """Run the compute-cost pipeline."""
+    cfg = _compose(args, config_name='flops_config', default_model=None)
+    if args.print_config:
+        from omegaconf import OmegaConf
+
+        print(OmegaConf.to_yaml(cfg), end='')
+        return
+    _setup_logging(verbose=True)
+    from torchgeo_bench.flops_pipeline import main as run_flops
+
+    run_flops(cfg)

--- a/src/torchgeo_bench/commands/_flops.py
+++ b/src/torchgeo_bench/commands/_flops.py
@@ -2,18 +2,18 @@
 
 import argparse
 
-from torchgeo_bench.cli import _compose, _setup_logging
+from torchgeo_bench.commands._common import compose, setup_logging
 
 
 def flops(args: argparse.Namespace) -> None:
     """Run the compute-cost pipeline."""
-    cfg = _compose(args, config_name='flops_config', default_model=None)
+    cfg = compose(args, config_name="flops_config", default_model=None)
     if args.print_config:
         from omegaconf import OmegaConf
 
-        print(OmegaConf.to_yaml(cfg), end='')
+        print(OmegaConf.to_yaml(cfg), end="")
         return
-    _setup_logging(verbose=True)
-    from torchgeo_bench.flops_pipeline import main as run_flops
+    setup_logging(verbose=True)
+    from torchgeo_bench.commands._flops_runtime import run as run_flops
 
     run_flops(cfg)

--- a/src/torchgeo_bench/commands/_flops.py
+++ b/src/torchgeo_bench/commands/_flops.py
@@ -1,17 +1,20 @@
+# Copyright (c) TorchGeo Contributors. All rights reserved.
+# Licensed under the MIT License.
+
 """Flops command handler."""
 
 import argparse
 
-from torchgeo_bench.commands._common import compose, setup_logging
+from ._common import compose, setup_logging
 
 
 def flops(args: argparse.Namespace) -> None:
     """Run the compute-cost pipeline."""
-    cfg = compose(args, config_name="flops_config", default_model=None)
+    cfg = compose(args, config_name='flops_config', default_model=None)
     if args.print_config:
         from omegaconf import OmegaConf
 
-        print(OmegaConf.to_yaml(cfg), end="")
+        print(OmegaConf.to_yaml(cfg), end='')
         return
     setup_logging(verbose=True)
     from torchgeo_bench.commands._flops_runtime import run as run_flops

--- a/src/torchgeo_bench/commands/_flops.py
+++ b/src/torchgeo_bench/commands/_flops.py
@@ -5,6 +5,9 @@
 
 import argparse
 
+from omegaconf import OmegaConf
+
+from .. import commands
 from ._common import compose, setup_logging
 
 
@@ -12,11 +15,7 @@ def flops(args: argparse.Namespace) -> None:
     """Run the compute-cost pipeline."""
     cfg = compose(args, config_name='flops_config', default_model=None)
     if args.print_config:
-        from omegaconf import OmegaConf
-
         print(OmegaConf.to_yaml(cfg), end='')
         return
     setup_logging(verbose=True)
-    from torchgeo_bench.commands._flops_runtime import run as run_flops
-
-    run_flops(cfg)
+    commands.run_flops(cfg)

--- a/src/torchgeo_bench/commands/_flops.py
+++ b/src/torchgeo_bench/commands/_flops.py
@@ -13,9 +13,9 @@ from ._common import compose, setup_logging
 
 def flops(args: argparse.Namespace) -> None:
     """Run the compute-cost pipeline."""
-    cfg = compose(args, config_name='flops_config', default_model=None)
+    cfg = compose(args, config_name="flops_config", default_model=None)
     if args.print_config:
-        print(OmegaConf.to_yaml(cfg), end='')
+        print(OmegaConf.to_yaml(cfg), end="")
         return
     setup_logging(verbose=True)
     commands.run_flops(cfg)

--- a/src/torchgeo_bench/commands/_flops_runtime.py
+++ b/src/torchgeo_bench/commands/_flops_runtime.py
@@ -11,3 +11,6 @@ import torchgeo_bench.flops_pipeline as flops_pipeline
 def run(config: DictConfig) -> None:
     """Execute the FLOP profiling runtime."""
     flops_pipeline.main(config)
+
+
+run_flops = run

--- a/src/torchgeo_bench/commands/_flops_runtime.py
+++ b/src/torchgeo_bench/commands/_flops_runtime.py
@@ -1,8 +1,13 @@
+# Copyright (c) TorchGeo Contributors. All rights reserved.
+# Licensed under the MIT License.
+
 """Heavy runtime for the flops command."""
+
+from omegaconf import DictConfig
 
 import torchgeo_bench.flops_pipeline as flops_pipeline
 
 
-def run(config: object) -> None:
+def run(config: DictConfig) -> None:
     """Execute the FLOP profiling runtime."""
     flops_pipeline.main(config)

--- a/src/torchgeo_bench/commands/_flops_runtime.py
+++ b/src/torchgeo_bench/commands/_flops_runtime.py
@@ -1,0 +1,8 @@
+"""Heavy runtime for the flops command."""
+
+import torchgeo_bench.flops_pipeline as flops_pipeline
+
+
+def run(config: object) -> None:
+    """Execute the FLOP profiling runtime."""
+    flops_pipeline.main(config)

--- a/src/torchgeo_bench/commands/_run.py
+++ b/src/torchgeo_bench/commands/_run.py
@@ -2,7 +2,7 @@
 
 import argparse
 
-from torchgeo_bench.cli import _compose, _setup_logging
+from torchgeo_bench.commands._common import compose, setup_logging
 
 
 def run(args: argparse.Namespace) -> None:
@@ -10,28 +10,28 @@ def run(args: argparse.Namespace) -> None:
     if args.list_models:
         from torchgeo_bench.config import list_model_configs
 
-        print('\n'.join(list_model_configs()))
+        print("\n".join(list_model_configs()))
         return
     if args.list_datasets:
         from torchgeo_bench.datasets import list_datasets
 
-        print('\n'.join(list_datasets()))
+        print("\n".join(list_datasets()))
         return
     if args.model_help is not None:
         from torchgeo_bench.config import model_config_path
 
         try:
-            print(model_config_path(args.model_help).read_text(), end='')
+            print(model_config_path(args.model_help).read_text(), end="")
         except ValueError as err:
-            raise SystemExit(f'error: {err}') from err
+            raise SystemExit(f"error: {err}") from err
         return
-    cfg = _compose(args, config_name='config', default_model='rcf')
+    cfg = compose(args, config_name="config", default_model="rcf")
     if args.print_config:
         from omegaconf import OmegaConf
 
-        print(OmegaConf.to_yaml(cfg), end='')
+        print(OmegaConf.to_yaml(cfg), end="")
         return
-    _setup_logging(verbose=bool(cfg.verbose))
-    from torchgeo_bench.main import main as run_benchmark
+    setup_logging(verbose=bool(cfg.verbose))
+    from torchgeo_bench.commands._run_runtime import run as run_benchmark
 
     run_benchmark(cfg)

--- a/src/torchgeo_bench/commands/_run.py
+++ b/src/torchgeo_bench/commands/_run.py
@@ -1,0 +1,37 @@
+"""Run command handler."""
+
+import argparse
+
+from torchgeo_bench.cli import _compose, _setup_logging
+
+
+def run(args: argparse.Namespace) -> None:
+    """Run a benchmark or a lightweight run command query."""
+    if args.list_models:
+        from torchgeo_bench.config import list_model_configs
+
+        print('\n'.join(list_model_configs()))
+        return
+    if args.list_datasets:
+        from torchgeo_bench.datasets import list_datasets
+
+        print('\n'.join(list_datasets()))
+        return
+    if args.model_help is not None:
+        from torchgeo_bench.config import model_config_path
+
+        try:
+            print(model_config_path(args.model_help).read_text(), end='')
+        except ValueError as err:
+            raise SystemExit(f'error: {err}') from err
+        return
+    cfg = _compose(args, config_name='config', default_model='rcf')
+    if args.print_config:
+        from omegaconf import OmegaConf
+
+        print(OmegaConf.to_yaml(cfg), end='')
+        return
+    _setup_logging(verbose=bool(cfg.verbose))
+    from torchgeo_bench.main import main as run_benchmark
+
+    run_benchmark(cfg)

--- a/src/torchgeo_bench/commands/_run.py
+++ b/src/torchgeo_bench/commands/_run.py
@@ -5,24 +5,23 @@
 
 import argparse
 
+from omegaconf import OmegaConf
+
+from .. import commands
+from ..config import list_model_configs, model_config_path
+from ..datasets import list_datasets
 from ._common import compose, setup_logging
 
 
 def run(args: argparse.Namespace) -> None:
     """Run a benchmark or a lightweight run command query."""
     if args.list_models:
-        from torchgeo_bench.config import list_model_configs
-
         print('\n'.join(list_model_configs()))
         return
     if args.list_datasets:
-        from torchgeo_bench.datasets import list_datasets
-
         print('\n'.join(list_datasets()))
         return
     if args.model_help is not None:
-        from torchgeo_bench.config import model_config_path
-
         try:
             print(model_config_path(args.model_help).read_text(), end='')
         except ValueError as err:
@@ -30,11 +29,7 @@ def run(args: argparse.Namespace) -> None:
         return
     cfg = compose(args, config_name='config', default_model='rcf')
     if args.print_config:
-        from omegaconf import OmegaConf
-
         print(OmegaConf.to_yaml(cfg), end='')
         return
     setup_logging(verbose=bool(cfg.verbose))
-    from torchgeo_bench.commands._run_runtime import run as run_benchmark
-
-    run_benchmark(cfg)
+    commands.run_benchmark(cfg)

--- a/src/torchgeo_bench/commands/_run.py
+++ b/src/torchgeo_bench/commands/_run.py
@@ -1,8 +1,11 @@
+# Copyright (c) TorchGeo Contributors. All rights reserved.
+# Licensed under the MIT License.
+
 """Run command handler."""
 
 import argparse
 
-from torchgeo_bench.commands._common import compose, setup_logging
+from ._common import compose, setup_logging
 
 
 def run(args: argparse.Namespace) -> None:
@@ -10,26 +13,26 @@ def run(args: argparse.Namespace) -> None:
     if args.list_models:
         from torchgeo_bench.config import list_model_configs
 
-        print("\n".join(list_model_configs()))
+        print('\n'.join(list_model_configs()))
         return
     if args.list_datasets:
         from torchgeo_bench.datasets import list_datasets
 
-        print("\n".join(list_datasets()))
+        print('\n'.join(list_datasets()))
         return
     if args.model_help is not None:
         from torchgeo_bench.config import model_config_path
 
         try:
-            print(model_config_path(args.model_help).read_text(), end="")
+            print(model_config_path(args.model_help).read_text(), end='')
         except ValueError as err:
-            raise SystemExit(f"error: {err}") from err
+            raise SystemExit(f'error: {err}') from err
         return
-    cfg = compose(args, config_name="config", default_model="rcf")
+    cfg = compose(args, config_name='config', default_model='rcf')
     if args.print_config:
         from omegaconf import OmegaConf
 
-        print(OmegaConf.to_yaml(cfg), end="")
+        print(OmegaConf.to_yaml(cfg), end='')
         return
     setup_logging(verbose=bool(cfg.verbose))
     from torchgeo_bench.commands._run_runtime import run as run_benchmark

--- a/src/torchgeo_bench/commands/_run.py
+++ b/src/torchgeo_bench/commands/_run.py
@@ -16,20 +16,20 @@ from ._common import compose, setup_logging
 def run(args: argparse.Namespace) -> None:
     """Run a benchmark or a lightweight run command query."""
     if args.list_models:
-        print('\n'.join(list_model_configs()))
+        print("\n".join(list_model_configs()))
         return
     if args.list_datasets:
-        print('\n'.join(list_datasets()))
+        print("\n".join(list_datasets()))
         return
     if args.model_help is not None:
         try:
-            print(model_config_path(args.model_help).read_text(), end='')
-        except ValueError as err:
-            raise SystemExit(f'error: {err}') from err
+            print(model_config_path(args.model_help).read_text(), end="")
+        except ValueError as err:  # allow-except: report an unknown model to the CLI user
+            raise SystemExit(f"error: {err}") from err
         return
-    cfg = compose(args, config_name='config', default_model='rcf')
+    cfg = compose(args, config_name="config", default_model="rcf")
     if args.print_config:
-        print(OmegaConf.to_yaml(cfg), end='')
+        print(OmegaConf.to_yaml(cfg), end="")
         return
     setup_logging(verbose=bool(cfg.verbose))
     commands.run_benchmark(cfg)

--- a/src/torchgeo_bench/commands/_run_runtime.py
+++ b/src/torchgeo_bench/commands/_run_runtime.py
@@ -1,0 +1,8 @@
+"""Heavy runtime for the run command."""
+
+import torchgeo_bench.main as benchmark_main
+
+
+def run(config: object) -> None:
+    """Execute the benchmark runtime."""
+    benchmark_main.main(config)

--- a/src/torchgeo_bench/commands/_run_runtime.py
+++ b/src/torchgeo_bench/commands/_run_runtime.py
@@ -1,8 +1,13 @@
+# Copyright (c) TorchGeo Contributors. All rights reserved.
+# Licensed under the MIT License.
+
 """Heavy runtime for the run command."""
+
+from omegaconf import DictConfig
 
 import torchgeo_bench.main as benchmark_main
 
 
-def run(config: object) -> None:
+def run(config: DictConfig) -> None:
     """Execute the benchmark runtime."""
     benchmark_main.main(config)

--- a/src/torchgeo_bench/commands/_run_runtime.py
+++ b/src/torchgeo_bench/commands/_run_runtime.py
@@ -11,3 +11,6 @@ import torchgeo_bench.main as benchmark_main
 def run(config: DictConfig) -> None:
     """Execute the benchmark runtime."""
     benchmark_main.main(config)
+
+
+run_benchmark = run

--- a/tests/test_lazy_commands.py
+++ b/tests/test_lazy_commands.py
@@ -1,0 +1,31 @@
+"""Regression tests for lightweight CLI command discovery."""
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    'arguments',
+    [
+        ['--help'],
+        ['run', '--help'],
+        ['run', '--list-models'],
+        ['run', '--list-datasets'],
+    ],
+)
+def test_cli_queries_do_not_import_heavy_modules(arguments: list[str]) -> None:
+    code = """
+import sys
+from torchgeo_bench.cli import main
+try:
+    main(ARGUMENTS)
+except SystemExit as error:
+    assert error.code in (0, None)
+assert not {'torch', 'torchgeo', 'timm', 'pandas'} & sys.modules.keys()
+""".replace('ARGUMENTS', repr(arguments))
+    environment = {**os.environ, 'PYTHONPATH': 'src'}
+    result = subprocess.run([sys.executable, '-c', code], env=environment, check=False)
+    assert result.returncode == 0

--- a/tests/test_lazy_commands.py
+++ b/tests/test_lazy_commands.py
@@ -25,7 +25,7 @@ import sys
 from torchgeo_bench.cli import main
 try:
     main(ARGUMENTS)
-except SystemExit as error:
+except SystemExit as error:  # allow-except: help exits successfully without running a benchmark
     assert error.code in (0, None)
 assert not {'torch', 'torchgeo', 'timm', 'pandas'} & sys.modules.keys()
 """.replace("ARGUMENTS", repr(arguments))

--- a/tests/test_lazy_commands.py
+++ b/tests/test_lazy_commands.py
@@ -8,12 +8,15 @@ import pytest
 
 
 @pytest.mark.parametrize(
-    'arguments',
+    "arguments",
     [
-        ['--help'],
-        ['run', '--help'],
-        ['run', '--list-models'],
-        ['run', '--list-datasets'],
+        ["--help"],
+        ["run", "--help"],
+        ["run", "--list-models"],
+        ["run", "--list-datasets"],
+        ["run", "--model-help", "rcf"],
+        ["run", "--print-config"],
+        ["flops", "--model", "rcf", "--print-config"],
     ],
 )
 def test_cli_queries_do_not_import_heavy_modules(arguments: list[str]) -> None:
@@ -25,7 +28,28 @@ try:
 except SystemExit as error:
     assert error.code in (0, None)
 assert not {'torch', 'torchgeo', 'timm', 'pandas'} & sys.modules.keys()
-""".replace('ARGUMENTS', repr(arguments))
-    environment = {**os.environ, 'PYTHONPATH': 'src'}
-    result = subprocess.run([sys.executable, '-c', code], env=environment, check=False)
+""".replace("ARGUMENTS", repr(arguments))
+    environment = {**os.environ, "PYTHONPATH": "src"}
+    result = subprocess.run([sys.executable, "-c", code], env=environment, check=False)
     assert result.returncode == 0
+
+
+def test_command_logging_uses_standard_logging() -> None:
+    code = """
+import logging
+import sys
+from torchgeo_bench.commands._common import setup_logging
+setup_logging(verbose=True)
+logging.getLogger("test").warning("sample message")
+assert "rich" not in sys.modules
+assert "torch" not in sys.modules
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        env={**os.environ, "PYTHONPATH": "src"},
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert result.stdout == ""
+    assert result.stderr == "WARNING: sample message\n"

--- a/uv.lock
+++ b/uv.lock
@@ -574,7 +574,7 @@ name = "cuda-bindings"
 version = "13.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "cuda-pathfinder" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/52/c8/b2589d68acf7e3d63e2be330b84bc25712e97ed799affbca7edd7eae25d6/cuda_bindings-13.2.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e865447abfb83d6a98ad5130ed3c70b1fc295ae3eeee39fd07b4ddb0671b6788", size = 5722404, upload-time = "2026-03-11T00:12:44.041Z" },
@@ -605,34 +605,34 @@ wheels = [
 
 [package.optional-dependencies]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufft" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufile" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cupti" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-curand" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusolver" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparse" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvtx" },
 ]
 
 [[package]]
@@ -714,8 +714,8 @@ name = "faiss-cpu"
 version = "1.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", marker = "platform_machine != 'x86_64' or sys_platform != 'linux'" },
-    { name = "packaging", marker = "platform_machine != 'x86_64' or sys_platform != 'linux'" },
+    { name = "numpy" },
+    { name = "packaging" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/8b/5d2cd7c9fd60bc4d1ca6e9f5e8b0eb57254a7b301daaa12d5853fdf48afe/faiss_cpu-1.14.2-cp310-abi3-macosx_14_0_arm64.whl", hash = "sha256:a20011b8a97318e6d5e29143a773277ca71f1c33140024aeec91f05ad56cdd04", size = 4621203, upload-time = "2026-05-22T19:58:27.415Z" },
@@ -732,10 +732,10 @@ name = "faiss-cuda"
 version = "1.14.3.post0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-runtime-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "packaging", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "numpy" },
+    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cuda-runtime-cu12" },
+    { name = "packaging" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cf/d9/ff4dc8cbae70a4f5c76a953ac1e189044940be7a22808b1c3ff865a2a1e6/faiss_cuda-1.14.3.post0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d83e92f341a1f79b5ab52fa0982eab3fe80428fcb1a69591ab2021b95f568f33", size = 106476496, upload-time = "2026-07-11T21:36:01.577Z" },
@@ -758,10 +758,10 @@ wheels = [
 
 [package.optional-dependencies]
 cpu = [
-    { name = "faiss-cpu", marker = "platform_machine != 'x86_64' or sys_platform != 'linux'" },
+    { name = "faiss-cpu" },
 ]
 cuda = [
-    { name = "faiss-cuda", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "faiss-cuda" },
 ]
 
 [[package]]
@@ -1894,7 +1894,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cuda-nvrtc" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -1906,7 +1906,7 @@ name = "nvidia-cublas-cu12"
 version = "12.9.2.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/c0/0a517bfe63ccd3b92eb254d264e28fca3c7cab75d07daea315250fb1bf73/nvidia_cublas_cu12-12.9.2.10-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:e4f53a8ca8c5d6e8c492d0d0a3d565ecb59a751b19cfdaa4f6da0ab2104c1702", size = 581240110, upload-time = "2026-04-08T18:52:31.532Z" },
@@ -1960,7 +1960,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cublas" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -1972,7 +1972,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -2002,9 +2002,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "nvidia-cusparse", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cublas" },
+    { name = "nvidia-cusparse" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -2016,7 +2016,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -3969,6 +3969,7 @@ dependencies = [
     { name = "geobenchv2" },
     { name = "h5py" },
     { name = "huggingface-hub" },
+    { name = "lazy-loader" },
     { name = "numpy" },
     { name = "omegaconf" },
     { name = "pandas" },
@@ -4047,6 +4048,7 @@ requires-dist = [
     { name = "geobenchv2", specifier = ">=0.9" },
     { name = "h5py", specifier = ">=3.8" },
     { name = "huggingface-hub", specifier = ">=0.20" },
+    { name = "lazy-loader", specifier = ">=0.4" },
     { name = "linkify-it-py", marker = "extra == 'docs'", specifier = ">=2" },
     { name = "mdformat", marker = "extra == 'dev'", specifier = ">=0.7.22" },
     { name = "myst-parser", marker = "extra == 'docs'", specifier = ">=2" },
@@ -4093,10 +4095,10 @@ name = "torchid"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", marker = "python_full_version >= '3.13'" },
-    { name = "scipy", marker = "python_full_version >= '3.13'" },
-    { name = "torch", marker = "python_full_version >= '3.13'" },
-    { name = "torchmetrics", marker = "python_full_version >= '3.13'" },
+    { name = "numpy" },
+    { name = "scipy" },
+    { name = "torch" },
+    { name = "torchmetrics" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/27/a7/cb4d5a769984d9aded6a779d6ecdd7e172224ae675af3180a0cf196034cb/torchid-0.4.0.tar.gz", hash = "sha256:2a48c8a7f4b11bc495f3e63f22c9b09ef30e2c5f93555e3f78986722ac07c463", size = 27304, upload-time = "2026-05-20T10:38:03.921Z" }
 wheels = [


### PR DESCRIPTION
Move command handlers and numerical runtimes behind typed lazy exports so help and catalog commands avoid loading model dependencies. Preserve the cleaned argument parsing, standard logging, and existing flags and key=value overrides.

Rebased onto main including #324, with the design/refactor documents removed. Refs #309.