### PR TITLE
fix(datasets): derive CLI catalog from registry

### DIFF
--- a/src/torchgeo_bench/datasets/__init__.py
+++ b/src/torchgeo_bench/datasets/__init__.py
@@ -6,6 +6,7 @@ Public API
 ----------
 .. autofunction:: get_datasets
 .. autofunction:: get_bench_dataset_class
+.. autofunction:: get_dataset_task
 .. autofunction:: list_datasets
 .. autoclass:: BandSpec
 .. autoclass:: BenchDataset
@@ -16,6 +17,7 @@ from importlib import import_module
 from .base import BandSpec, BenchDataset
 from .loading import (
     get_bench_dataset_class,
+    get_dataset_task,
     get_datasets,
     list_datasets,
 )
@@ -47,6 +49,7 @@ __all__ = [
     "SpaceNet7",
     "TreeSatAI",
     "get_bench_dataset_class",
+    "get_dataset_task",
     "get_datasets",
     "list_datasets",
 ]

--- a/src/torchgeo_bench/datasets/loading.py
+++ b/src/torchgeo_bench/datasets/loading.py
@@ -6,7 +6,7 @@ Wrapper modules and torch load only when needed; listing datasets does not impor
 import logging
 import warnings
 from importlib import import_module
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from .base import BenchDataset
 
@@ -19,35 +19,35 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-# Store (submodule, class name) as strings so listing datasets needs no wrapper imports.
-_REGISTRY_SPEC: dict[str, tuple[str, str]] = {
+# Store (submodule, class name, task) so catalogs need no wrapper imports.
+_REGISTRY_SPEC: dict[str, tuple[str, str, Literal["classification", "segmentation"]]] = {
     # V1 classification
-    "m-eurosat": ("m_eurosat", "MEurosat"),
-    "m-forestnet": ("m_forestnet", "MForestnet"),
-    "m-so2sat": ("m_so2sat", "MSo2Sat"),
-    "m-pv4ger": ("m_pv4ger", "MPv4ger"),
-    "m-brick-kiln": ("m_brick_kiln", "MBrickKiln"),
-    "m-bigearthnet": ("m_bigearthnet", "MBigEarthNet"),
+    "m-eurosat": ("m_eurosat", "MEurosat", "classification"),
+    "m-forestnet": ("m_forestnet", "MForestnet", "classification"),
+    "m-so2sat": ("m_so2sat", "MSo2Sat", "classification"),
+    "m-pv4ger": ("m_pv4ger", "MPv4ger", "classification"),
+    "m-brick-kiln": ("m_brick_kiln", "MBrickKiln", "classification"),
+    "m-bigearthnet": ("m_bigearthnet", "MBigEarthNet", "classification"),
     # V2 classification
-    "benv2": ("benv2", "BENV2"),
-    "treesatai": ("treesatai", "TreeSatAI"),
-    "so2sat": ("so2sat", "So2Sat"),
-    "forestnet": ("forestnet", "Forestnet"),
+    "benv2": ("benv2", "BENV2", "classification"),
+    "treesatai": ("treesatai", "TreeSatAI", "classification"),
+    "so2sat": ("so2sat", "So2Sat", "classification"),
+    "forestnet": ("forestnet", "Forestnet", "classification"),
     # V2 segmentation
-    "caffe": ("caffe", "CaFFe"),
-    "burn_scars": ("burn_scars", "BurnScars"),
-    "cloudsen12": ("cloudsen12", "CloudSEN12"),
-    "dynamic_earthnet": ("dynamic_earthnet", "DynamicEarthNet"),
-    "flair2": ("flair2", "FLAIR2"),
-    "fotw": ("fotw", "FieldsOfTheWorld"),
-    "kuro_siwo": ("kuro_siwo", "KuroSiwo"),
-    "pastis": ("pastis", "PASTIS"),
-    "spacenet2": ("spacenet2", "SpaceNet2"),
-    "spacenet7": ("spacenet7", "SpaceNet7"),
+    "caffe": ("caffe", "CaFFe", "segmentation"),
+    "burn_scars": ("burn_scars", "BurnScars", "segmentation"),
+    "cloudsen12": ("cloudsen12", "CloudSEN12", "segmentation"),
+    "dynamic_earthnet": ("dynamic_earthnet", "DynamicEarthNet", "segmentation"),
+    "flair2": ("flair2", "FLAIR2", "segmentation"),
+    "fotw": ("fotw", "FieldsOfTheWorld", "segmentation"),
+    "kuro_siwo": ("kuro_siwo", "KuroSiwo", "segmentation"),
+    "pastis": ("pastis", "PASTIS", "segmentation"),
+    "spacenet2": ("spacenet2", "SpaceNet2", "segmentation"),
+    "spacenet7": ("spacenet7", "SpaceNet7", "segmentation"),
     # torchgeo datasets
-    "eurosat": ("eurosat", "EuroSAT"),
-    "eurosat-spatial": ("eurosat", "EuroSATSpatial"),
-    "resisc45": ("resisc45", "RESISC45"),
+    "eurosat": ("eurosat", "EuroSAT", "classification"),
+    "eurosat-spatial": ("eurosat", "EuroSATSpatial", "classification"),
+    "resisc45": ("resisc45", "RESISC45", "classification"),
 }
 
 
@@ -66,7 +66,7 @@ def get_bench_dataset_class(name: str) -> type[BenchDataset]:
     if name not in _REGISTRY_SPEC:
         available = ", ".join(sorted(_REGISTRY_SPEC))
         raise KeyError(f"Unknown dataset '{name}'. Available: {available}")
-    module_name, class_name = _REGISTRY_SPEC[name]
+    module_name, class_name, _ = _REGISTRY_SPEC[name]
     cls: type[BenchDataset] = getattr(import_module(f".{module_name}", __package__), class_name)
     if cls.name != name:
         raise RuntimeError(
@@ -79,6 +79,15 @@ def get_bench_dataset_class(name: str) -> type[BenchDataset]:
 def list_datasets() -> list[str]:
     """Return sorted names of all registered benchmark datasets."""
     return sorted(_REGISTRY_SPEC)
+
+
+def get_dataset_task(name: str) -> Literal["classification", "segmentation"]:
+    """Return a registered dataset's task without importing its wrapper.
+
+    Raises:
+        KeyError: If *name* is not in the registry.
+    """
+    return _REGISTRY_SPEC[name][2]
 
 
 def download_command(name: str) -> str:
@@ -264,6 +273,7 @@ def get_datasets(  # noqa: PLR0913 - public dataset loading options.
 
 __all__ = [
     "get_bench_dataset_class",
+    "get_dataset_task",
     "get_datasets",
     "list_datasets",
 ]

--- a/src/torchgeo_bench/image_cli.py
+++ b/src/torchgeo_bench/image_cli.py
@@ -10,46 +10,7 @@ from collections.abc import Callable, Sequence
 
 from . import commands
 from .cli import add_profile_arguments
-
-_DATASETS = (
-    "m-eurosat",
-    "m-forestnet",
-    "m-so2sat",
-    "m-pv4ger",
-    "m-brick-kiln",
-    "m-bigearthnet",
-    "benv2",
-    "treesatai",
-    "so2sat",
-    "forestnet",
-    "caffe",
-    "burn_scars",
-    "cloudsen12",
-    "dynamic_earthnet",
-    "flair2",
-    "fotw",
-    "kuro_siwo",
-    "pastis",
-    "spacenet2",
-    "spacenet7",
-    "eurosat",
-    "eurosat-spatial",
-    "resisc45",
-)
-_SEGMENTATION_DATASETS = frozenset(
-    {
-        "caffe",
-        "burn_scars",
-        "cloudsen12",
-        "dynamic_earthnet",
-        "flair2",
-        "fotw",
-        "kuro_siwo",
-        "pastis",
-        "spacenet2",
-        "spacenet7",
-    }
-)
+from .datasets import get_dataset_task, list_datasets
 
 
 def _model_names() -> list[str]:
@@ -68,7 +29,7 @@ def _model_detail(name: str) -> str:
 
 def _dataset_detail(name: str) -> str:
     """Return lightweight metadata for a dataset catalog detail request."""
-    task = "segmentation" if name in _SEGMENTATION_DATASETS else "classification"
+    task = get_dataset_task(name)
     return f"name: {name}\ntask: {task}\n"
 
 
@@ -131,7 +92,7 @@ def _image_size(value: str) -> int | None:
 
 def _run(args: argparse.Namespace) -> None:
     """Validate and execute one image benchmark."""
-    commands._image.run(args, _model_names(), _DATASETS)
+    commands._image.run(args, _model_names(), tuple(list_datasets()))
 
 
 def _show_catalog(
@@ -158,7 +119,7 @@ def main(argv: list[str] | None = None) -> None:
     elif args.command == "models":
         _show_catalog(args.name, _model_names(), _model_detail, "model")
     elif args.command == "datasets":
-        _show_catalog(args.name, _DATASETS, _dataset_detail, "dataset")
+        _show_catalog(args.name, list_datasets(), _dataset_detail, "dataset")
     elif args.command == "download":
         commands.download(args)
     elif args.command == "profile":

--- a/tests/test_dataset_catalog.py
+++ b/tests/test_dataset_catalog.py
@@ -1,0 +1,164 @@
+"""Regression tests for the shared, lightweight dataset catalog."""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import TYPE_CHECKING, ClassVar, Literal
+
+import pytest
+import yaml
+
+from torchgeo_bench.datasets import (
+    BandSpec,
+    BenchDataset,
+    get_bench_dataset_class,
+    get_dataset_task,
+    list_datasets,
+    loading,
+)
+from torchgeo_bench.image_cli import main
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from torch.utils.data import Dataset
+
+
+@pytest.fixture(params=["classification", "segmentation"])
+def registered_dataset(
+    request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch
+) -> type[BenchDataset]:
+    class TinyDataset(BenchDataset):
+        name = "catalog-test"
+        task: Literal["classification", "segmentation"] = request.param
+        num_classes = 2
+        bands: ClassVar[list[BandSpec]] = [BandSpec("aerial", "gray", "gray", 0, 1, 0, 1)]
+        rgb_bands: ClassVar[list[str]] = ["gray"]
+        split_sizes: ClassVar[dict[str, int]] = {"train": 1, "val": 1, "test": 1}
+
+        @classmethod
+        def data_root(cls) -> Path:
+            return Path("data/catalog-test")
+
+        def get_dataset(
+            self,
+            split: str,
+            *,
+            partition: str = "default",
+            bands: tuple[str, ...] | None = None,
+            transform: "Callable | None" = None,
+        ) -> "Dataset":
+            raise AssertionError("Catalogs and dry runs must not load samples")
+
+    module = ModuleType("torchgeo_bench.datasets._catalog_test")
+    module.TinyDataset = TinyDataset
+    monkeypatch.setitem(sys.modules, module.__name__, module)
+    monkeypatch.setitem(
+        loading._REGISTRY_SPEC,
+        TinyDataset.name,
+        ("_catalog_test", "TinyDataset", TinyDataset.task),
+    )
+    return TinyDataset
+
+
+def test_registered_dataset_appears_in_catalog(
+    registered_dataset: type[BenchDataset], capsys: pytest.CaptureFixture[str]
+) -> None:
+    main(["datasets"])
+    names = capsys.readouterr().out.splitlines()
+    assert registered_dataset.name in names
+    assert names == list_datasets()
+
+    main(["datasets", registered_dataset.name])
+    assert yaml.safe_load(capsys.readouterr().out) == {
+        "name": registered_dataset.name,
+        "task": registered_dataset.task,
+    }
+    assert get_bench_dataset_class(registered_dataset.name) is registered_dataset
+
+
+@pytest.mark.parametrize("source", ["flags", "yaml"])
+def test_dry_run_accepts_registered_dataset(
+    registered_dataset: type[BenchDataset],
+    source: str,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    if source == "flags":
+        arguments = ["--model", "rcf", "--dataset", registered_dataset.name, "--device", "cpu"]
+    else:
+        config = tmp_path / "run.yaml"
+        config.write_text(
+            yaml.safe_dump(
+                {
+                    "model": {"name": "rcf"},
+                    "datasets": [registered_dataset.name],
+                    "runtime": {"device": "cpu"},
+                }
+            ),
+            encoding="utf-8",
+        )
+        arguments = ["--config", str(config)]
+
+    main(["run", *arguments, "--dry-run"])
+    assert yaml.safe_load(capsys.readouterr().out)["datasets"] == [registered_dataset.name]
+
+
+@pytest.mark.parametrize("name", list_datasets())
+def test_catalog_task_matches_registered_wrapper(
+    name: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    main(["datasets", name])
+    assert yaml.safe_load(capsys.readouterr().out) == {
+        "name": name,
+        "task": get_bench_dataset_class(name).task,
+    }
+
+
+def test_unknown_dataset_task_raises() -> None:
+    with pytest.raises(KeyError, match="unregistered-dataset"):
+        get_dataset_task("unregistered-dataset")
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        ["--help"],
+        ["run", "--help"],
+        ["datasets"],
+        ["datasets", "m-eurosat"],
+        ["datasets", "burn_scars"],
+        ["datasets", "catalog-test"],
+        ["models"],
+        ["models", "rcf"],
+        ["run", "--model", "rcf", "--dataset", "m-eurosat", "--device", "cpu", "--dry-run"],
+        ["run", "--model", "rcf", "--dataset", "catalog-test", "--device", "cpu", "--dry-run"],
+    ],
+)
+def test_catalog_queries_do_not_import_wrappers_or_ml(arguments: list[str]) -> None:
+    code = """
+import sys
+from torchgeo_bench.image_cli import main
+from torchgeo_bench.datasets.loading import _REGISTRY_SPEC
+_REGISTRY_SPEC['catalog-test'] = ('_unimportable', 'TinyDataset', 'segmentation')
+try:
+    main(sys.argv[1:])
+except SystemExit as error:  # allow-except: argparse help exits successfully
+    assert error.code == 0
+assert not {'torch', 'torchgeo', 'timm', 'numpy', 'pandas', 'geobench_v2'} & sys.modules.keys()
+assert not any(name.startswith('torchgeo_bench.models') for name in sys.modules)
+assert not any(
+    f'torchgeo_bench.datasets.{spec[0]}' in sys.modules
+    for spec in _REGISTRY_SPEC.values()
+)
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", code, *arguments],
+        env={**os.environ, "PYTHONPATH": str(Path(__file__).resolve().parents[1] / "src")},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
Dataset registrations now drive CLI listing, details, and run validation, including task metadata, without importing dataset or model wrappers. This removes the duplicate CLI catalog that rejected newly registered datasets.