### PR TITLE
fix(cli): align package module with image entrypoint

### DIFF
--- a/src/torchgeo_bench/__main__.py
+++ b/src/torchgeo_bench/__main__.py
@@ -1,6 +1,6 @@
 """Module entry point: ``python -m torchgeo_bench`` is the same as ``torchgeo-bench``."""
 
-from .cli import main
+from .image_cli import main
 
 if __name__ == "__main__":
     main()  # pragma: no cover

--- a/tests/test_cli_entrypoints.py
+++ b/tests/test_cli_entrypoints.py
@@ -1,0 +1,75 @@
+"""Subprocess coverage of the canonical image CLI entry points."""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+def run_entrypoint(
+    module: str, arguments: list[str], cwd: Path
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", module, *arguments],
+        cwd=cwd,
+        env={
+            **os.environ,
+            "PYTHONPATH": str(Path(__file__).resolve().parents[1] / "src"),
+            "CUDA_VISIBLE_DEVICES": "",
+            "HF_HUB_OFFLINE": "1",
+        },
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+
+@pytest.mark.parametrize(
+    ("arguments", "status", "expected"),
+    [
+        (["--help"], 0, "Run image benchmarks"),
+        (["run", "--help"], 0, "--config"),
+        (["models", "rcf"], 0, "_target_:"),
+        (["datasets", "m-eurosat"], 0, "task: classification"),
+        ([], 2, "required: command"),
+        (["run", "--unknown-option"], 2, "unrecognized arguments: --unknown-option"),
+    ],
+)
+def test_package_module_matches_image_cli(
+    arguments: list[str], status: int, expected: str, tmp_path: Path
+) -> None:
+    package = run_entrypoint("torchgeo_bench", arguments, tmp_path)
+    canonical = run_entrypoint("torchgeo_bench.image_cli", arguments, tmp_path)
+    assert package.returncode == canonical.returncode == status
+    assert package.stdout == canonical.stdout
+    assert package.stderr == canonical.stderr
+    assert expected in package.stdout + package.stderr
+
+
+@pytest.mark.parametrize("use_config", [False, True])
+def test_package_module_dry_run_matches_image_cli(tmp_path: Path, *, use_config: bool) -> None:
+    if use_config:
+        path = tmp_path / "run.yaml"
+        path.write_text(
+            "model: {name: rcf}\ndatasets: [m-eurosat]\n"
+            "runtime: {device: cpu, seed: 8}\noutput: {resume: true}\n",
+            encoding="utf-8",
+        )
+        arguments = ["run", "--config", str(path)]
+    else:
+        arguments = ["run", "--model", "rcf", "--dataset", "m-eurosat", "--device", "cpu"]
+    arguments.extend(["--seed", "3", "--no-resume", "--dry-run"])
+    package = run_entrypoint("torchgeo_bench", arguments, tmp_path)
+    canonical = run_entrypoint("torchgeo_bench.image_cli", arguments, tmp_path)
+    assert package.returncode == canonical.returncode == 0, package.stderr + canonical.stderr
+    assert package.stdout == canonical.stdout
+    assert package.stderr == canonical.stderr == ""
+    config = yaml.safe_load(package.stdout)
+    assert config["model"]["name"] == "rcf"
+    assert config["datasets"] == ["m-eurosat"]
+    assert config["runtime"] == {"device": "cpu", "seed": 3}
+    assert config["output"]["resume"] is False

--- a/tests/test_cli_program.py
+++ b/tests/test_cli_program.py
@@ -1,4 +1,4 @@
-"""Run the installed program against tiny on-disk inputs without mocking its internals."""
+"""Run the legacy CLI against tiny on-disk inputs without mocking its internals."""
 
 import json
 import os
@@ -15,10 +15,10 @@ import pytest
 from torchgeo_bench.datasets import get_bench_dataset_class
 
 
-def run_cli(
+def run_legacy_cli(
     *arguments: str, cwd: Path, timeout: int = 120, offline: bool = True
 ) -> subprocess.CompletedProcess[str]:
-    """Invoke the same entry point used by the console command."""
+    """Invoke the explicit legacy entry point for key=value program coverage."""
     env = {
         **os.environ,
         "OMP_NUM_THREADS": "1",
@@ -28,7 +28,7 @@ def run_cli(
     if offline:
         env["HF_HUB_OFFLINE"] = "1"
     return subprocess.run(
-        [sys.executable, "-m", "torchgeo_bench", *arguments],
+        [sys.executable, "-m", "torchgeo_bench.cli", *arguments],
         cwd=cwd,
         env=env,
         capture_output=True,
@@ -102,7 +102,7 @@ def test_classification_program_handles_noncontiguous_labels(
     arguments = classification_arguments(output)
     if temperature_scaling:
         arguments.extend(["eval.merge_val=false", "eval.calibration.temp_scale=true"])
-    completed = run_cli(*arguments, cwd=tmp_path)
+    completed = run_legacy_cli(*arguments, cwd=tmp_path)
     assert completed.returncode == 0, completed.stdout + completed.stderr
     assert output.is_file(), completed.stdout + completed.stderr
 
@@ -131,7 +131,7 @@ def test_program_profiles_features_and_resumes_without_input_files(
         "eval.profile.n_warmup=0",
         "eval.profile.n_measure=1",
     ]
-    completed = run_cli(*arguments, cwd=tmp_path)
+    completed = run_legacy_cli(*arguments, cwd=tmp_path)
     assert completed.returncode == 0, completed.stdout + completed.stderr
     assert output.is_file(), completed.stdout + completed.stderr
     rows = pd.read_csv(output)
@@ -144,7 +144,7 @@ def test_program_profiles_features_and_resumes_without_input_files(
 
     before = output.read_bytes()
     shutil.rmtree(classification_files)
-    resumed = run_cli(*arguments, "resume=true", cwd=tmp_path)
+    resumed = run_legacy_cli(*arguments, "resume=true", cwd=tmp_path)
     assert resumed.returncode == 0, resumed.stdout + resumed.stderr
     assert output.read_bytes() == before
 
@@ -154,7 +154,7 @@ def test_program_reinitializes_for_multispectral_and_multilabel_datasets(tmp_pat
     labels = tuple([int(index == label) for index in range(43)] for label in (0, 1))
     write_classification_files(tmp_path, "m-bigearthnet", labels, all_bands=True)
     output = tmp_path / "multiple.csv"
-    completed = run_cli(
+    completed = run_legacy_cli(
         *classification_arguments(output),
         "dataset.names=[m-eurosat,m-bigearthnet]",
         "dataset.bands=all",
@@ -185,7 +185,7 @@ def test_program_fails_when_any_requested_data_is_unavailable(
     tmp_path: Path, classification_files: Path, dataset_names: tuple[str, ...]
 ) -> None:
     output = tmp_path / "missing.csv"
-    completed = run_cli(
+    completed = run_legacy_cli(
         *classification_arguments(output),
         f"dataset.names=[{','.join(dataset_names)}]",
         cwd=tmp_path,
@@ -215,7 +215,7 @@ def test_flops_program_writes_both_band_configurations_and_resumes(tmp_path: Pat
         "seg_band_configs=[]",
         f"output={output}",
     ]
-    completed = run_cli(*arguments, cwd=tmp_path)
+    completed = run_legacy_cli(*arguments, cwd=tmp_path)
     assert completed.returncode == 0, completed.stdout + completed.stderr
     assert output.is_file(), completed.stdout + completed.stderr
     rows = pd.read_csv(output).set_index("band_config")
@@ -225,6 +225,6 @@ def test_flops_program_writes_both_band_configurations_and_resumes(tmp_path: Pat
     assert rows.loc["s2", "gflops_backbone"] > rows.loc["rgb", "gflops_backbone"]
     assert (rows["throughput_samples_per_sec"] > 0).all()
     before = output.read_bytes()
-    resumed = run_cli(*arguments, "resume=true", cwd=tmp_path)
+    resumed = run_legacy_cli(*arguments, "resume=true", cwd=tmp_path)
     assert resumed.returncode == 0, resumed.stdout + resumed.stderr
     assert output.read_bytes() == before

--- a/tests/test_cli_program.py
+++ b/tests/test_cli_program.py
@@ -15,7 +15,7 @@ import pytest
 from torchgeo_bench.datasets import get_bench_dataset_class
 
 
-def run_legacy_cli(
+def run_cli(
     *arguments: str, cwd: Path, timeout: int = 120, offline: bool = True
 ) -> subprocess.CompletedProcess[str]:
     """Invoke the explicit legacy entry point for key=value program coverage."""
@@ -102,7 +102,7 @@ def test_classification_program_handles_noncontiguous_labels(
     arguments = classification_arguments(output)
     if temperature_scaling:
         arguments.extend(["eval.merge_val=false", "eval.calibration.temp_scale=true"])
-    completed = run_legacy_cli(*arguments, cwd=tmp_path)
+    completed = run_cli(*arguments, cwd=tmp_path)
     assert completed.returncode == 0, completed.stdout + completed.stderr
     assert output.is_file(), completed.stdout + completed.stderr
 
@@ -131,7 +131,7 @@ def test_program_profiles_features_and_resumes_without_input_files(
         "eval.profile.n_warmup=0",
         "eval.profile.n_measure=1",
     ]
-    completed = run_legacy_cli(*arguments, cwd=tmp_path)
+    completed = run_cli(*arguments, cwd=tmp_path)
     assert completed.returncode == 0, completed.stdout + completed.stderr
     assert output.is_file(), completed.stdout + completed.stderr
     rows = pd.read_csv(output)
@@ -144,7 +144,7 @@ def test_program_profiles_features_and_resumes_without_input_files(
 
     before = output.read_bytes()
     shutil.rmtree(classification_files)
-    resumed = run_legacy_cli(*arguments, "resume=true", cwd=tmp_path)
+    resumed = run_cli(*arguments, "resume=true", cwd=tmp_path)
     assert resumed.returncode == 0, resumed.stdout + resumed.stderr
     assert output.read_bytes() == before
 
@@ -154,7 +154,7 @@ def test_program_reinitializes_for_multispectral_and_multilabel_datasets(tmp_pat
     labels = tuple([int(index == label) for index in range(43)] for label in (0, 1))
     write_classification_files(tmp_path, "m-bigearthnet", labels, all_bands=True)
     output = tmp_path / "multiple.csv"
-    completed = run_legacy_cli(
+    completed = run_cli(
         *classification_arguments(output),
         "dataset.names=[m-eurosat,m-bigearthnet]",
         "dataset.bands=all",
@@ -185,7 +185,7 @@ def test_program_fails_when_any_requested_data_is_unavailable(
     tmp_path: Path, classification_files: Path, dataset_names: tuple[str, ...]
 ) -> None:
     output = tmp_path / "missing.csv"
-    completed = run_legacy_cli(
+    completed = run_cli(
         *classification_arguments(output),
         f"dataset.names=[{','.join(dataset_names)}]",
         cwd=tmp_path,
@@ -215,7 +215,7 @@ def test_flops_program_writes_both_band_configurations_and_resumes(tmp_path: Pat
         "seg_band_configs=[]",
         f"output={output}",
     ]
-    completed = run_legacy_cli(*arguments, cwd=tmp_path)
+    completed = run_cli(*arguments, cwd=tmp_path)
     assert completed.returncode == 0, completed.stdout + completed.stderr
     assert output.is_file(), completed.stdout + completed.stderr
     rows = pd.read_csv(output).set_index("band_config")
@@ -225,6 +225,6 @@ def test_flops_program_writes_both_band_configurations_and_resumes(tmp_path: Pat
     assert rows.loc["s2", "gflops_backbone"] > rows.loc["rgb", "gflops_backbone"]
     assert (rows["throughput_samples_per_sec"] > 0).all()
     before = output.read_bytes()
-    resumed = run_legacy_cli(*arguments, "resume=true", cwd=tmp_path)
+    resumed = run_cli(*arguments, "resume=true", cwd=tmp_path)
     assert resumed.returncode == 0, resumed.stdout + resumed.stderr
     assert output.read_bytes() == before


### PR DESCRIPTION
Route `python -m torchgeo_bench` through the same image CLI as the installed command, so YAML configuration, dry runs, help, and catalogs agree. Keep `python -m torchgeo_bench.cli` unchanged for legacy invocations and preserve its end-to-end program coverage.