### PR TITLE
fix(models): repair copied model template

### DIFF
--- a/src/torchgeo_bench/models/contrib_template.py
+++ b/src/torchgeo_bench/models/contrib_template.py
@@ -12,8 +12,7 @@ import torch
 import torch.nn as nn
 
 from torchgeo_bench.datasets.base import BandSpec
-
-from .interface import BenchModel
+from torchgeo_bench.models.interface import BenchModel
 
 logger = logging.getLogger(__name__)
 
@@ -27,9 +26,12 @@ class NewModel(BenchModel):
 
     Args:
         bands: Ordered list of :class:`BandSpec` from the dataset wrapper.
-            Do **not** include ``bands`` in the Hydra YAML — the runner
+            Do **not** include ``bands`` in the model YAML - the runner
             injects it at construction time.
         pretrained: Load pretrained weights (default: ``True``).
+        normalization: Input strategy forwarded to ``BenchModel``. Defaults
+            to ``"bandspec_zscore"``. Use ``"identity"`` if your backbone
+            normalizes raw sensor values internally.
     """
 
     def __init__(
@@ -37,12 +39,12 @@ class NewModel(BenchModel):
         bands: list[BandSpec],
         *,
         pretrained: bool = True,
+        normalization: str = "bandspec_zscore",
         # TODO: add any extra kwargs your backbone needs and mirror them in
         #       src/torchgeo_bench/conf/model/<name>.yaml
-        **_kwargs: object,
+        **kwargs: object,
     ) -> None:
-        super().__init__(bands=bands, normalization="bandspec_zscore")
-        # Use identity normalization if the backbone handles raw inputs internally.
+        super().__init__(bands=bands, normalization=normalization, **kwargs)
         self.backbone = nn.Identity()  # TODO: replace with your backbone
         logger.info(
             "NewModel initialized with %d input channels (pretrained=%s)",
@@ -51,17 +53,12 @@ class NewModel(BenchModel):
         )
 
     @torch.no_grad()
-    def _forward_patch_features(
-        self,
-        images: torch.Tensor,
-        _bboxes: torch.Tensor | None = None,  # optional; BenchModel passes images only
-    ) -> torch.Tensor:
+    def _forward_patch_features(self, images: torch.Tensor) -> torch.Tensor:
         """Return embeddings ``(B, K)`` from already-normalized inputs.
 
         ``images`` has shape ``(B, C, H, W)`` and has already been passed
         through ``normalize_inputs`` by the sealed ``forward_patch_features``.
-        If you chose ``normalization="identity"`` above, ``images`` is the
-        raw sensor tensor.
+        With ``normalization="identity"``, ``images`` is the raw sensor tensor.
 
         Args:
             images: Normalized input tensor of shape ``(B, C, H, W)``.
@@ -70,6 +67,6 @@ class NewModel(BenchModel):
             Embedding tensor of shape ``(B, K)``.
         """
         x = self.backbone(images)
-        if x.ndim == 4:  # (B, K, H, W) — pool spatial dims
+        if x.ndim == 4:
             x = x.flatten(start_dim=2).mean(dim=-1)
-        return x  # (B, K)
+        return x

--- a/tests/test_contrib_template.py
+++ b/tests/test_contrib_template.py
@@ -1,0 +1,111 @@
+"""Regressions for the standalone copied-model workflow."""
+
+import runpy
+import shutil
+from pathlib import Path
+
+import pytest
+import torch
+from torch import nn
+
+from torchgeo_bench.datasets.base import BandSpec
+from torchgeo_bench.models._normalization import UnsupportedNormalizationError
+from torchgeo_bench.models.interface import BenchModel
+
+
+@pytest.fixture
+def copied_model(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> type[BenchModel]:
+    template = Path(__file__).resolve().parents[1] / "src/torchgeo_bench/models/contrib_template.py"
+    shutil.copyfile(template, tmp_path / "new_model.py")
+    monkeypatch.chdir(tmp_path)
+    model_class = runpy.run_path("new_model.py")["NewModel"]
+    assert issubclass(model_class, BenchModel)
+    return model_class
+
+
+@pytest.fixture(params=[1, 3, 19])
+def bands(request: pytest.FixtureRequest) -> list[BandSpec]:
+    return [
+        BandSpec(
+            sensor=("s2", "sar", "dem")[i % 3],
+            name=f"band_{i}",
+            source_name=f"B{i}",
+            mean=10.0 * (i + 1),
+            std=2.0 * (i + 1),
+            min=1.0 * (i + 1),
+            max=101.0 * (i + 1),
+        )
+        for i in range(request.param)
+    ]
+
+
+@pytest.fixture
+def images(bands: list[BandSpec]) -> torch.Tensor:
+    mean = torch.tensor([band.mean for band in bands]).view(1, -1, 1, 1)
+    std = torch.tensor([band.std for band in bands]).view(1, -1, 1, 1)
+    return mean + std * torch.arange(24, dtype=torch.float32).view(2, 1, 3, 4)
+
+
+def test_copied_template_default_forward(
+    copied_model: type[BenchModel], bands: list[BandSpec], images: torch.Tensor
+) -> None:
+    model = copied_model(bands=bands, pretrained=False, name="new_model").eval()
+    mean = torch.tensor([band.mean for band in bands]).view(1, -1, 1, 1)
+    std = torch.tensor([band.std for band in bands]).view(1, -1, 1, 1)
+    normalized = (images - mean) / std
+    expected = normalized.mean(dim=(-2, -1))
+
+    assert model.num_channels == len(bands)
+    assert model.bands == bands
+    assert isinstance(model.backbone, nn.Identity)
+    assert model.normalization == "bandspec_zscore"
+    assert expected.shape == (2, len(bands))
+    torch.testing.assert_close(model._forward_patch_features(normalized), expected)
+    torch.testing.assert_close(model.forward_patch_features(images), expected)
+    torch.testing.assert_close(model(images), expected)
+
+
+@pytest.mark.parametrize(
+    "normalization", ["identity", "minmax", "bandspec_zscore", "minmax_zscore"]
+)
+def test_copied_template_requested_normalization(
+    copied_model: type[BenchModel],
+    bands: list[BandSpec],
+    images: torch.Tensor,
+    normalization: str,
+) -> None:
+    model = copied_model(bands=bands, normalization=normalization, pretrained=False).eval()
+    raw = images.clone()
+    if normalization == "identity":
+        expected = images
+    elif normalization == "minmax":
+        lo = torch.tensor([band.min for band in bands]).view(1, -1, 1, 1)
+        span = torch.tensor([band.max - band.min for band in bands]).view(1, -1, 1, 1)
+        expected = (images - lo) / span
+    else:
+        mean = torch.tensor([band.mean for band in bands]).view(1, -1, 1, 1)
+        std = torch.tensor([band.std for band in bands]).view(1, -1, 1, 1)
+        expected = (images - mean) / std
+
+    received: list[torch.Tensor] = []
+
+    def capture_inputs(_module: nn.Module, inputs: tuple[torch.Tensor, ...]) -> None:
+        received.append(inputs[0])
+
+    assert isinstance(model.backbone, nn.Identity)
+    with model.backbone.register_forward_pre_hook(capture_inputs):
+        features = model(images)
+
+    assert model.normalization == normalization
+    assert len(received) == 1
+    torch.testing.assert_close(received[0], expected)
+    torch.testing.assert_close(features, expected.mean(dim=(-2, -1)))
+    torch.testing.assert_close(images, raw)
+
+
+def test_copied_template_rejects_invalid_normalization(copied_model: type[BenchModel]) -> None:
+    bands = [BandSpec(sensor="s2", name="red", source_name="B04", mean=10, std=2, min=0, max=100)]
+    with pytest.raises(ValueError, match="not a valid NormalizationStrategy"):
+        copied_model(bands=bands, normalization="invalid")
+    with pytest.raises(UnsupportedNormalizationError, match="expected_input_unit"):
+        copied_model(bands=bands, normalization="model_native")


### PR DESCRIPTION
A template copied to `new_model.py` failed to import outside the package and silently ignored requested normalization. Use an absolute `BenchModel` import and forward the selected strategy, retaining the Identity placeholder and normalized `_forward_patch_features` hook. Dedicated regressions cover standalone copies, variable band counts, and normalization.