### PR TITLE
fix(knn): use the requested CUDA context

### DIFF
--- a/src/torchgeo_bench/knn.py
+++ b/src/torchgeo_bench/knn.py
@@ -92,7 +92,7 @@ class KNNClassifier:
             raise ValueError(f"n_neighbors must be a positive integer, got {n_neighbors!r}.")
         self.n_neighbors = n_neighbors
         self._effective_n_neighbors: int | None = None
-        self.device = device
+        self.device = "cuda:0" if device == "cuda" else device
         self.metric = metric
         self.use_fp16 = use_fp16
 
@@ -193,7 +193,8 @@ class KNNClassifier:
             # Gaps in class IDs require max(y) + 1 slots, not faissknn's unique-label count.
             self._n_classes = int(np.max(y)) + 1
             self._impl = FaissKNNClassifier(n_classes=self._n_classes, **kwargs)
-        self._impl.fit(X, y.astype(np.int64))
+        with torch.cuda.device(self.device):
+            self._impl.fit(X, y.astype(np.int64))
 
     def _to_gpu_tensor(self, X: np.ndarray) -> torch.Tensor:
         """Give faissknn a CUDA tensor so it can use device memory directly."""
@@ -213,7 +214,9 @@ class KNNClassifier:
         if _is_cpu_device(self.device):
             return self._predict_cpu(X)
         assert self._impl is not None, "Call fit() first."
-        result = self._impl.predict(self._to_gpu_tensor(X))
+        # FAISS's Torch wrapper uses the current device to choose its CUDA stream.
+        with torch.cuda.device(self.device):
+            result = self._impl.predict(self._to_gpu_tensor(X))
         return result.cpu().numpy() if isinstance(result, torch.Tensor) else result
 
     def predict_proba(self, X: np.ndarray) -> np.ndarray:
@@ -221,5 +224,6 @@ class KNNClassifier:
         if _is_cpu_device(self.device):
             return self._predict_proba_cpu(X)
         assert self._impl is not None, "Call fit() first."
-        result = self._impl.predict_proba(self._to_gpu_tensor(X))
+        with torch.cuda.device(self.device):
+            result = self._impl.predict_proba(self._to_gpu_tensor(X))
         return result.cpu().numpy() if isinstance(result, torch.Tensor) else result

--- a/tests/test_knn_device_context.py
+++ b/tests/test_knn_device_context.py
@@ -1,0 +1,17 @@
+"""Device validation must remain useful when GPU FAISS is not installed."""
+
+import numpy as np
+import pytest
+
+from torchgeo_bench import knn
+
+
+def test_missing_gpu_faiss_is_reported_before_cuda_initialization(monkeypatch):
+    monkeypatch.setattr(knn, "gpu_faiss_available", lambda: False)
+
+    def unexpected_context(_device):
+        raise AssertionError("CUDA must not initialize before the backend check")
+
+    monkeypatch.setattr(knn.torch.cuda, "device", unexpected_context)
+    with pytest.raises(RuntimeError, match="GPU-enabled FAISS is unavailable"):
+        knn.KNNClassifier(device="cuda:1").fit(np.ones((2, 3), dtype=np.float32), np.array([0, 1]))

--- a/tests/test_knn_gpu_parity.py
+++ b/tests/test_knn_gpu_parity.py
@@ -52,3 +52,38 @@ def test_multilabel_parity(features: tuple[np.ndarray, np.ndarray]) -> None:
     assert (p_cpu == p_cu).all()
 
     np.testing.assert_allclose(cpu.predict_proba(x_test), cu.predict_proba(x_test), atol=1e-5)
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="requires a nondefault CUDA device")
+@pytest.mark.parametrize("multilabel", [False, True])
+def test_nondefault_gpu_uses_its_own_stream(*, multilabel: bool) -> None:
+    rng = np.random.default_rng(3)
+    train = rng.normal(size=(20000, 378)).astype(np.float32)
+    query = rng.normal(size=(4000, 378)).astype(np.float32)
+    labels = (
+        (rng.random((len(train), 19)) > 0.7).astype(np.int64)
+        if multilabel
+        else rng.integers(0, 19, len(train))
+    )
+    cpu = KNNClassifier(5, "cpu").fit(train, labels)
+    with torch.cuda.device(0):
+        gpu = KNNClassifier(5, "cuda:1").fit(train, labels)
+        assert torch.cuda.current_device() == 0
+        np.testing.assert_array_equal(gpu.predict(query), cpu.predict(query))
+        np.testing.assert_allclose(gpu.predict_proba(query), cpu.predict_proba(query), atol=1e-5)
+        assert torch.cuda.current_device() == 0
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="requires a nondefault CUDA device")
+def test_unnumbered_cuda_agrees_with_faiss_default_device(
+    features: tuple[np.ndarray, np.ndarray],
+) -> None:
+    train, query = features
+    labels = np.random.default_rng(1).integers(0, N_CLASSES, len(train))
+    expected = KNNClassifier(K, "cpu").fit(train, labels).predict(query)
+    with torch.cuda.device(1):
+        model = KNNClassifier(K, "cuda").fit(train, labels)
+        assert model.device == "cuda:0"
+        np.testing.assert_array_equal(model.predict(query), expected)
+        assert torch.cuda.current_device() == 1

--- a/tests/test_multilabel.py
+++ b/tests/test_multilabel.py
@@ -3,6 +3,7 @@
 import builtins
 import logging
 import sys
+from contextlib import nullcontext
 from types import SimpleNamespace
 
 import numpy as np
@@ -102,6 +103,7 @@ class TestKNNClassifierSingleLabel:
                 del X, y
 
         monkeypatch.setattr(knn, "gpu_faiss_available", lambda: True)
+        monkeypatch.setattr(knn.torch.cuda, "device", lambda _device: nullcontext())
         monkeypatch.setitem(
             sys.modules,
             "faissknn",


### PR DESCRIPTION
Run FAISS fitting and prediction inside the requested CUDA device context. Without it, searches on a nondefault GPU can use the wrong stream and return invalid indices or silently wrong neighbors. Also resolve bare `cuda` to the same device-0 default used by faissknn and restore the caller's device after each operation.

Includes single-label and multilabel CPU/GPU regression cases, plus a check that a missing GPU FAISS backend raises before CUDA initialization. This was found while benchmarking the handcrafted baseline; its model and result changes are submitted separately.
