### PR TITLE
refactor(config): introduce typed preset resolution

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main, 'docs/refactor-**']
 
 jobs:
   test:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main, 'docs/refactor-**']
   workflow_dispatch:
 
 # Run one deployment at a time without interrupting the one in progress.

--- a/src/torchgeo_bench/config.py
+++ b/src/torchgeo_bench/config.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from omegaconf import DictConfig
+    import omegaconf.dictconfig
 
 CONF_DIR = Path(str(files("torchgeo_bench") / "conf"))
 
@@ -54,7 +54,7 @@ def compose_config(
     *,
     config_name: str = "config",
     default_model: str | None = "rcf",
-) -> "DictConfig":
+) -> "omegaconf.dictconfig.DictConfig":
     """Build the run config from base YAML, model YAML, and ``key=value`` overrides.
 
     Args:
@@ -107,7 +107,7 @@ def compose_config(
     return cfg
 
 
-def instantiate(config: "DictConfig | dict", **kwargs: Any) -> Any:
+def instantiate(config: "omegaconf.dictconfig.DictConfig | dict", **kwargs: Any) -> Any:
     """Instantiate the class named by ``config._target_`` with the remaining keys.
 
     Extra ``kwargs`` override config keys.

--- a/src/torchgeo_bench/config.py
+++ b/src/torchgeo_bench/config.py
@@ -13,9 +13,10 @@ import importlib
 from collections.abc import Sequence
 from importlib.resources import files
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from omegaconf import DictConfig, OmegaConf, open_dict
+if TYPE_CHECKING:
+    from omegaconf import DictConfig
 
 CONF_DIR = Path(str(files("torchgeo_bench") / "conf"))
 
@@ -53,7 +54,7 @@ def compose_config(
     *,
     config_name: str = "config",
     default_model: str | None = "rcf",
-) -> DictConfig:
+) -> "DictConfig":
     """Build the run config from base YAML, model YAML, and ``key=value`` overrides.
 
     Args:
@@ -66,6 +67,8 @@ def compose_config(
     Returns:
         The merged config, which rejects unknown keys.
     """
+    from omegaconf import DictConfig, OmegaConf, open_dict
+
     cfg = OmegaConf.load(CONF_DIR / f"{config_name}.yaml")
     assert isinstance(cfg, DictConfig)
 
@@ -104,13 +107,15 @@ def compose_config(
     return cfg
 
 
-def instantiate(config: DictConfig | dict, **kwargs: Any) -> Any:
+def instantiate(config: "DictConfig | dict", **kwargs: Any) -> Any:
     """Instantiate the class named by ``config._target_`` with the remaining keys.
 
     Extra ``kwargs`` override config keys.
 
     Pass nested values as plain containers; do not instantiate nested ``_target_`` values.
     """
+    from omegaconf import DictConfig, OmegaConf
+
     if isinstance(config, DictConfig):
         config = OmegaConf.to_container(config, resolve=True)  # type: ignore[assignment]
     conf = dict(config)

--- a/src/torchgeo_bench/config_schema.py
+++ b/src/torchgeo_bench/config_schema.py
@@ -75,9 +75,21 @@ class StrictModel(BaseModel):
 
 
 class ModelConfig(StrictModel):
-    """Selected model preset."""
+    """Selected preset or importable custom model with constructor-only options."""
 
     name: StrictStr = Field(min_length=1)
+    target: StrictStr | None = None
+    kwargs: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("target")
+    @classmethod
+    def validate_target(cls, value: str | None) -> str | None:
+        """Require an importable dotted symbol, without importing optional models."""
+        if value is not None and (
+            "." not in value or any(not part.isidentifier() for part in value.split("."))
+        ):
+            raise ValueError("target must be a dotted Python symbol")
+        return value
 
     @field_validator("name")
     @classmethod
@@ -96,7 +108,7 @@ class InputConfig(StrictModel):
     time_steps: StrictInt | None = Field(default=None, gt=0)
     image_size: StrictInt | None = Field(default=224, gt=0)
     interpolation: Literal["area", "bilinear", "bicubic", "nearest"] = "bilinear"
-    normalization: Literal["dataset", "model", "minmax", "none"] = "dataset"
+    normalization: Literal["dataset", "model", "minmax", "minmax_zscore", "none"] = "dataset"
 
     @field_validator("partition")
     @classmethod
@@ -225,14 +237,62 @@ class OutputConfig(StrictModel):
     directory: StrictStr = "results/models"
     file: StrictStr | None = None
     resume: StrictBool = False
+    profile_directory: StrictStr = "results/profiles"
+    intrinsic_dim_directory: StrictStr = "results/intrinsic_dim"
 
-    @field_validator("directory", "file")
+    @field_validator("directory", "file", "profile_directory", "intrinsic_dim_directory")
     @classmethod
     def validate_paths(cls, value: str | None) -> str | None:
         """Reject blank paths while allowing a null optional file."""
         if value is not None and not value.strip():
             raise ValueError("paths must not be blank")
         return value
+
+
+class CPUThroughputConfig(StrictModel):
+    """Optional bounded CPU measurement alongside an image run."""
+
+    enabled: StrictBool = False
+    batch_size: StrictInt = Field(default=8, gt=0)
+    n_warmup: StrictInt = Field(default=1, ge=0)
+    n_measure: StrictInt = Field(default=5, gt=0)
+    time_budget_s: StrictFloat = Field(default=300.0, gt=0)
+
+
+class FeatureProfileConfig(StrictModel):
+    """Additive encoder measurements stored separately from probe scores."""
+
+    enabled: StrictBool = False
+    n_warmup: StrictInt = Field(default=3, ge=0)
+    n_measure: StrictInt = Field(default=20, gt=0)
+    cpu_throughput: CPUThroughputConfig = Field(default_factory=CPUThroughputConfig)
+
+
+def _default_splits() -> list[Literal["train", "val", "test"]]:
+    """Return the default intrinsic-dimension split selection."""
+    return ["train"]
+
+
+class IntrinsicDimensionConfig(StrictModel):
+    """Additive feature-dimension and spectrum measurements."""
+
+    enabled: StrictBool = False
+    estimators: list[StrictStr] = Field(default_factory=lambda: ["TwoNN", "MLE", "lPCA"])
+    splits: list[Literal["train", "val", "test"]] = Field(default_factory=_default_splits)
+    max_samples: StrictInt | None = Field(default=10000, gt=0)
+    device: StrictStr | None = None
+
+    @field_validator("estimators", "splits")
+    @classmethod
+    def validate_selections(cls, values: list[str]) -> list[str]:
+        """Require distinct non-empty selections."""
+        if (
+            not values
+            or any(not value.strip() for value in values)
+            or len(set(values)) != len(values)
+        ):
+            raise ValueError("selections must contain distinct non-empty names")
+        return values
 
 
 class RunConfig(StrictModel):
@@ -246,6 +306,8 @@ class RunConfig(StrictModel):
     segmentation: SegmentationConfig = Field(default_factory=SegmentationConfig)
     runtime: RuntimeConfig = Field(default_factory=RuntimeConfig)
     output: OutputConfig = Field(default_factory=OutputConfig)
+    profile: FeatureProfileConfig = Field(default_factory=FeatureProfileConfig)
+    intrinsic_dim: IntrinsicDimensionConfig = Field(default_factory=IntrinsicDimensionConfig)
 
     @field_validator("schema_version", mode="before")
     @classmethod

--- a/src/torchgeo_bench/presets.py
+++ b/src/torchgeo_bench/presets.py
@@ -1,0 +1,168 @@
+"""Typed model presets and effective image settings.
+
+Only explicitly supplied values override preset defaults. Runtime objects such as
+BandSpecs and empirical-RCF datasets are passed directly to construction, never YAML.
+"""
+
+import importlib
+from copy import deepcopy
+from typing import Any, Literal
+
+from pydantic import Field
+
+from .config_schema import (
+    ClassificationConfig,
+    InputConfig,
+    ModelConfig,
+    RunConfig,
+    SegmentationConfig,
+    StrictModel,
+    load_yaml,
+)
+
+NORMALIZATIONS = {
+    "dataset": "bandspec_zscore",
+    "model": "model_native",
+    "minmax": "minmax",
+    "minmax_zscore": "minmax_zscore",
+    "none": "identity",
+}
+
+
+def merge_settings(base: dict[str, Any], overrides: dict[str, Any]) -> dict[str, Any]:
+    """Merge explicit YAML settings; nulls and empty lists replace prior values."""
+    result = deepcopy(base)
+    for key, value in overrides.items():
+        if isinstance(value, dict) and isinstance(result.get(key), dict):
+            result[key] = merge_settings(result[key], value)
+        else:
+            result[key] = deepcopy(value)
+    return result
+
+
+class PresetDefaults(StrictModel):
+    """Constructor and benchmark defaults for one dataset or model."""
+
+    kwargs: dict[str, Any] = Field(default_factory=dict)
+    input: InputConfig = Field(default_factory=InputConfig)
+    classification: ClassificationConfig = Field(default_factory=ClassificationConfig)
+    segmentation: SegmentationConfig = Field(default_factory=SegmentationConfig)
+
+
+class ModelPreset(PresetDefaults):
+    """A named constructor, separate from preprocessing and evaluation metadata."""
+
+    name: str
+    target: str
+    track: Literal["image", "coord"] = "image"
+    seed_from_run: bool = False
+    dataset_overrides: dict[str, PresetDefaults] = Field(default_factory=dict)
+
+    def for_dataset(self, dataset: str) -> "ModelPreset":
+        """Apply a dataset override without mutating the shared preset."""
+        values = self.model_dump(exclude_unset=True)
+        values.pop("dataset_overrides", None)
+        override = self.dataset_overrides.get(dataset)
+        if override is not None:
+            values = merge_settings(values, override.model_dump(exclude_unset=True))
+        return ModelPreset.model_validate(values)
+
+
+def _legacy_defaults(raw: dict[str, Any]) -> dict[str, Any]:
+    """Translate the finite packaged preset vocabulary during staged migration."""
+    values = deepcopy(raw)
+    result: dict[str, Any] = {}
+    inputs = {key: values.pop(key) for key in ("image_size", "interpolation") if key in values}
+    if inputs:
+        result["input"] = inputs
+    evaluation = values.pop("eval", {})
+    if "c_range" in evaluation:
+        start, stop, count = evaluation.pop("c_range")
+        result["classification"] = {
+            "linear": {"c_log10_start": start, "c_log10_stop": stop, "c_count": count}
+        }
+    if "segmentation" in evaluation:
+        segmentation = evaluation.pop("segmentation")
+        for old, new in (
+            ("head_type", "head"),
+            ("lr", "learning_rate"),
+            ("lr_scheduler", "scheduler"),
+        ):
+            if old in segmentation:
+                segmentation[new] = segmentation.pop(old)
+        result["segmentation"] = segmentation
+    if evaluation:
+        raise ValueError(f"Unsupported preset evaluation defaults: {sorted(evaluation)}")
+    result["kwargs"] = values
+    return result
+
+
+def load_model_preset(selection: ModelConfig, *, seed: int = 0) -> ModelPreset:
+    """Load a packaged preset or a custom constructor without importing weights."""
+    if selection.target is not None:
+        return ModelPreset(name=selection.name, target=selection.target, kwargs=selection.kwargs)
+    from .config import model_config_path
+
+    raw = load_yaml(model_config_path(selection.name))
+    if "target" in raw:
+        preset = ModelPreset.model_validate(raw)
+    else:
+        name, target = raw.pop("name"), raw.pop("_target_")
+        overrides = raw.pop("dataset_overrides", {})
+        seed_from_run = raw.get("seed") == "${seed}"
+        if seed_from_run:
+            raw.pop("seed")
+        preset = ModelPreset(
+            name=name,
+            target=target,
+            track="coord" if ".coordbench." in target else "image",
+            seed_from_run=seed_from_run,
+            dataset_overrides={
+                key: PresetDefaults.model_validate(_legacy_defaults(value))
+                for key, value in overrides.items()
+            },
+            **_legacy_defaults(raw),
+        )
+    kwargs = dict(preset.kwargs)
+    if preset.seed_from_run:
+        kwargs["seed"] = seed
+    kwargs.update(selection.kwargs)
+    return preset.model_copy(update={"kwargs": kwargs})
+
+
+def resolve_run_config(config: RunConfig, dataset: str) -> tuple[RunConfig, ModelPreset]:
+    """Resolve preset and dataset defaults beneath explicitly supplied settings."""
+    preset = load_model_preset(config.model, seed=config.runtime.seed).for_dataset(dataset)
+    if preset.track != "image":
+        raise ValueError(f"{config.model.name!r} is a coordinate encoder; use 'coord'")
+    defaults = {
+        key: getattr(preset, key).model_dump(exclude_unset=True)
+        for key in ("input", "classification", "segmentation")
+    }
+    effective = RunConfig.model_validate(merge_settings(defaults, config.model_dump_yaml()))
+    return effective, preset
+
+
+def build_model(preset: ModelPreset, **runtime_options: Any) -> Any:
+    """Construct one model; nested target-like kwargs remain ordinary mappings."""
+    options = {**preset.kwargs, **runtime_options}
+    if preset.target in {
+        "torchgeo_bench.models.TimmPatchBenchModel",
+        "torchgeo_bench.models.RCFBench",
+    }:
+        from .models.build import (
+            RCFModelConfig,
+            TimmModelConfig,
+            build_rcf_model,
+            build_timm_model,
+        )
+
+        bands = options.pop("bands")
+        normalization = options.pop("normalization", "bandspec_zscore")
+        if preset.target.endswith("TimmPatchBenchModel"):
+            options.pop("seed", None)
+            return build_timm_model(TimmModelConfig(**options), bands, normalization=normalization)
+        return build_rcf_model(RCFModelConfig(**options), bands, normalization=normalization)
+    module, _, symbol = preset.target.rpartition(".")
+    constructor = getattr(importlib.import_module(module), symbol)
+    return constructor(**options)

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -25,7 +25,9 @@ def test_packaged_preset_is_typed_without_loading_weights(name: str) -> None:
 
 def test_rcf_seed_is_explicit_and_overridable() -> None:
     assert load_model_preset(ModelConfig(name="rcf"), seed=17).kwargs["seed"] == 17
-    assert load_model_preset(ModelConfig(name="rcf", kwargs={"seed": 9}), seed=17).kwargs["seed"] == 9
+    assert (
+        load_model_preset(ModelConfig(name="rcf", kwargs={"seed": 9}), seed=17).kwargs["seed"] == 9
+    )
 
 
 def test_preset_layers_do_not_override_an_explicit_empty_selection() -> None:

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -1,0 +1,70 @@
+"""Offline coverage of the typed preset boundary."""
+
+import subprocess
+import sys
+
+import pytest
+
+from torchgeo_bench.config import list_model_configs
+from torchgeo_bench.config_schema import ModelConfig, RunConfig
+from torchgeo_bench.presets import ModelPreset, load_model_preset, resolve_run_config
+
+
+@pytest.mark.parametrize("name", list_model_configs())
+def test_packaged_preset_is_typed_without_loading_weights(name: str) -> None:
+    preset = load_model_preset(ModelConfig(name=name), seed=17)
+    assert isinstance(preset, ModelPreset)
+    assert preset.target
+    assert "name" not in preset.kwargs
+    assert "eval" not in preset.kwargs
+    assert "dataset_overrides" not in preset.kwargs
+    assert "image_size" not in preset.kwargs
+    assert "interpolation" not in preset.kwargs
+    assert "${" not in str(preset.model_dump())
+
+
+def test_rcf_seed_is_explicit_and_overridable() -> None:
+    assert load_model_preset(ModelConfig(name="rcf"), seed=17).kwargs["seed"] == 17
+    assert load_model_preset(ModelConfig(name="rcf", kwargs={"seed": 9}), seed=17).kwargs["seed"] == 9
+
+
+def test_preset_layers_do_not_override_an_explicit_empty_selection() -> None:
+    omitted = RunConfig(model=ModelConfig(name="timm/resnet50"), datasets=["caffe"])
+    explicit = RunConfig.model_validate(
+        {
+            **omitted.model_dump_yaml(),
+            "segmentation": {"layers": [], "cache_features": False},
+            "input": {"image_size": None},
+        }
+    )
+    effective, _ = resolve_run_config(omitted, "caffe")
+    assert effective.segmentation.layers == ["layer4", "layer3", "layer2", "layer1"]
+    effective, _ = resolve_run_config(explicit, "caffe")
+    assert effective.segmentation.layers == []
+    assert not effective.segmentation.cache_features
+    assert effective.input.image_size is None
+    assert explicit.model_dump_yaml()["input"] == {"image_size": None}
+
+
+def test_custom_model_keeps_constructor_options_separate() -> None:
+    selection = ModelConfig(
+        name="custom",
+        target="custom_model.Model",
+        kwargs={"options": {"_target_": "ordinary.mapping"}},
+    )
+    preset = load_model_preset(selection)
+    assert preset.kwargs == {"options": {"_target_": "ordinary.mapping"}}
+    assert preset.target == "custom_model.Model"
+
+
+def test_configuration_import_and_resolution_do_not_import_omegaconf() -> None:
+    code = """
+import sys
+from torchgeo_bench.config import list_model_configs
+from torchgeo_bench.config_schema import ModelConfig
+from torchgeo_bench.presets import load_model_preset
+for name in list_model_configs():
+    load_model_preset(ModelConfig(name=name))
+assert not set(('omegaconf', 'torch', 'torchgeo', 'numpy', 'pandas')) & sys.modules.keys()
+"""
+    subprocess.run([sys.executable, "-c", code], check=True)

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1,0 +1,32 @@
+"""Workflow coverage for independently reviewable stacked pull requests."""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+WORKFLOWS = Path(__file__).resolve().parents[1] / ".github" / "workflows"
+
+
+@pytest.mark.parametrize("name", ["ci", "docs"])
+def test_checks_cover_every_pull_request_base(name: str) -> None:
+    # BaseLoader keeps GitHub's "on" key instead of treating it as a YAML 1.1 boolean.
+    config = yaml.load((WORKFLOWS / f"{name}.yaml").read_text(), Loader=yaml.BaseLoader)
+    events = config["on"]
+    assert "pull_request" in events
+    selection = events["pull_request"] or {}
+    assert "branches" not in selection
+    assert "branches-ignore" not in selection
+    assert events["push"]["branches"] == ["main"]
+
+
+def test_pull_requests_cannot_deploy_documentation() -> None:
+    config = yaml.load((WORKFLOWS / "docs.yaml").read_text(), Loader=yaml.BaseLoader)
+    not_pull_request = "github.event_name != 'pull_request'"
+    assert config["jobs"]["deploy"]["if"] == not_pull_request
+    upload = next(
+        step
+        for step in config["jobs"]["build"]["steps"]
+        if step.get("name") == "Upload Pages artifact"
+    )
+    assert upload["if"] == not_pull_request


### PR DESCRIPTION
Introduce a Pydantic preset boundary separating constructor options from input and evaluation defaults, with explicit seed passing and omission-aware dataset overrides. Extend image settings with custom targets and optional profile/intrinsic-dimension outputs. Existing runtime callers remain supported while dependent migrations move to the typed boundary.