### PR TITLE
fix(cli): report invalid collection selections

### DIFF
--- a/src/torchgeo_bench/commands/_download.py
+++ b/src/torchgeo_bench/commands/_download.py
@@ -33,7 +33,10 @@ def download(args: argparse.Namespace) -> None:
         if not names:
             raise SystemExit("error: --datasets must contain at least one dataset name")
     output_dir = Path(args.output_dir)
-    if target == "geobench_v1":
-        commands.download_module.download_geobench_v1(output_dir, datasets=names)
-    else:
-        commands.download_module.download_geobench_v2(output_dir, datasets=names)
+    try:
+        if target == "geobench_v1":
+            commands.download_module.download_geobench_v1(output_dir, datasets=names)
+        else:
+            commands.download_module.download_geobench_v2(output_dir, datasets=names)
+    except ValueError as err:  # allow-except: report invalid collection selections
+        raise SystemExit(f"error: {err}") from err

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,9 +1,13 @@
 """Unit tests for CLI entrypoints."""
 
+from collections.abc import Callable
+from pathlib import Path
+
 import pytest
 from omegaconf import OmegaConf
 
 from torchgeo_bench.cli import main as cli_main
+from torchgeo_bench.image_cli import main as image_cli_main
 
 
 def test_run_composes_and_calls_main(monkeypatch) -> None:
@@ -134,6 +138,43 @@ def test_run_model_help_rejects_path_traversal() -> None:
 def test_download_invalid_target() -> None:
     with pytest.raises(SystemExit, match="Unknown dataset"):
         cli_main(["download", "bogus"])
+
+
+@pytest.mark.parametrize("entrypoint", [cli_main, image_cli_main])
+@pytest.mark.parametrize(
+    ("collection", "selection"),
+    [
+        ("geobench_v1", "unknown"),
+        ("geobench_v1", "m-eurosat,unknown"),
+        ("geobench_v2", "unknown"),
+        ("geobench_v2", "caffe,unknown"),
+    ],
+)
+def test_download_invalid_collection_selection(
+    tmp_path: Path,
+    entrypoint: Callable[[list[str]], None],
+    collection: str,
+    selection: str,
+) -> None:
+    output = tmp_path / "downloads"
+    with pytest.raises(SystemExit, match="error: Unknown GeoBench"):
+        entrypoint(["download", collection, "--datasets", selection, "--output-dir", str(output)])
+    assert not output.exists()
+
+
+@pytest.mark.parametrize("entrypoint", [cli_main, image_cli_main])
+@pytest.mark.parametrize("collection", ["geobench_v1", "geobench_v2"])
+def test_download_collection_propagates_unexpected_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    entrypoint: Callable[[list[str]], None],
+    collection: str,
+) -> None:
+    def fail(*args: object, **kwargs: object) -> None:
+        raise RuntimeError("unexpected download failure")
+
+    monkeypatch.setattr(f"torchgeo_bench.download.download_{collection}", fail)
+    with pytest.raises(RuntimeError, match="unexpected download failure"):
+        entrypoint(["download", collection])
 
 
 def test_download_geobench_v1(monkeypatch) -> None:


### PR DESCRIPTION
Invalid dataset names passed through GeoBench collection downloads now produce the same concise error as named downloads, instead of a traceback. Unexpected download failures still propagate, and invalid selections are rejected before creating output directories.