### PR TITLE
fix(cli): report image configuration input errors

### DIFF
--- a/src/torchgeo_bench/commands/_image.py
+++ b/src/torchgeo_bench/commands/_image.py
@@ -4,6 +4,7 @@
 """Implementation of the image benchmark command."""
 
 import argparse
+import sys
 from typing import Any
 
 import yaml
@@ -61,12 +62,16 @@ def _apply_overrides(base: dict[str, Any], overrides: dict[str, Any]) -> dict[st
     result = dict(base)
     for key, value in overrides.items():
         if key in {"model", "input", "classification", "runtime", "output"}:
-            section = dict(result.get(key, {}))
+            original = result.get(key, {})
+            if not isinstance(original, dict):
+                raise ValueError(f"{key} must be a YAML mapping")
+            section = dict(original)
             for nested_key, nested_value in value.items():
-                if isinstance(nested_value, dict) and isinstance(section.get(nested_key), dict):
-                    merged = dict(section[nested_key])
-                    merged.update(nested_value)
-                    section[nested_key] = merged
+                if isinstance(nested_value, dict):
+                    original_nested = section.get(nested_key, {})
+                    if not isinstance(original_nested, dict):
+                        raise ValueError(f"{key}.{nested_key} must be a YAML mapping")  # noqa: TRY004 - preserve the CLI configuration-error contract
+                    section[nested_key] = {**original_nested, **nested_value}
                 else:
                     section[nested_key] = nested_value
             result[key] = section
@@ -101,7 +106,17 @@ def _load_run(
 
 def run(args: argparse.Namespace, model_names: list[str], datasets: tuple[str, ...]) -> None:
     """Validate and execute one image benchmark."""
-    config = _load_run(args, model_names, datasets)
+    try:
+        config = _load_run(args, model_names, datasets)
+    except (
+        OSError,
+        ValueError,
+        yaml.YAMLError,
+    ) as error:  # allow-except: report config input failures before entering the benchmark runtime
+        path = getattr(args, "config", None)
+        source = f"{path}: " if path is not None else ""
+        print(f"error: {source}{error}", file=sys.stderr)
+        raise SystemExit(2) from error
     if getattr(args, "dry_run", False):
         print(yaml.safe_dump(config.model_dump_yaml(), sort_keys=False), end="")
         return

--- a/src/torchgeo_bench/image_cli.py
+++ b/src/torchgeo_bench/image_cli.py
@@ -150,11 +150,7 @@ def main(argv: list[str] | None = None) -> None:
     """Run the image benchmark CLI."""
     args = _parser().parse_args(sys.argv[1:] if argv is None else argv)
     if args.command == "run":
-        try:
-            _run(args)
-        except ValueError as error:  # allow-except: report configuration errors to the CLI user
-            print(f"error: {error}", file=sys.stderr)
-            raise SystemExit(2) from error
+        _run(args)
     elif args.command == "models":
         _show_catalog(args.name, _model_names(), _model_detail, "model")
     elif args.command == "datasets":

--- a/tests/test_image_cli.py
+++ b/tests/test_image_cli.py
@@ -4,6 +4,7 @@
 """Tests for the discoverable image CLI."""
 
 import argparse
+import os
 import runpy
 import subprocess
 import sys
@@ -272,13 +273,170 @@ def test_unknown_config_field_fails_before_execution(tmp_path: Path) -> None:
         main(["run", "--config", str(path), "--dry-run"])
 
 
-def test_runtime_failure_propagates_from_image_cli(monkeypatch: MonkeyPatch) -> None:
+@pytest.mark.parametrize(
+    "error_type",
+    [FileNotFoundError, PermissionError, ValueError, yaml.YAMLError, RuntimeError, TypeError],
+)
+def test_runtime_failure_propagates_from_image_cli(
+    monkeypatch: MonkeyPatch, error_type: type[Exception]
+) -> None:
     def fail(_: object) -> None:
-        raise FileNotFoundError("dataset missing")
+        raise error_type("benchmark failed")
 
     monkeypatch.setattr("torchgeo_bench.commands._image_runtime.run", fail)
-    with pytest.raises(FileNotFoundError, match="dataset missing"):
-        main(["run", "--model", "rcf", "--dataset", "m-eurosat"])
+    with pytest.raises(error_type, match="benchmark failed"):
+        main(["run", "--model", "rcf", "--dataset", "m-eurosat", "--device", "cpu"])
+
+
+@pytest.mark.parametrize(
+    ("contents", "diagnostic"),
+    [
+        (None, "No such file"),
+        ("model: [\n", "while parsing"),
+        ("model: {name: rcf}\nmodel: {name: other}\n", "duplicate key"),
+        ("[a, b]: value\n", "unhashable key"),
+        ("model: !unknown rcf\n", "could not determine a constructor"),
+        ("null\n", "top level"),
+        ("runtime: null\n", "runtime"),
+        ("runtime: []\n", "runtime"),
+        ("runtime: {workers: -1}\n", "runtime.workers"),
+    ],
+)
+def test_config_errors_exit_without_tracebacks(
+    contents: str | None, diagnostic: str, tmp_path: Path
+) -> None:
+    path = tmp_path / "invalid.yaml"
+    if contents is not None:
+        path.write_text(contents, encoding="utf-8")
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "torchgeo_bench.image_cli",
+            "run",
+            "--config",
+            str(path),
+            "--model",
+            "rcf",
+            "--dataset",
+            "m-eurosat",
+            "--device",
+            "cpu",
+            "--dry-run",
+        ],
+        cwd=tmp_path,
+        env={
+            **os.environ,
+            "PYTHONPATH": str(Path(__file__).resolve().parents[1] / "src"),
+            "CUDA_VISIBLE_DEVICES": "",
+            "HF_HUB_OFFLINE": "1",
+        },
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 2
+    assert result.stdout == ""
+    assert "error:" in result.stderr
+    assert str(path) in result.stderr
+    assert diagnostic in result.stderr
+    assert "Traceback" not in result.stderr
+
+
+def test_config_directory_is_reported(tmp_path: Path, capsys: CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as error:
+        main(["run", "--config", str(tmp_path), "--dry-run"])
+    assert error.value.code == 2
+    message = capsys.readouterr().err
+    assert str(tmp_path) in message
+    assert "directory" in message
+
+
+def test_unreadable_config_is_reported(
+    tmp_path: Path, monkeypatch: MonkeyPatch, capsys: CaptureFixture[str]
+) -> None:
+    path = tmp_path / "unreadable.yaml"
+
+    def deny_read(_: Path, **kwargs: object) -> None:
+        raise PermissionError(13, "Permission denied", str(path))
+
+    monkeypatch.setattr(Path, "open", deny_read)
+    with pytest.raises(SystemExit) as error:
+        main(["run", "--config", str(path), "--dry-run"])
+    assert error.value.code == 2
+    message = capsys.readouterr().err
+    assert str(path) in message
+    assert "Permission denied" in message
+
+
+def test_invalid_config_encoding_is_reported(tmp_path: Path, capsys: CaptureFixture[str]) -> None:
+    path = tmp_path / "invalid-encoding.yaml"
+    path.write_bytes(b"\xff")
+    with pytest.raises(SystemExit) as error:
+        main(["run", "--config", str(path), "--dry-run"])
+    assert error.value.code == 2
+    message = capsys.readouterr().err
+    assert str(path) in message
+    assert "utf-8" in message
+
+
+@pytest.mark.parametrize(
+    ("section", "flags"),
+    [
+        ("model", ["--model", "rcf"]),
+        ("runtime", ["--seed", "3"]),
+        ("input", ["--image-size", "32"]),
+        ("classification", ["--knn-k", "3"]),
+        ("output", ["--no-resume"]),
+        ("classification.linear", ["--no-refit-train-val"]),
+        ("classification.calibration", ["--no-temp-scale"]),
+    ],
+)
+@pytest.mark.parametrize("value", [None, [], [["seed", 8]], 3])
+def test_invalid_sections_are_not_coerced_or_replaced_by_overrides(
+    section: str, flags: list[str], value: object, tmp_path: Path, capsys: CaptureFixture[str]
+) -> None:
+    config = {"model": {"name": "rcf"}, "datasets": ["m-eurosat"]}
+    if "." in section:
+        parent, child = section.split(".")
+        config[parent] = {child: value}
+    else:
+        config[section] = value
+    path = tmp_path / "invalid-section.yaml"
+    path.write_text(yaml.safe_dump(config), encoding="utf-8")
+    with pytest.raises(SystemExit) as error:
+        main(["run", "--config", str(path), *flags, "--dry-run"])
+    assert error.value.code == 2
+    message = capsys.readouterr().err
+    assert str(path) in message
+    assert section in message
+    assert "mapping" in message
+
+
+def test_flags_complete_partial_config(tmp_path: Path, capsys: CaptureFixture[str]) -> None:
+    path = tmp_path / "partial.yaml"
+    path.write_text("runtime: {seed: 8}\n", encoding="utf-8")
+    main(
+        [
+            "run",
+            "--config",
+            str(path),
+            "--model",
+            "rcf",
+            "--dataset",
+            "m-eurosat",
+            "--device",
+            "cpu",
+            "--seed",
+            "3",
+            "--dry-run",
+        ]
+    )
+    config = yaml.safe_load(capsys.readouterr().out)
+    assert config["runtime"] == {"device": "cpu", "seed": 3}
+    assert config["model"]["name"] == "rcf"
+    assert config["datasets"] == ["m-eurosat"]
 
 
 def test_nested_linear_override_preserves_sibling_values(


### PR DESCRIPTION
Report expected configuration file, YAML, and override errors on stderr with exit status 2 and path/field diagnostics. Reject non-mapping sections before merging flags, and limit recovery to configuration loading so benchmark runtime failures still propagate.