### PR TITLE
Add reproducible segmentation optimizer and layer studies

### DIFF
--- a/docs/user/segmentation-layers.md
+++ b/docs/user/segmentation-layers.md
@@ -163,3 +163,23 @@ Config: `layers: ["s4", "s3", "s2", "s1"]`
 3. Run the discovery script above to confirm spatial sizes
 4. Add to the model config in coarse-to-fine order (deepest first)
 5. Note any stages that share spatial size (common in EfficientNet/MobileNet)
+
+## Comparing optimization and layer connections
+
+The standalone study scripts run from a development checkout, discover all visible GPUs by default, and schedule one process per GPU. They use frozen FP32 features, full dataset splits, and training-loss stopping criteria rather than a wall-clock budget. Run `--dry-run` to inspect the grid without downloading data or starting jobs.
+
+```bash
+# Sweep Adam learning rates to a training-loss plateau, then compare full-batch L-BFGS.
+python scripts/run_segmentation_optimizer_study.py --gpus all --resume
+
+# Compare equally sized layer sets across three decoder families.
+python scripts/run_segmentation_layer_study.py --gpus all --resume \
+    --heads linear conv_block fpn \
+    --layer-groups late_four spread_four early_four
+```
+
+Both scripts default to Burn Scars with a pretrained ViT-Small/16 backbone and RGB inputs at 224 pixels. Adam and L-BFGS use the same fixed minibatch membership so training-mode BatchNorm sees a shared objective; Adam shuffles batch order, not the images within batches. The layer study extracts the union of the requested intermediate features once, then selects the appropriate tensors for each decoder. Four-layer comparisons keep the number of connections fixed; comparing one layer with four also changes decoder capacity. Parameter counts and exact layer names are included in the results.
+
+Each output directory contains `combined.csv` with raw outcomes and timings, `validation_selected.csv` with learning rates selected by mean validation mIoU across seeds, and per-trial learning curves, checkpoints, and logs. Optimization-only time is separate from convergence checks, validation, and checkpoint I/O. Test data never selects learning rates or checkpoints. Convergence requires a flat recent training-loss window, not merely failure to beat a historical minimum. A plateau is an operational stopping rule, not proof of stationarity; unsuccessful learning rates, numerical stalls, and optional `--max-iterations` safety limits are labeled as nonconvergence.
+
+Use `--gpus 0,2` to restrict resources, `--seeds` and `--adam-lrs` to change the sweep, and `--help` for convergence controls or custom layer groups. DPT requires four connections and the patch-linear decoder uses one. DPT also requires the optional `transformers` dependency, available through `pip install "torchgeo-bench[sam3]"`. Resume only a compatible configuration; scientific changes require a new output directory.

--- a/scripts/_segmentation_convergence.py
+++ b/scripts/_segmentation_convergence.py
@@ -1,0 +1,841 @@
+"""Resumable accepted-training-CE convergence, shared by both production studies.
+
+Adam is constant-rate with zero decay. L-BFGS keeps strong-Wolfe history across
+20-iteration chunks; closures accumulate globally valid-pixel-weighted gradients
+over fixed microbatches. Adam shuffles these same batches, never their membership,
+and scales summed batch CE by the number of batches / total valid pixels.
+Train-mode BN makes this shared objective dependent on fixed batch membership.
+Convergence requires a flat recent loss window after minimum iterations, not just
+stale historical best loss. Stale, nonrecovering oscillations are not_converged;
+materially falling windows continue, even above the historical best. Plateaus are
+operational convergence, not stationarity. Validation selects the earliest
+strictly best checkpoint; test never controls training or selection.
+
+Each block commits model/optimizer/RNG/buffers/patience/curve to checkpoint.pt
+before publishing derived CSV/progress. Resumption replays only uncommitted work.
+Active training wall time excludes offline time. Optimization timing excludes
+monitoring, calibration, validation, selection, persistence and final evaluation.
+"""
+
+import csv
+import json
+import logging
+import math
+import random
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+import _segmentation_features as shared
+import numpy as np
+import torch
+from filelock import FileLock
+from torch import nn
+
+logger = logging.getLogger(__name__)
+STAGES = (
+    "setup",
+    "warmup",
+    "optimization",
+    "convergence",
+    "calibration",
+    "validation",
+    "selection",
+    "checkpoint",
+    "test",
+    "bootstrap",
+)
+
+
+@dataclass(frozen=True)
+class TrialConfig:
+    """Scientific identity of a constant-LR, unregularized convergence fit."""
+
+    head: str
+    optimizer: str
+    lr: float
+    seed: int = 0
+    hidden_dim: int = 256
+    batch_size: int = 8
+    check_every: int = 5
+    lbfgs_iterations: int = 20
+    history_size: int = 10
+    patience: int = 10
+    min_iterations: int = 50
+    absolute_tol: float = 1e-5
+    relative_tol: float = 1e-4
+    gradient_tol: float = 1e-7
+    numerical_patience: int = 3
+    max_iterations: int | None = None
+    bootstrap: int = 1000
+
+    def __post_init__(self) -> None:
+        if self.head not in shared.HEADS or self.optimizer not in ("adam", "lbfgs"):
+            raise ValueError("Unknown head or optimizer.")
+        if not math.isfinite(self.lr) or self.lr <= 0:
+            raise ValueError("lr must be positive and finite.")
+        if any(
+            not math.isfinite(v) or v < 0
+            for v in (self.absolute_tol, self.relative_tol, self.gradient_tol)
+        ):
+            raise ValueError("Tolerances must be finite and nonnegative.")
+        counts = (
+            self.hidden_dim,
+            self.batch_size,
+            self.check_every,
+            self.lbfgs_iterations,
+            self.history_size,
+            self.patience,
+            self.numerical_patience,
+            self.bootstrap,
+        )
+        if min(counts) < 1 or self.min_iterations < 0 or not 0 <= self.seed < 2**32:
+            raise ValueError("Counts must be positive and seed in [0, 2**32).")
+        if self.max_iterations is not None and self.max_iterations < 1:
+            raise ValueError("max_iterations is a positive optional safety cap.")
+
+
+@dataclass
+class Plateau:
+    """Track cumulative best improvement and recent, post-minimum loss behavior."""
+
+    reference: float | None = None
+    best_loss: float | None = None
+    stale_checks: int = 0
+    checks: int = 0
+    recent_losses: list[float] = field(default_factory=list)
+
+    def window_statistics(self, config: TrialConfig) -> dict[str, float | None]:
+        """Measure range and equal-half mean decrease, excluding an odd middle value."""
+        if not self.recent_losses:
+            return {
+                "recent_ce_range": None,
+                "recent_ce_half_mean_decrease": None,
+                "recent_ce_tolerance": None,
+            }
+        half = len(self.recent_losses) // 2
+        decrease = (
+            (math.fsum(self.recent_losses[:half]) - math.fsum(self.recent_losses[-half:])) / half
+            if half
+            else None
+        )
+        return {
+            "recent_ce_range": max(self.recent_losses) - min(self.recent_losses),
+            "recent_ce_half_mean_decrease": decrease,
+            "recent_ce_tolerance": max(
+                config.absolute_tol, config.relative_tol * abs(min(self.recent_losses))
+            ),
+        }
+
+    def observe(self, loss: float, iterations: int, config: TrialConfig) -> str | None:
+        """Distinguish a flat window from stale, nonrecovering historical-best patience.
+
+        Small improvements accumulate against ``reference``. Only checks at or
+        after ``min_iterations`` enter the recent window, which holds ``patience``
+        observations (at least two to measure a trend). Stale patience alone must
+        never stop a materially recovering window above an early historical best.
+        """
+        if not math.isfinite(loss):
+            raise shared.DivergedError("Nonfinite accepted training loss.")
+        self.checks += 1
+        self.best_loss = loss if self.best_loss is None else min(self.best_loss, loss)
+        threshold = max(config.absolute_tol, config.relative_tol * abs(self.reference or 0))
+        if self.reference is None or self.reference - loss > threshold:
+            self.reference, self.stale_checks = loss, 0
+        else:
+            self.stale_checks += 1
+        if iterations < config.min_iterations:
+            return None
+        window_size = max(2, config.patience)
+        self.recent_losses.append(loss)
+        del self.recent_losses[:-window_size]
+        if len(self.recent_losses) < window_size or self.stale_checks < config.patience:
+            return None
+        window = self.window_statistics(config)
+        if window["recent_ce_range"] <= window["recent_ce_tolerance"]:
+            return "train_loss_plateau"
+        if window["recent_ce_half_mean_decrease"] <= window["recent_ce_tolerance"]:
+            return "no_best_improvement"
+        return None
+
+
+class Timings:
+    """Synchronized cumulative stage costs, including stages that fail."""
+
+    def __init__(self, device: torch.device) -> None:
+        self.device = device
+        self.seconds = dict.fromkeys(STAGES, 0.0)
+
+    @contextmanager
+    def measure(self, stage: str) -> Iterator[None]:
+        """Accumulate wall time after synchronizing device work."""
+        shared.synchronize(self.device)
+        start = time.perf_counter()
+        try:
+            yield
+        finally:
+            shared.synchronize(self.device)
+            self.seconds[stage] += time.perf_counter() - start
+
+
+@contextmanager
+def preserved_training_buffers(head: nn.Module) -> Iterator[None]:
+    """Use train-mode statistics without leaking buffers or module modes."""
+    buffers = [(buffer, buffer.detach().clone()) for buffer in head.buffers()]
+    modes = [(module, module.training) for module in head.modules()]
+    head.train()
+    try:
+        yield
+    finally:
+        with torch.no_grad():
+            for buffer, original in buffers:
+                buffer.copy_(original)
+        for module, training in modes:
+            module.training = training
+
+
+def gradient_norm(head: nn.Module) -> float:
+    """Return accepted-gradient infinity norm with a single host reduction."""
+    gradients = [p.grad.detach().abs().amax() for p in head.parameters() if p.grad is not None]
+    value = float(torch.stack(gradients).amax()) if gradients else 0.0
+    if not math.isfinite(value):
+        raise shared.DivergedError("Nonfinite accepted gradient.")
+    return value
+
+
+class FullObjective:
+    """Resident, fixed-order global valid-pixel CE with memory-bounded autograd."""
+
+    def __init__(self, head: nn.Module, cache: shared.GPUTensorCache, batch_size: int) -> None:
+        shared.reject_stochastic_modules(head)
+        self.head, self.cache, self.batch_size = head, cache, batch_size
+        self.valid_per_image = cache.masks.ne(shared.IGNORE_INDEX).sum((1, 2)).cpu()
+        self.valid_pixels = int(self.valid_per_image.sum())
+        if not self.valid_pixels:
+            raise ValueError("Training split has no valid pixels.")
+        self.evaluations = 0
+        self.monitor_evaluations = 0
+        self.batch_count = (len(cache) + batch_size - 1) // batch_size
+
+    def compute(self, *, backward: bool) -> torch.Tensor:
+        """Compute one microbatch graph at a time, preserving train-mode buffers."""
+        if backward:
+            self.head.zero_grad(set_to_none=True)
+        total = torch.zeros((), device=self.cache.device)
+        with preserved_training_buffers(self.head), torch.set_grad_enabled(backward):
+            for features, masks in self.cache.ordered_batches(self.batch_size):
+                loss = shared.summed_cross_entropy(self.head(features, *masks.shape[-2:]), masks)
+                loss = loss / self.valid_pixels
+                if backward:
+                    loss.backward()
+                total += loss.detach()
+        if not torch.isfinite(total):
+            raise shared.DivergedError("Nonfinite full training objective.")
+        return total
+
+    def __call__(self) -> torch.Tensor:
+        """Supply the full backward closure while counting actual evaluations."""
+        self.evaluations += 1
+        return self.compute(backward=True)
+
+    def monitor(self, *, backward: bool) -> tuple[float, float | None]:
+        """Recompute accepted weights, separately from optimization timing."""
+        self.monitor_evaluations += 1
+        loss = self.compute(backward=backward)
+        return float(loss), gradient_norm(self.head) if backward else None
+
+
+def adam_epoch(objective: FullObjective, optimizer: torch.optim.Adam, counters: dict) -> None:
+    """Shuffle fixed BN buckets with uniform-batch unbiased global-CE scaling."""
+    head, cache = objective.head, objective.cache
+    head.train()
+    total = torch.zeros((), device=cache.device)
+    for batch_index in torch.randperm(objective.batch_count).tolist():
+        start = batch_index * objective.batch_size
+        stop = min(start + objective.batch_size, len(cache))
+        bucket = slice(start, stop)
+        counters["samples"] += stop - start
+        if not objective.valid_per_image[bucket].sum():
+            continue
+        features = [tensor[bucket] for tensor in cache.layer_tensors]
+        masks = cache.masks[bucket]
+        optimizer.zero_grad(set_to_none=True)
+        loss = shared.summed_cross_entropy(head(features, *masks.shape[-2:]), masks)
+        loss = loss * objective.batch_count / objective.valid_pixels
+        loss.backward()
+        optimizer.step()
+        total += loss.detach()
+        counters["optimizer_step_calls"] += 1
+        counters["optimizer_updates"] += 1
+    if not torch.isfinite(total):
+        raise shared.DivergedError("Nonfinite Adam epoch.")
+    counters["epochs"] += 1
+
+
+def optimizer_settings(config: TrialConfig) -> dict:
+    """Record every explicitly selected optimizer option."""
+    if config.optimizer == "adam":
+        return {
+            "lr": config.lr,
+            "weight_decay": 0.0,
+            "betas": (0.9, 0.999),
+            "eps": 1e-8,
+            "amsgrad": False,
+            "foreach": True,
+            "fused": False,
+        }
+    return {
+        "lr": config.lr,
+        "max_iter": config.lbfgs_iterations,
+        "max_eval": max(25, config.lbfgs_iterations * 5 // 4),
+        "history_size": config.history_size,
+        "line_search_fn": "strong_wolfe",
+        "tolerance_grad": config.gradient_tol,
+        "tolerance_change": 1e-9,
+    }
+
+
+def model_snapshot(head: nn.Module) -> dict:
+    """Capture parameters, nonpersistent buffers and individual module flags."""
+    return {
+        "state_dict": shared.snapshot(head),
+        "buffers": {name: buffer.detach().cpu().clone() for name, buffer in head.named_buffers()},
+        "modes": {name: module.training for name, module in head.named_modules()},
+    }
+
+
+def restore_model(head: nn.Module, state: dict) -> None:
+    """Restore all state, including nonpersistent buffers."""
+    head.load_state_dict(state["state_dict"])
+    with torch.no_grad():
+        for name, buffer in head.named_buffers():
+            buffer.copy_(state["buffers"][name])
+    for name, module in head.named_modules():
+        module.training = state["modes"][name]
+
+
+def rng_snapshot(device: torch.device) -> dict:
+    """Serialize all used RNGs as safe primitive values and tensors."""
+    numpy_state = np.random.get_state()  # noqa: NPY002 -- Preserve upstream global RNG.
+    return {
+        "python": random.getstate(),
+        "numpy": (numpy_state[0], numpy_state[1].tolist(), *numpy_state[2:]),
+        "torch": torch.get_rng_state(),
+        "cuda": torch.cuda.get_rng_state(device) if device.type == "cuda" else None,
+    }
+
+
+def restore_rng(state: dict, device: torch.device) -> None:
+    """Resume permutations and RNG streams, allowing a different CUDA index."""
+    random.setstate(state["python"])
+    numpy_state = state["numpy"]
+    np.random.set_state(  # noqa: NPY002 -- Restore upstream global RNG.
+        (numpy_state[0], np.asarray(numpy_state[1], dtype=np.uint32), *numpy_state[2:])
+    )
+    torch.set_rng_state(state["torch"])
+    if state["cuda"] is not None and device.type == "cuda":
+        torch.cuda.set_rng_state(state["cuda"], device)
+
+
+def warmup(head: nn.Module, cache: shared.GPUTensorCache, batch_size: int) -> None:
+    """Warm dummy forward/backward without changing model state or any RNG."""
+    state, rng = model_snapshot(head), rng_snapshot(torch.device(cache.device))
+    try:
+        head.train()
+        count = min(batch_size, len(cache))
+        features = [torch.zeros_like(t[:count]) for t in cache.layer_tensors]
+        masks = torch.zeros_like(cache.masks[:count])
+        (
+            shared.summed_cross_entropy(head(features, *masks.shape[-2:]), masks) / masks.numel()
+        ).backward()
+    finally:
+        restore_model(head, state)
+        head.zero_grad(set_to_none=True)
+        restore_rng(rng, torch.device(cache.device))
+
+
+class TrialStore:
+    """Treat checkpoint.pt as the authoritative commit, repairing derived files."""
+
+    def __init__(self, directory: Path, trial_identity: dict) -> None:
+        self.directory, self.identity = directory, trial_identity
+
+    def load(self) -> dict:
+        """Validate identity and recover accounting from a complete same-block progress file."""
+        state = torch.load(self.directory / "checkpoint.pt", map_location="cpu", weights_only=True)
+        if state["identity"] != self.identity:
+            raise ValueError("Checkpoint identity mismatch.")
+        path = self.directory / "progress.json"
+        if path.exists():
+            try:
+                progress = json.loads(path.read_text())
+            except json.JSONDecodeError:  # allow-except: the checkpoint is authoritative
+                logger.warning(
+                    "Invalid progress JSON at %s; restoring timing from checkpoint.", path
+                )
+                progress = None
+            if progress is not None:
+                if progress["identity"] != self.identity:
+                    raise ValueError("Progress identity mismatch.")
+                if progress["block"] == state["counters"]["blocks"]:
+                    state["timings_seconds"] = progress["timings_seconds"]
+                    state["training_wall_seconds"] = progress["training_wall_seconds"]
+        return state
+
+    def write_checkpoint(self, run: "ConvergenceRun") -> None:
+        """Commit continuation before derived curve, so crashes cannot advance only the CSV."""
+        with run.timings.measure("checkpoint"):
+            shared.atomic_save(
+                self.directory / "checkpoint.pt", {"identity": self.identity, **run.state()}
+            )
+            with shared.atomic_stream(self.directory / "curve.csv", "w") as stream:
+                writer = csv.DictWriter(
+                    stream, fieldnames=list(run.curve[0]) if run.curve else ["block"]
+                )
+                writer.writeheader()
+                writer.writerows(run.curve)
+
+    def progress(self, run: "ConvergenceRun") -> None:
+        """Publish complete block accounting and live scientific status."""
+        shared.atomic_json(
+            self.directory / "progress.json",
+            {
+                "identity": self.identity,
+                "status": run.status,
+                "stop_reason": run.stop_reason,
+                "block": run.counters["blocks"],
+                "latest": run.curve[-1] if run.curve else None,
+                "timings_seconds": run.timings.seconds,
+                "training_wall_seconds": run.training_wall_seconds,
+                "plateau": asdict(run.plateau),
+            },
+        )
+
+
+class ConvergenceRun:
+    """Resumable training state machine with validation-only checkpoint selection."""
+
+    def __init__(
+        self, head: nn.Module, caches: dict, config: TrialConfig, store: TrialStore | None = None
+    ) -> None:
+        self.head, self.caches, self.config, self.store = head, caches, config, store
+        self.device = torch.device(caches["train"].device)
+        self.timings = Timings(self.device)
+        with self.timings.measure("setup"):
+            self.objective = FullObjective(head, caches["train"], config.batch_size)
+            constructor = torch.optim.Adam if config.optimizer == "adam" else torch.optim.LBFGS
+            self.optimizer = constructor(head.parameters(), **optimizer_settings(config))
+            self.initial_state_sha256 = shared.tensor_digest(head.state_dict())
+        self.best: dict | None = None
+        self.plateau = Plateau()
+        self.curve: list[dict] = []
+        self.counters = dict.fromkeys(
+            (
+                "blocks",
+                "epochs",
+                "optimizer_step_calls",
+                "optimizer_updates",
+                "samples",
+                "calibration_passes",
+                "unchanged_blocks",
+                "stalled_iteration_blocks",
+            ),
+            0,
+        )
+        self.status, self.stop_reason = "running", None
+        self.training_wall_seconds = 0.0
+        self.failure: str | None = None
+        self.hardware_history = [shared.hardware(self.device)]
+
+    @property
+    def lbfgs_state(self) -> dict:
+        """Return actual persistent PyTorch iteration/history/evaluation counters."""
+        return self.optimizer.state.get(next(self.head.parameters()), {})
+
+    @property
+    def iterations(self) -> int:
+        """Count Adam epochs or actual L-BFGS internal iterations, not closure calls."""
+        return (
+            self.counters["epochs"]
+            if self.config.optimizer == "adam"
+            else int(self.lbfgs_state.get("n_iter", 0))
+        )
+
+    def state(self) -> dict:
+        """Capture every value needed to continue a committed block exactly."""
+        return {
+            "model": model_snapshot(self.head),
+            "optimizer": self.optimizer.state_dict(),
+            "rng": rng_snapshot(self.device),
+            "counters": self.counters,
+            "plateau": asdict(self.plateau),
+            "curve": self.curve,
+            "best": self.best,
+            "status": self.status,
+            "stop_reason": self.stop_reason,
+            "failure": self.failure,
+            "initial_state_sha256": self.initial_state_sha256,
+            "timings_seconds": self.timings.seconds,
+            "training_wall_seconds": self.training_wall_seconds,
+            "closure_evaluations": self.objective.evaluations,
+            "monitor_evaluations": self.objective.monitor_evaluations,
+            "hardware_history": self.hardware_history,
+        }
+
+    def restore(self, state: dict) -> None:
+        """Continue without resetting momentum, curvature, RNG or patience."""
+        setup_seconds = self.timings.seconds["setup"]
+        restore_model(self.head, state["model"])
+        self.optimizer.load_state_dict(state["optimizer"])
+        self.counters = state["counters"]
+        self.plateau = Plateau(**state["plateau"])
+        self.curve, self.best = state["curve"], state["best"]
+        self.status, self.stop_reason, self.failure = (
+            state["status"],
+            state["stop_reason"],
+            state["failure"],
+        )
+        self.initial_state_sha256 = state["initial_state_sha256"]
+        self.timings.seconds = state["timings_seconds"]
+        self.timings.seconds["setup"] += setup_seconds
+        self.training_wall_seconds = state["training_wall_seconds"]
+        self.objective.evaluations = state["closure_evaluations"]
+        self.objective.monitor_evaluations = state["monitor_evaluations"]
+        self.hardware_history = state["hardware_history"]
+        current = shared.hardware(self.device)
+        if current != self.hardware_history[-1]:
+            self.hardware_history.append(current)
+        restore_rng(state["rng"], self.device)
+
+    def optimize(self) -> bool:
+        """Execute a block and report exact accepted parameter change for L-BFGS."""
+        config = self.config
+        remaining = (
+            None if config.max_iterations is None else config.max_iterations - self.iterations
+        )
+        if config.optimizer == "adam":
+            with self.timings.measure("optimization"):
+                for _ in range(
+                    config.check_every if remaining is None else min(config.check_every, remaining)
+                ):
+                    adam_epoch(self.objective, self.optimizer, self.counters)
+            return True
+        chunk = (
+            config.lbfgs_iterations
+            if remaining is None
+            else min(config.lbfgs_iterations, remaining)
+        )
+        self.optimizer.param_groups[0]["max_iter"] = chunk
+        self.optimizer.param_groups[0]["max_eval"] = max(25, chunk * 5 // 4)
+        with self.timings.measure("convergence"):
+            before = [p.detach().clone() for p in self.head.parameters()]
+        previous_iterations = self.iterations
+        with self.timings.measure("optimization"):
+            self.optimizer.step(self.objective)
+        with self.timings.measure("convergence"):
+            changed = not bool(
+                torch.stack(
+                    [
+                        torch.eq(p, original).all()
+                        for p, original in zip(self.head.parameters(), before, strict=True)
+                    ]
+                ).all()
+            )
+        self.counters["optimizer_step_calls"] += 1
+        self.counters["optimizer_updates"] += int(changed)
+        stalled = self.iterations == previous_iterations
+        self.counters["stalled_iteration_blocks"] = (
+            self.counters["stalled_iteration_blocks"] + 1 if stalled else 0
+        )
+        return changed
+
+    def stopping_reason(self, loss: float, gradient: float | None, *, changed: bool) -> str | None:
+        """Separate stationarity, operational plateau, numerical stalls and safety caps."""
+        config = self.config
+        plateau_reason = self.plateau.observe(loss, self.iterations, config)
+        if gradient is not None and gradient <= config.gradient_tol:
+            return "gradient_tolerance"
+        no_decrease = bool(self.curve) and loss >= self.curve[-1]["train_ce"]
+        self.counters["unchanged_blocks"] = (
+            self.counters["unchanged_blocks"] + 1 if not changed and no_decrease else 0
+        )
+        if (
+            max(self.counters["unchanged_blocks"], self.counters["stalled_iteration_blocks"])
+            >= config.numerical_patience
+        ):
+            return "numerical_stall"
+        if plateau_reason is not None:
+            return plateau_reason
+        if config.max_iterations is not None and self.iterations >= config.max_iterations:
+            return "safety_max_iterations"
+        return None
+
+    def row(self, loss: float, gradient: float | None, val: dict) -> dict:
+        """Describe accepted weights with cumulative counters and stage costs."""
+        return {
+            "block": self.counters["blocks"],
+            "iterations": self.iterations,
+            "epochs": self.counters["epochs"],
+            "train_ce": loss,
+            "gradient_inf_norm": gradient,
+            "val_ce": val["ce"],
+            "val_miou": val["miou"],
+            "plateau_reference_ce": self.plateau.reference,
+            "stale_checks": self.plateau.stale_checks,
+            **self.plateau.window_statistics(self.config),
+            "optimizer_step_calls": self.counters["optimizer_step_calls"],
+            "optimizer_updates": self.counters["optimizer_updates"],
+            "lbfgs_n_iter": self.lbfgs_state.get("n_iter", 0),
+            "lbfgs_func_evals": self.lbfgs_state.get("func_evals", 0),
+            "lbfgs_history_length": len(self.lbfgs_state.get("old_dirs", [])),
+            "closure_evaluations": self.objective.evaluations,
+            "monitor_evaluations": self.objective.monitor_evaluations,
+            "optimization_data_passes": self.objective.evaluations
+            if self.config.optimizer == "lbfgs"
+            else self.counters["samples"] / len(self.caches["train"]),
+            "calibration_passes": self.counters["calibration_passes"],
+            "status": self.status,
+            "stop_reason": self.stop_reason,
+            **{f"{stage}_seconds": value for stage, value in self.timings.seconds.items()},
+        }
+
+    def check(self, block_started_at: float, *, changed: bool) -> None:
+        """Monitor training CE, calibrate BN on train, then select by validation mIoU."""
+        with self.timings.measure("convergence"):
+            loss, gradient = self.objective.monitor(backward=self.config.optimizer == "lbfgs")
+            self.stop_reason = self.stopping_reason(loss, gradient, changed=changed)
+            if self.stop_reason is not None:
+                self.status = (
+                    "converged"
+                    if self.stop_reason in ("gradient_tolerance", "train_loss_plateau")
+                    else "not_converged"
+                )
+        with self.timings.measure("calibration"):
+            self.counters["calibration_passes"] += int(
+                shared.recalibrate_bn(self.head, self.caches["train"], self.config.batch_size)
+            )
+        with self.timings.measure("validation"):
+            val = shared.evaluate(self.head, self.caches["val"], self.config.batch_size)
+        row = self.row(loss, gradient, val)
+        selected = self.best is None or row["val_miou"] > self.best["val_miou"]
+        with self.timings.measure("selection"):
+            if selected:
+                self.best = {**row, **model_snapshot(self.head)}
+        row["selection_seconds"] = self.timings.seconds["selection"]
+        row["training_wall_seconds"] = (
+            self.training_wall_seconds + time.perf_counter() - block_started_at
+        )
+        if selected:
+            self.best.update(
+                selection_seconds=row["selection_seconds"],
+                training_wall_seconds=row["training_wall_seconds"],
+            )
+        self.curve.append(row)
+
+    def block(self, *, initial: bool = False) -> None:
+        """Commit one monitored block; only numerical divergence becomes a failed result."""
+        shared.synchronize(self.device)
+        start = time.perf_counter()
+        try:
+            changed = True
+            if not initial:
+                changed = self.optimize()
+                self.counters["blocks"] += 1
+            self.check(start, changed=changed)
+        except (
+            shared.DivergedError
+        ) as error:  # allow-except: record numerical failure as a trial result
+            self.status, self.stop_reason, self.failure = "failed", "nonfinite", str(error)
+        shared.synchronize(self.device)
+        self.training_wall_seconds += time.perf_counter() - start
+        if self.store:
+            start = time.perf_counter()
+            self.store.write_checkpoint(self)
+            self.training_wall_seconds += time.perf_counter() - start
+            self.store.progress(self)
+        logger.info(
+            "%s %s lr=%g seed=%d iterations=%d status=%s reason=%s optimization=%.3fs",
+            self.config.head,
+            self.config.optimizer,
+            self.config.lr,
+            self.config.seed,
+            self.iterations,
+            self.status,
+            self.stop_reason,
+            self.timings.seconds["optimization"],
+        )
+
+    def fit(self) -> dict:
+        """Train until a declared stopping condition and retain both stopping/selected weights."""
+        with self.timings.measure("warmup"):
+            warmup(self.head, self.caches["train"], self.config.batch_size)
+        if self.device.type == "cuda":
+            torch.cuda.reset_peak_memory_stats(self.device)
+        if not self.curve and self.status == "running":
+            self.block(initial=True)
+        while self.status == "running":
+            self.block()
+        return self.finish()
+
+    def finish(self) -> dict:
+        """Evaluate only validation-selected weights on test."""
+        if self.store:
+            with self.timings.measure("checkpoint"):
+                shared.atomic_save(
+                    self.store.directory / "final.pt",
+                    {
+                        "identity": self.store.identity,
+                        **model_snapshot(self.head),
+                        "counters": self.counters,
+                    },
+                )
+        result = self.summary()
+        if self.best is not None and self.status != "failed":
+            with self.timings.measure("selection"):
+                restore_model(self.head, self.best)
+            with self.timings.measure("test"):
+                test = shared.evaluate(self.head, self.caches["test"], self.config.batch_size)
+            confusions = test.pop("per_image_confusions")
+            with self.timings.measure("bootstrap"):
+                result["test_miou_ci95"] = shared.bootstrap_interval(
+                    confusions, self.config.bootstrap, self.config.seed
+                )
+            result["test"] = test
+            if self.store:
+                with self.timings.measure("checkpoint"):
+                    shared.atomic_save(self.store.directory / "test_confusions.pt", confusions)
+                    shared.atomic_save(
+                        self.store.directory / "best.pt",
+                        {"identity": self.store.identity, **self.best},
+                    )
+        result["timings_seconds"] = dict(self.timings.seconds)
+        return result
+
+    def summary(self) -> dict:
+        """Report scientific outcome without conflating a plateau with stationarity."""
+        hardware_types = {
+            shared.identity({k: v for k, v in h.items() if k != "device"})
+            for h in self.hardware_history
+        }
+        return {
+            "status": self.status,
+            "stop_reason": self.stop_reason,
+            "stationary": self.stop_reason == "gradient_tolerance",
+            "failure": self.failure,
+            "initial_state_sha256": self.initial_state_sha256,
+            "parameter_count": sum(p.numel() for p in self.head.parameters()),
+            "trainable_parameter_count": sum(
+                p.numel() for p in self.head.parameters() if p.requires_grad
+            ),
+            "optimizer_settings": optimizer_settings(self.config),
+            "precision": "float32",
+            "tf32": False,
+            "weight_decay": 0.0,
+            "training_wall_seconds": self.training_wall_seconds,
+            "iterations": self.iterations,
+            "counters": self.counters,
+            "plateau": asdict(self.plateau),
+            "final": self.curve[-1] if self.curve else None,
+            "selected": {
+                k: v for k, v in self.best.items() if k not in ("state_dict", "buffers", "modes")
+            }
+            if self.best
+            else None,
+            "closure_evaluations": self.objective.evaluations,
+            "monitor_evaluations": self.objective.monitor_evaluations,
+            "hardware_history": self.hardware_history,
+            "mixed_hardware_timings": len(hardware_types) > 1,
+            "peak_allocated_bytes": torch.cuda.max_memory_allocated(self.device)
+            if self.device.type == "cuda"
+            else None,
+        }
+
+
+def scientific_identity(config: TrialConfig, metadata: dict) -> dict:
+    """Exclude GPU indices and hardware, but bind exact cache and selected connections."""
+    return {
+        "schema": 2,
+        "trial": asdict(config),
+        "cache_key": metadata["key"],
+        "cache_tensor_sha256": metadata["tensor_sha256"],
+        "selected_layers": metadata["selected_layers"],
+        "selected_feature_shapes": metadata["selected_feature_shapes"],
+        "versions": metadata["spec"]["versions"],
+        "strict_determinism": metadata["spec"]["strict_determinism"],
+    }
+
+
+def trial_directory(output: Path, trial_identity: dict) -> Path:
+    """Use full scientific digest, independent of scheduling and human labels."""
+    return output / shared.identity(trial_identity)
+
+
+def completed_result(directory: Path, trial_identity: dict) -> dict:
+    """Load an immutable result after checking identity, integrity and required artifacts."""
+    result = json.loads((directory / "result.json").read_text())
+    checksum = result.pop("result_sha256")
+    if shared.identity(result) != checksum:
+        raise ValueError("Result checksum mismatch.")
+    if result["identity"] != trial_identity:
+        raise ValueError("Completed result identity mismatch.")
+    required = ["identity.json", "checkpoint.pt", "curve.csv", "progress.json", "final.pt"]
+    if result["status"] not in ("converged", "not_converged", "failed"):
+        raise ValueError("Result does not have a terminal status.")
+    if result["status"] != "failed":
+        required.extend(["best.pt", "test_confusions.pt"])
+        if not math.isfinite(result["test"]["miou"]) or not math.isfinite(
+            result["selected"]["val_miou"]
+        ):
+            raise ValueError("Completed metrics must be finite.")
+    if not all((directory / name).is_file() for name in required):
+        raise ValueError(f"Incomplete completed trial in {directory}.")
+    return result
+
+
+def run_trial(
+    config: TrialConfig, caches: dict, metadata: dict, output: Path, *, resume: bool = False
+) -> dict:
+    """Reserve and exactly continue one paired initialization, never overwrite a result."""
+    device = torch.device(caches["train"].device)
+    trial_identity = scientific_identity(config, metadata)
+    directory = trial_directory(output, trial_identity)
+    output.mkdir(parents=True, exist_ok=True)
+    with FileLock(str(directory) + ".lock", timeout=0):
+        existing = directory.exists()
+        if existing:
+            if not resume:
+                raise FileExistsError(f"Trial {directory} exists; use --resume.")
+            if json.loads((directory / "identity.json").read_text()) != trial_identity:
+                raise ValueError("Trial identity mismatch.")
+            if (directory / "result.json").exists():
+                return completed_result(directory, trial_identity)
+        else:
+            directory.mkdir()
+            shared.atomic_json(directory / "identity.json", trial_identity)
+        shared.synchronize(device)
+        start = time.perf_counter()
+        shared.seed_everything(config.seed)
+        head = shared.make_head(
+            config.head, caches["train"], metadata["spec"]["num_classes"], config.hidden_dim
+        )
+        shared.synchronize(device)
+        setup_seconds = time.perf_counter() - start
+        store = TrialStore(directory, trial_identity)
+        run = ConvergenceRun(head, caches, config, store)
+        run.timings.seconds["setup"] += setup_seconds
+        if existing and (directory / "checkpoint.pt").exists():
+            run.restore(store.load())
+            store.write_checkpoint(run)
+            store.progress(run)
+        result = run.fit()
+        result.update(
+            identity=trial_identity,
+            trial_key=shared.identity(trial_identity),
+            cache_metadata=metadata,
+        )
+        shared.atomic_json(
+            directory / "result.json", {**result, "result_sha256": shared.identity(result)}
+        )
+        return result

--- a/scripts/_segmentation_features.py
+++ b/scripts/_segmentation_features.py
@@ -1,0 +1,568 @@
+"""Strict FP32 feature caches and decoder evaluation shared by the two studies."""
+
+import hashlib
+import json
+import os
+import platform
+import random
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import asdict, dataclass
+from importlib import import_module
+from importlib.metadata import PackageNotFoundError, version
+from itertools import pairwise
+from pathlib import Path
+from typing import IO, Any
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from filelock import FileLock
+from omegaconf import OmegaConf
+from torch import nn
+from torch.utils.data import DataLoader
+
+from torchgeo_bench.config import compose_config, instantiate
+from torchgeo_bench.datasets import get_bench_dataset_class, get_datasets
+from torchgeo_bench.models.interface import BenchModel
+from torchgeo_bench.models.segmentation_heads import (
+    ConvBlockHead,
+    DPTHead,
+    FPNHead,
+    LinearHead,
+    PatchLinearHead,
+)
+from torchgeo_bench.segmentation_probe import GPUTensorCache, SegmentationProbe
+
+HEADS = ("linear", "conv_block", "fpn", "dpt", "patch_linear")
+SPLITS = ("train", "val", "test")
+IGNORE_INDEX = 255
+
+
+class DivergedError(RuntimeError):
+    """A nonfinite objective, gradient or buffer ended a trial."""
+
+
+def identity(value: Any) -> str:
+    """Hash JSON-compatible scientific configuration canonically."""
+    return hashlib.sha256(
+        json.dumps(value, sort_keys=True, separators=(",", ":"), allow_nan=False).encode()
+    ).hexdigest()
+
+
+def tensor_digest(tensors: dict[str, torch.Tensor]) -> str:
+    """Fingerprint names, shapes, dtypes and exact tensor bytes."""
+    digest = hashlib.sha256()
+    for name, tensor in sorted(tensors.items()):
+        tensor = tensor.detach().cpu().contiguous()
+        digest.update(f"{name}:{tuple(tensor.shape)}:{tensor.dtype}".encode())
+        digest.update(tensor.reshape(-1).view(torch.uint8).numpy().tobytes())
+    return digest.hexdigest()
+
+
+def software_versions() -> dict:
+    """Identify installed dependencies and implementation, excluding session experiments."""
+    import torchgeo_bench
+
+    package = Path(torchgeo_bench.__file__).parent
+    scripts = Path(__file__).parent
+    paths = sorted(package.rglob("*.py")) + sorted(package.rglob("*.yaml"))
+    paths += [
+        scripts / name
+        for name in (
+            "_seg_sweep_common.py",
+            "_segmentation_features.py",
+            "_segmentation_convergence.py",
+            "_segmentation_study.py",
+            "run_segmentation_optimizer_study.py",
+            "run_segmentation_layer_study.py",
+        )
+    ]
+    digest = hashlib.sha256()
+    for path in paths:
+        digest.update(
+            str(path.relative_to(package if path.is_relative_to(package) else scripts)).encode()
+        )
+        digest.update(path.read_bytes())
+    packages = {
+        name: version(name)
+        for name in ("torch", "torchvision", "timm", "torchgeo", "geobenchv2", "numpy", "omegaconf")
+    }
+    try:
+        packages["transformers"] = version("transformers")
+    except PackageNotFoundError:  # allow-except: transformers is an optional dependency
+        packages["transformers"] = None
+    return {
+        "python": platform.python_version(),
+        "packages": packages,
+        "source_sha256": digest.hexdigest(),
+    }
+
+
+def hardware(device: torch.device) -> dict:
+    """Record hardware separately from scientific identity, including scheduling index."""
+    return {
+        "device": str(device),
+        "name": torch.cuda.get_device_name(device)
+        if device.type == "cuda"
+        else platform.processor(),
+        "platform": platform.platform(),
+        "torch_threads": torch.get_num_threads(),
+        "cuda": torch.version.cuda,
+        "cudnn": torch.backends.cudnn.version(),
+    }
+
+
+def seed_everything(seed: int) -> None:
+    """Reset initialization and minibatch RNGs independently of LR and scheduling."""
+    random.seed(seed)
+    np.random.seed(seed)  # noqa: NPY002 -- Seed upstream global NumPy users as well.
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+
+def configure_device(device: torch.device, *, strict: bool = True) -> None:
+    """Require deterministic FP32 computation without AMP or TF32."""
+    if device.type not in ("cpu", "cuda"):
+        raise ValueError("Only CPU and CUDA are supported.")
+    os.environ.setdefault("CUBLAS_WORKSPACE_CONFIG", ":4096:8")
+    if device.type == "cuda":
+        torch.cuda.set_device(device)
+    torch.use_deterministic_algorithms(True, warn_only=not strict)
+    torch.backends.cudnn.benchmark = False
+    torch.backends.cudnn.deterministic = True
+    torch.backends.cudnn.allow_tf32 = False
+    torch.backends.cuda.matmul.allow_tf32 = False
+
+
+def synchronize(device: torch.device) -> None:
+    """Wait for device work at timing boundaries."""
+    if device.type == "cuda":
+        torch.cuda.synchronize(device)
+
+
+@contextmanager
+def atomic_stream(path: Path, mode: str) -> Iterator[IO]:
+    """Durably replace an artifact under the caller's exclusive output lock."""
+    staging = path.with_name(path.name + ".writing")
+    try:
+        with staging.open(mode) as stream:
+            yield stream
+            stream.flush()
+            os.fsync(stream.fileno())
+        staging.replace(path)
+        directory_flag = getattr(os, "O_DIRECTORY", None)
+        if os.name != "nt" and directory_flag is not None:
+            descriptor = os.open(path.parent, os.O_RDONLY | directory_flag)
+            try:
+                os.fsync(descriptor)
+            finally:
+                os.close(descriptor)
+    finally:
+        staging.unlink(missing_ok=True)
+
+
+def atomic_json(path: Path, value: dict) -> None:
+    """Write strict JSON without exposing partial state."""
+    with atomic_stream(path, "w") as stream:
+        json.dump(value, stream, sort_keys=True, indent=2, allow_nan=False)
+        stream.write("\n")
+
+
+def atomic_save(path: Path, value: Any) -> None:
+    """Write a weights-only-loadable tensor artifact."""
+    with atomic_stream(path, "wb") as stream:
+        torch.save(value, stream)
+
+
+@dataclass(frozen=True)
+class ExtractionConfig:
+    """Raw-input extraction controls; the layer union is supplied separately."""
+
+    dataset: str = "burn_scars"
+    model: str = "timm/vit/vit_small_patch16_224"
+    bands: str = "rgb"
+    image_size: int = 224
+    normalization: str = "model_native"
+    extract_batch_size: int = 16
+    strict_determinism: bool = True
+
+    def __post_init__(self) -> None:
+        if self.bands not in ("rgb", "all"):
+            raise ValueError("bands must be rgb or all.")
+        if min(self.image_size, self.extract_batch_size) < 1:
+            raise ValueError("Image and extraction batch sizes must be positive.")
+
+
+def validate_layers(layers: list[str] | tuple[str, ...]) -> None:
+    """Reject empty, malformed or repeated feature connections."""
+    if not layers or any(not isinstance(name, str) or not name.strip() for name in layers):
+        raise ValueError("Layers must be nonempty strings.")
+    if len(set(layers)) != len(layers):
+        raise ValueError("Duplicate layers are not allowed.")
+
+
+def cache_spec(config: ExtractionConfig, layers: list[str]) -> dict:
+    """Resolve extraction identity without loading data or pretrained weights."""
+    validate_layers(layers)
+    bench = get_bench_dataset_class(config.dataset)()
+    if bench.task != "segmentation":
+        raise ValueError("This study requires a segmentation dataset.")
+    bands = bench.select_band_specs(bench.rgb_bands) if config.bands == "rgb" else bench.bands
+    cfg = compose_config([f"model={config.model}"])
+    return {
+        "schema": 1,
+        **asdict(config),
+        "split_counts": dict(bench.split_sizes),
+        "num_classes": bench.num_classes,
+        "model_config": OmegaConf.to_container(cfg.model, resolve=True),
+        "layers": layers,
+        "band_specs": [asdict(band) for band in bands],
+        "interpolation": "bilinear",
+        "mask_interpolation": "nearest",
+        "partition": "default",
+        "temporal_pool": "mean",
+        "dtype": "float32",
+        "extraction_seed": 0,
+        "versions": software_versions(),
+    }
+
+
+def cache_tensors(splits: dict) -> dict[str, torch.Tensor]:
+    """Flatten cache tensors for content fingerprinting."""
+    return {
+        f"{split}/{name}": tensor
+        for split, data in splits.items()
+        for name, tensor in [("masks", data["masks"]), *enumerate(data["features"])]
+    }
+
+
+def validate_cache(payload: dict, expected: dict) -> None:  # noqa: C901 -- Check all cache invariants.
+    """Refuse stale configuration, truncated splits, invalid geometry or corrupt bytes."""
+    metadata = payload["metadata"]
+    validate_layers(expected["layers"])
+    if metadata["spec"] != expected or metadata["key"] != identity(expected):
+        raise ValueError("Cache configuration mismatch; use a new cache path.")
+    if set(payload["splits"]) != set(SPLITS):
+        raise ValueError("Cache must contain exactly train, val and test.")
+    shapes = None
+    for split in SPLITS:
+        data = payload["splits"][split]
+        masks, features = data["masks"], data["features"]
+        n, size = expected["split_counts"][split], expected["image_size"]
+        if masks.dtype != torch.int64 or tuple(masks.shape) != (n, size, size):
+            raise ValueError(f"Invalid mask shape/dtype or split count in {split}.")
+        allowed = ((masks >= 0) & (masks < expected["num_classes"])) | (masks == IGNORE_INDEX)
+        if not allowed.all() or not (masks != IGNORE_INDEX).any():
+            raise ValueError(f"Invalid or entirely ignored labels in {split}.")
+        if len(features) != len(expected["layers"]):
+            raise ValueError(f"Wrong feature layer count in {split}.")
+        for tensor in features:
+            if (
+                tensor.dtype != torch.float32
+                or tensor.ndim != 4
+                or tensor.shape[0] != n
+                or min(tensor.shape) < 1
+                or tensor.requires_grad
+                or not torch.isfinite(tensor).all()
+            ):
+                raise ValueError(f"Invalid FP32 feature tensor in {split}.")
+        current = [list(t.shape[1:]) for t in features]
+        if shapes is not None and shapes != current:
+            raise ValueError("Feature geometry differs between splits.")
+        shapes = current
+    if metadata["feature_shapes"] != shapes:
+        raise ValueError("Cache geometry metadata mismatch.")
+    if tensor_digest(cache_tensors(payload["splits"])) != metadata["tensor_sha256"]:
+        raise ValueError("Cache tensor checksum mismatch.")
+
+
+def load_cache(path: Path, expected: dict) -> dict:
+    """Load only tensors/primitive metadata and verify before use."""
+    payload = torch.load(path, map_location="cpu", weights_only=True)
+    validate_cache(payload, expected)
+    return payload
+
+
+class FeatureExtractor(SegmentationProbe):
+    """Use probe hook/token handling without its fixed-224 dummy forward or decoder."""
+
+    def __init__(self, backbone: BenchModel, layers: list[str]) -> None:
+        nn.Module.__init__(self)
+        self.backbone, self.layer_names = backbone, layers
+        self.temporal_pool = "mean"
+        self._features = {}
+        self.hooks = []
+        self.register_hooks()
+
+    @torch.no_grad()
+    def extract(self, loader: DataLoader) -> dict:
+        """Encode each actual input once, optionally averaging temporal features."""
+        features: list[list[torch.Tensor]] = [[] for _ in self.layer_names]
+        masks = []
+        for batch in loader:
+            if isinstance(batch, dict):
+                image, mask = batch["image"], batch["mask"]
+            else:
+                image, mask = batch[:2]
+            image = image.to(device=self._backbone_device(), dtype=torch.float32)
+            steps = image.shape[1] if image.ndim == 5 else 0
+            if steps:
+                image = image.flatten(0, 1)
+            self._features.clear()
+            self.backbone(image)
+            for name, batches in zip(self.layer_names, features, strict=True):
+                value = self._process_feature(self._features[name])
+                if steps:
+                    value = self._pool_time(value, steps)
+                batches.append(value.detach().to(device="cpu", dtype=torch.float32))
+            if mask.ndim == 4 and mask.shape[1] == 1:
+                mask = mask.squeeze(1)
+            masks.append(mask.long().cpu())
+        return {"features": [torch.cat(batches) for batches in features], "masks": torch.cat(masks)}
+
+
+def prepare_cache(path: Path, spec: dict, device: torch.device, num_workers: int) -> dict:
+    """Extract complete official splits once through a frozen BenchModel wrapper."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with FileLock(str(path) + ".lock", timeout=0):
+        if path.exists():
+            return load_cache(path, spec)
+        configure_device(device, strict=spec["strict_determinism"])
+        seed_everything(spec["extraction_seed"])
+        start = time.perf_counter()
+        bench = get_bench_dataset_class(spec["dataset"])()
+        bands = bench.select_band_specs(bench.rgb_bands) if spec["bands"] == "rgb" else bench.bands
+        _, train, val, test = get_datasets(
+            dataset_name=spec["dataset"],
+            return_val=True,
+            batch_size=spec["extract_batch_size"],
+            num_workers=num_workers,
+            image_size=spec["image_size"],
+            interpolation=spec["interpolation"],
+            bands=spec["bands"],
+        )
+        model = instantiate(spec["model_config"], bands=bands, normalization=spec["normalization"])
+        if not isinstance(model, BenchModel):
+            raise TypeError("The model configuration must instantiate a BenchModel.")
+        model.to(device=device, dtype=torch.float32).eval().requires_grad_(False)
+        probe = FeatureExtractor(model, spec["layers"])
+        metadata = {
+            "spec": spec,
+            "key": identity(spec),
+            "backbone_state_sha256": tensor_digest(model.state_dict()),
+            "hardware": hardware(device),
+            "extraction_seconds": {},
+        }
+        synchronize(device)
+        metadata["setup_seconds"] = time.perf_counter() - start
+        splits = {}
+        try:
+            for split, loader in zip(SPLITS, (train, val, test), strict=True):
+                if len(loader.dataset) != spec["split_counts"][split]:
+                    raise ValueError(f"{split} must use the entire official split.")
+                ordered = DataLoader(
+                    loader.dataset,
+                    batch_size=spec["extract_batch_size"],
+                    shuffle=False,
+                    num_workers=num_workers,
+                    collate_fn=loader.collate_fn,
+                )
+                synchronize(device)
+                start = time.perf_counter()
+                splits[split] = probe.extract(ordered)
+                synchronize(device)
+                metadata["extraction_seconds"][split] = time.perf_counter() - start
+        finally:
+            for hook in probe.hooks:
+                hook.remove()
+        metadata["feature_shapes"] = [list(t.shape[1:]) for t in splits["train"]["features"]]
+        metadata["tensor_sha256"] = tensor_digest(cache_tensors(splits))
+        payload = {"metadata": metadata, "splits": splits}
+        validate_cache(payload, spec)
+        atomic_save(path, payload)
+        return payload
+
+
+def select_layers(payload: dict, layers: list[str]) -> tuple[dict, dict]:
+    """Select a named ordered subset without copying tensors or losing union provenance."""
+    validate_layers(layers)
+    metadata = payload["metadata"]
+    available = metadata["spec"]["layers"]
+    if not set(layers) <= set(available):
+        raise ValueError("Requested layer is absent from the union cache.")
+    indices = [available.index(name) for name in layers]
+    selected = {
+        split: {"masks": data["masks"], "features": [data["features"][i] for i in indices]}
+        for split, data in payload["splits"].items()
+    }
+    return selected, {
+        **metadata,
+        "selected_layers": layers,
+        "selected_feature_shapes": [metadata["feature_shapes"][i] for i in indices],
+    }
+
+
+def device_cache(data: dict, device: torch.device) -> GPUTensorCache:
+    """Keep resident features in FP32, including on CUDA."""
+    return GPUTensorCache(
+        [t.to(device=device, dtype=torch.float32).contiguous() for t in data["features"]],
+        data["masks"].to(device=device, dtype=torch.long).contiguous(),
+        device,
+    )
+
+
+def check_head_layers(head: str, layers: list[str] | tuple[str, ...]) -> None:
+    """Refuse incompatible connections instead of ignoring layers or changing heads."""
+    validate_layers(layers)
+    if head not in HEADS:
+        raise ValueError(f"Unknown head {head}.")
+    if head == "dpt" and len(layers) != 4:
+        raise ValueError("DPT requires exactly four layers.")
+    if head == "patch_linear" and len(layers) != 1:
+        raise ValueError("Patch-linear requires exactly one layer.")
+
+
+def preflight_heads(heads: list[str]) -> None:
+    """Fail before extraction if a requested decoder's optional dependency is unavailable."""
+    if "dpt" not in heads:
+        return
+    try:
+        module = import_module("transformers.models.dpt.modeling_dpt")
+    except ModuleNotFoundError as error:  # allow-except: explain a missing optional dependency
+        if error.name == "transformers":
+            raise ModuleNotFoundError(
+                "The dpt head requires the optional transformers dependency; "
+                "install it or choose --heads without dpt."
+            ) from error
+        raise
+    if not hasattr(module, "DPTFeatureFusionLayer"):
+        raise ImportError("Installed transformers lacks the DPTFeatureFusionLayer decoder API.")
+
+
+def make_head(name: str, cache: GPUTensorCache, num_classes: int, hidden_dim: int) -> nn.Module:
+    """Materialize lazy parameters using the actual selected feature/mask geometry."""
+    check_head_layers(name, [str(i) for i in range(len(cache.layer_tensors))])
+    shapes = [tuple(t.shape[-2:]) for t in cache.layer_tensors]
+    if name in ("fpn", "dpt") and any(h > nh or w > nw for (h, w), (nh, nw) in pairwise(shapes)):
+        raise ValueError("FPN/DPT features must be ordered coarse-to-fine.")
+    constructors = {
+        "linear": LinearHead,
+        "conv_block": ConvBlockHead,
+        "fpn": FPNHead,
+        "dpt": DPTHead,
+        "patch_linear": PatchLinearHead,
+    }
+    kwargs = {} if name in ("linear", "patch_linear") else {"hidden_dim": hidden_dim}
+    head = constructors[name]([t.shape[1] for t in cache.layer_tensors], num_classes, **kwargs)
+    head.to(device=cache.device, dtype=torch.float32).eval()
+    with torch.no_grad():
+        head([t[:1].clone() for t in cache.layer_tensors], *cache.masks.shape[-2:])
+    return head.train()
+
+
+def snapshot(module: nn.Module) -> dict[str, torch.Tensor]:
+    """Copy parameters and persistent normalization buffers to CPU."""
+    return {name: tensor.detach().cpu().clone() for name, tensor in module.state_dict().items()}
+
+
+def require_finite(tensors: Iterator[torch.Tensor] | list[torch.Tensor], stage: str) -> None:
+    """Raise a specific divergence error rather than publish NaNs."""
+    if any(not torch.isfinite(tensor).all() for tensor in tensors):
+        raise DivergedError(f"Nonfinite {stage}.")
+
+
+def summed_cross_entropy(logits: torch.Tensor, masks: torch.Tensor) -> torch.Tensor:
+    """Use deterministic 2-D CE, avoiding CUDA's atomic NCHW reduction."""
+    pixels = logits.permute(0, 2, 3, 1).reshape(-1, logits.shape[1])
+    return F.cross_entropy(pixels, masks.reshape(-1), ignore_index=IGNORE_INDEX, reduction="sum")
+
+
+def reject_stochastic_modules(head: nn.Module) -> None:
+    """Reject stochastic activations incompatible with deterministic closures."""
+    for module in head.modules():
+        if isinstance(
+            module,
+            (nn.modules.dropout._DropoutNd, nn.AlphaDropout, nn.FeatureAlphaDropout, nn.RReLU),
+        ) or type(module).__name__ in ("DropPath", "StochasticDepth"):
+            raise ValueError(f"Closures cannot use stochastic module {type(module).__name__}.")
+
+
+@torch.no_grad()
+def recalibrate_bn(head: nn.Module, cache: GPUTensorCache, batch_size: int) -> bool:
+    """Reset and cumulatively recalibrate BN on ordered training images only."""
+    modules = [m for m in head.modules() if isinstance(m, nn.modules.batchnorm._BatchNorm)]
+    if not modules:
+        return False
+    momenta = [m.momentum for m in modules]
+    head.train()
+    try:
+        for module in modules:
+            module.reset_running_stats()
+            module.momentum = None
+        for features, masks in cache.ordered_batches(batch_size):
+            require_finite([head(features, *masks.shape[-2:])], "BN calibration")
+        require_finite(iter(head.buffers()), "BN buffers")
+    finally:
+        for module, momentum in zip(modules, momenta, strict=True):
+            module.momentum = momentum
+    return True
+
+
+def per_image_confusions(
+    predictions: torch.Tensor, masks: torch.Tensor, num_classes: int
+) -> torch.Tensor:
+    """Return (N,C,C) true-row/predicted-column counts excluding ignored labels."""
+    valid = (masks >= 0) & (masks < num_classes) & (masks != IGNORE_INDEX)
+    offsets = torch.arange(len(masks), device=masks.device)[:, None, None] * num_classes**2
+    indices = (offsets + masks * num_classes + predictions)[valid]
+    return torch.bincount(indices, minlength=len(masks) * num_classes**2).reshape(
+        len(masks), num_classes, num_classes
+    )
+
+
+def macro_miou(confusion: torch.Tensor) -> float:
+    """Macro-average IoU, assigning zero to zero-denominator classes."""
+    matrix = confusion.double()
+    intersection = matrix.diagonal()
+    union = matrix.sum(0) + matrix.sum(1) - intersection
+    return float((intersection / union.clamp_min(1)).mean())
+
+
+@torch.no_grad()
+def evaluate(head: nn.Module, cache: GPUTensorCache, batch_size: int) -> dict:
+    """Evaluate a frozen head without updating BN."""
+    head.eval()
+    confusions = []
+    loss_sum = torch.zeros((), dtype=torch.float64, device=cache.device)
+    for features, masks in cache.ordered_batches(batch_size):
+        logits = head(features, *masks.shape[-2:])
+        require_finite([logits], "evaluation logits")
+        loss_sum += summed_cross_entropy(logits, masks)
+        confusions.append(per_image_confusions(logits.argmax(1), masks, logits.shape[1]).cpu())
+    require_finite([loss_sum], "evaluation loss")
+    per_image = torch.cat(confusions)
+    return {
+        "miou": macro_miou(per_image.sum(0)),
+        "ce": float(loss_sum / cache.masks.ne(IGNORE_INDEX).sum()),
+        "per_image_confusions": per_image,
+    }
+
+
+def bootstrap_interval(confusions: torch.Tensor, samples: int, seed: int) -> list[float]:
+    """Return deterministic image-bootstrap 95% CIs, not seed-variance intervals."""
+    generator = torch.Generator().manual_seed(seed)
+    scores = [
+        macro_miou(
+            confusions[torch.randint(len(confusions), (len(confusions),), generator=generator)].sum(
+                0
+            )
+        )
+        for _ in range(samples)
+    ]
+    return torch.quantile(
+        torch.tensor(scores, dtype=torch.float64),
+        torch.tensor([0.025, 0.975], dtype=torch.float64),
+    ).tolist()

--- a/scripts/_segmentation_study.py
+++ b/scripts/_segmentation_study.py
@@ -1,0 +1,672 @@
+"""Shared CLI, multi-GPU scheduling and atomic CSV reporting for decoder studies."""
+
+import argparse
+import csv
+import json
+import logging
+import queue
+import signal
+import statistics
+import sys
+from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+import _segmentation_convergence as convergence
+import _segmentation_features as features
+import torch
+from _seg_sweep_common import BaseGpuRunner, RunnerConfig, parse_gpus, resolve_path
+from filelock import FileLock
+
+logger = logging.getLogger(__name__)
+ROOT = Path(__file__).resolve().parents[1]
+LAYER_PRESETS = {
+    "deep_single": ["blocks.11"],
+    "late_single": ["blocks.8"],
+    "mid_single": ["blocks.5"],
+    "shallow_single": ["blocks.2"],
+    "late_four": ["blocks.11", "blocks.10", "blocks.9", "blocks.8"],
+    "spread_four": ["blocks.11", "blocks.8", "blocks.5", "blocks.2"],
+    "early_four": ["blocks.5", "blocks.4", "blocks.3", "blocks.2"],
+}
+
+
+@dataclass(frozen=True)
+class Job:
+    """One decoder, connection set, optimizer, LR and paired seed."""
+
+    trial: convergence.TrialConfig
+    layer_group: str
+    layers: tuple[str, ...]
+
+    @property
+    def job_id(self) -> str:
+        """Return a scheduling-independent identifier, without redundant group aliases."""
+        return features.identity({"trial": asdict(self.trial), "layers": self.layers})
+
+
+@dataclass(frozen=True)
+class StudyConfig(RunnerConfig):
+    """Runtime locations and resources, deliberately outside scientific identity."""
+
+    script: Path
+    cache: Path
+    output_dir: Path
+    resume: bool
+
+
+def selected_gpus(value: str, *, dry_run: bool = False) -> list[int]:
+    """Select all visible GPUs by default; reject repeats rather than oversubscribe."""
+    if dry_run and not torch.cuda.device_count():
+        gpus = [0] if value == "all" else [int(item) for item in value.split(",")]
+        logger.info("No CUDA devices visible: dry-run commands use hypothetical GPU indices.")
+        if not gpus or min(gpus) < 0:
+            raise ValueError("GPU indices must be nonnegative.")
+    else:
+        gpus = parse_gpus(value)
+    if len(set(gpus)) != len(gpus):
+        raise ValueError("Duplicate GPU indices are not allowed.")
+    return gpus
+
+
+def layer_groups(args: argparse.Namespace, suite: str) -> dict[str, list[str]]:
+    """Validate named ordered groups and refuse aliases for identical connections."""
+    if suite == "optimizer":
+        features.validate_layers(args.layers)
+        return {"connections": list(args.layers)}
+    if args.layer_groups_json:
+        groups = json.loads(args.layer_groups_json, object_pairs_hook=unique_group_names)
+        if not isinstance(groups, dict) or not groups:
+            raise ValueError("--layer-groups-json must be a nonempty JSON object.")
+    else:
+        if len(set(args.layer_groups)) != len(args.layer_groups):
+            raise ValueError("Duplicate layer group names.")
+        groups = {name: LAYER_PRESETS[name] for name in args.layer_groups}
+    for name, layers in groups.items():
+        if not isinstance(name, str) or not name.strip() or not isinstance(layers, list):
+            raise ValueError("Layer groups map nonempty names to lists of layer names.")
+        features.validate_layers(layers)
+    if len({tuple(layers) for layers in groups.values()}) != len(groups):
+        raise ValueError("Duplicate layer connections under different group names.")
+    return groups
+
+
+def unique_group_names(pairs: list[tuple[str, object]]) -> dict:
+    """Reject duplicate JSON keys instead of silently replacing a requested group."""
+    groups = dict(pairs)
+    if len(groups) != len(pairs):
+        raise ValueError("Duplicate layer group names in JSON.")
+    return groups
+
+
+def build_jobs(args: argparse.Namespace, suite: str) -> list[Job]:
+    """Build paired seeds with all Adam jobs before L-BFGS and explicit compatibility."""
+    groups = layer_groups(args, suite)
+    for values in (args.heads, args.seeds, args.adam_lrs, args.lbfgs_lrs):
+        if not values or len(set(values)) != len(values):
+            raise ValueError("Empty or duplicate heads, seeds or learning rates.")
+    options = {
+        name: getattr(args, name)
+        for name in convergence.TrialConfig.__dataclass_fields__
+        if name not in ("head", "optimizer", "lr", "seed")
+    }
+    jobs = []
+    for optimizer, rates in (("adam", args.adam_lrs), ("lbfgs", args.lbfgs_lrs)):
+        if suite == "layer" and optimizer != "adam":
+            continue
+        if args.phase not in ("both", optimizer):
+            continue
+        for head in args.heads:
+            for group, layers in groups.items():
+                selected = layers
+                if suite == "optimizer" and head == "patch_linear":
+                    selected = layers[:1]
+                    logger.info("patch_linear explicitly uses only deepest layer %s.", selected)
+                features.check_head_layers(head, selected)
+                jobs.extend(
+                    Job(
+                        convergence.TrialConfig(head, optimizer, lr, seed=seed, **options),
+                        group,
+                        tuple(selected),
+                    )
+                    for seed in args.seeds
+                    for lr in rates
+                )
+    if not jobs or len({job.job_id for job in jobs}) != len(jobs):
+        raise ValueError("Empty or ambiguous duplicate trial grid.")
+    return jobs
+
+
+def layer_union(jobs: list[Job]) -> list[str]:
+    """Preserve first occurrence order while extracting every required connection once."""
+    return list(dict.fromkeys(name for job in jobs for name in job.layers))
+
+
+def job_identity(job: Job, metadata: dict) -> dict:
+    """Bind a trial to its named subset and the validated union cache."""
+    indices = [metadata["spec"]["layers"].index(name) for name in job.layers]
+    selected = {
+        **metadata,
+        "selected_layers": list(job.layers),
+        "selected_feature_shapes": [metadata["feature_shapes"][i] for i in indices],
+    }
+    return convergence.scientific_identity(job.trial, selected)
+
+
+def result_row(job: Job, metadata: dict, result: dict | None) -> dict:
+    """Flatten scientific status, selected performance and comparable timing counters."""
+    spec = metadata["spec"]
+    selected = (result or {}).get("selected") or {}
+    final = (result or {}).get("final") or {}
+    timing = (result or {}).get("timings_seconds") or {}
+    ci = (result or {}).get("test_miou_ci95", [None, None])
+    row = {
+        "job_id": job.job_id,
+        "trial_key": features.identity(job_identity(job, metadata)),
+        "dataset": spec["dataset"],
+        "model": spec["model"],
+        "head": job.trial.head,
+        "layer_group": job.layer_group,
+        "layers": json.dumps(job.layers),
+        "layer_count": len(job.layers),
+        "feature_shapes": json.dumps(job_identity(job, metadata)["selected_feature_shapes"]),
+        "bands": spec["bands"],
+        "image_size": spec["image_size"],
+        "normalization": spec["normalization"],
+        "optimizer": job.trial.optimizer,
+        "lr": job.trial.lr,
+        "seed": job.trial.seed,
+        "batch_size": job.trial.batch_size,
+        "hidden_dim": job.trial.hidden_dim,
+        "status": (result or {}).get("status", "incomplete"),
+        "stop_reason": (result or {}).get("stop_reason"),
+        "stationary": (result or {}).get("stationary"),
+        "failure": (result or {}).get("failure"),
+        "best_val_miou": selected.get("val_miou"),
+        "best_val_ce": selected.get("val_ce"),
+        "test_miou": (result or {}).get("test", {}).get("miou"),
+        "test_miou_ci95_low": ci[0],
+        "test_miou_ci95_high": ci[1],
+        "parameter_count": (result or {}).get("parameter_count"),
+        "trainable_parameter_count": (result or {}).get("trainable_parameter_count"),
+        "optimization_seconds": timing.get("optimization"),
+        "training_wall_seconds": (result or {}).get("training_wall_seconds"),
+        "selected_optimization_seconds": selected.get("optimization_seconds"),
+        "selected_training_wall_seconds": selected.get("training_wall_seconds"),
+        "selected_iterations": selected.get("iterations"),
+        "iterations": (result or {}).get("iterations"),
+        "final_train_ce": final.get("train_ce"),
+        "final_gradient_inf_norm": final.get("gradient_inf_norm"),
+        "initial_state_sha256": (result or {}).get("initial_state_sha256"),
+        "cache_key": metadata["key"],
+        "cache_tensor_sha256": metadata["tensor_sha256"],
+        "hardware_history": json.dumps((result or {}).get("hardware_history", []), sort_keys=True),
+        "mixed_hardware_timings": (result or {}).get("mixed_hardware_timings"),
+    }
+    for name in (
+        "blocks",
+        "epochs",
+        "optimizer_step_calls",
+        "optimizer_updates",
+        "samples",
+        "calibration_passes",
+        "unchanged_blocks",
+        "stalled_iteration_blocks",
+    ):
+        row[name] = (result or {}).get("counters", {}).get(name)
+    for name in ("closure_evaluations", "monitor_evaluations"):
+        row[name] = (result or {}).get(name)
+    for name in (
+        "lbfgs_n_iter",
+        "lbfgs_func_evals",
+        "lbfgs_history_length",
+        "optimization_data_passes",
+        "recent_ce_range",
+        "recent_ce_half_mean_decrease",
+        "recent_ce_tolerance",
+    ):
+        row[name] = final.get(name)
+    row.update(
+        {
+            f"{stage}_seconds": timing.get(stage)
+            for stage in convergence.STAGES
+            if stage != "optimization"
+        }
+    )
+    return row
+
+
+def validation_summary(rows: list[dict]) -> list[dict]:
+    """Choose one LR by mean validation across paired seeds, never per-trial test score.
+
+    A summary is withheld for an incomplete/failed grid. Standard deviations are
+    across seeds; per-image test CIs remain in the raw CSV and are not averaged
+    into an incorrectly labeled aggregate confidence interval.
+    """
+    groups = defaultdict(list)
+    for row in rows:
+        groups[(row["head"], row["layer_group"], row["optimizer"])].append(row)
+    summary = []
+    for (head, group, optimizer), candidates in groups.items():
+        record = {
+            "head": head,
+            "layer_group": group,
+            "optimizer": optimizer,
+            "dataset": candidates[0]["dataset"],
+            "model": candidates[0]["model"],
+            "layers": candidates[0]["layers"],
+            "layer_count": candidates[0]["layer_count"],
+            "selection_status": "incomplete_grid",
+            "selected_lr": None,
+            "seeds": None,
+            "parameter_count": None,
+            "mean_best_val_miou": None,
+            "mean_test_miou": None,
+            "std_test_miou": None,
+            "mean_optimization_seconds": None,
+            "mean_training_wall_seconds": None,
+            "mean_selected_optimization_seconds": None,
+            "converged_seeds": None,
+            "stationary_seeds": None,
+            "mixed_hardware_timings": None,
+        }
+        if any(row["status"] not in ("converged", "not_converged") for row in candidates):
+            summary.append(record)
+            continue
+        rates = defaultdict(list)
+        for row in candidates:
+            rates[row["lr"]].append(row)
+        seed_sets = [sorted(row["seed"] for row in values) for values in rates.values()]
+        if any(seeds != seed_sets[0] or len(set(seeds)) != len(seeds) for seeds in seed_sets):
+            raise ValueError("LR selection requires identical unique paired seeds.")
+        lr = min(
+            rates,
+            key=lambda rate: (-statistics.mean(row["best_val_miou"] for row in rates[rate]), rate),
+        )
+        chosen = rates[lr]
+        hardware_types = {
+            features.identity({k: v for k, v in device.items() if k != "device"})
+            for row in chosen
+            for device in json.loads(row["hardware_history"])
+        }
+        record.update(
+            selection_status="validation_selected",
+            selected_lr=lr,
+            seeds=json.dumps(seed_sets[0]),
+            parameter_count=chosen[0]["parameter_count"],
+            mean_best_val_miou=statistics.mean(row["best_val_miou"] for row in chosen),
+            mean_test_miou=statistics.mean(row["test_miou"] for row in chosen),
+            std_test_miou=statistics.stdev(row["test_miou"] for row in chosen)
+            if len(chosen) > 1
+            else 0.0,
+            mean_optimization_seconds=statistics.mean(
+                row["optimization_seconds"] for row in chosen
+            ),
+            mean_training_wall_seconds=statistics.mean(
+                row["training_wall_seconds"] for row in chosen
+            ),
+            mean_selected_optimization_seconds=statistics.mean(
+                row["selected_optimization_seconds"] for row in chosen
+            ),
+            converged_seeds=sum(row["status"] == "converged" for row in chosen),
+            stationary_seeds=sum(row["stationary"] for row in chosen),
+            mixed_hardware_timings=len(hardware_types) > 1
+            or any(row["mixed_hardware_timings"] for row in chosen),
+        )
+        summary.append(record)
+    return summary
+
+
+def atomic_csv(path: Path, rows: list[dict]) -> None:
+    """Replace a complete CSV under the caller's aggregate lock."""
+    with features.atomic_stream(path, "w") as stream:
+        writer = csv.DictWriter(stream, fieldnames=list(rows[0]))
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def aggregate(output: Path, jobs: list[Job], metadata: dict) -> None:
+    """Regenerate raw/selected CSVs from immutable results, retaining incomplete rows."""
+    with FileLock(str(output / "aggregate.lock")):
+        rows = []
+        for job in jobs:
+            expected = job_identity(job, metadata)
+            directory = convergence.trial_directory(output / "trials", expected)
+            result = (
+                convergence.completed_result(directory, expected)
+                if (directory / "result.json").exists()
+                else None
+            )
+            rows.append(result_row(job, metadata, result))
+        atomic_csv(output / "combined.csv", rows)
+        atomic_csv(output / "validation_selected.csv", validation_summary(rows))
+
+
+class StudyRunner(BaseGpuRunner):
+    """Schedule one subprocess per trial, with a global Adam-before-L-BFGS barrier."""
+
+    config: StudyConfig
+
+    def __init__(self, config: StudyConfig, jobs: list[Job], spec: dict, metadata: dict) -> None:
+        super().__init__(config, jobs)
+        self.spec, self.metadata = spec, metadata
+
+    def _summary_extra(self) -> dict:
+        return {"output_dir": str(self.config.output_dir), "cache": str(self.config.cache)}
+
+    def _command(self, job: Job, gpu: int, attempt: int) -> list[str]:  # noqa: ARG002
+        command = [
+            sys.executable,
+            str(self.config.script),
+            "--worker",
+            str(self.config.state_dir / "jobs" / f"{job.job_id}.json"),
+            "--device",
+            f"cuda:{gpu}",
+            "--cache",
+            str(self.config.cache),
+            "--output-dir",
+            str(self.config.output_dir),
+        ]
+        if self.config.resume:
+            command.append("--resume")
+        return command
+
+    def _is_complete(self, job: Job) -> bool:
+        expected = job_identity(job, self.metadata)
+        directory = convergence.trial_directory(self.config.output_dir / "trials", expected)
+        if not (directory / "result.json").exists():
+            return False
+        result = convergence.completed_result(directory, expected)
+        if result["status"] == "failed":
+            raise RuntimeError(
+                f"Immutable failed trial {directory}; inspect diagnostics and use a new study output."
+            )
+        return True
+
+    def _run_job(self, job: Job, gpu: int) -> bool:
+        success = self._run_attempt(job, gpu, 1) and self._is_complete(job)
+        aggregate(self.config.output_dir, self.jobs, self.metadata)
+        return success
+
+    def _work_gpu(self, gpu: int, jobs: queue.Queue) -> None:
+        while not self.stop_requested.is_set():
+            try:
+                job = jobs.get_nowait()
+            except queue.Empty:  # allow-except: this worker has no more queued jobs
+                return
+            success = False
+            with self.state_lock:
+                self.counts["queued"] -= 1
+                self.counts["running"] += 1
+                self._write_summary_locked()
+            try:
+                success = self._run_job(job, gpu)
+            finally:
+                with self.state_lock:
+                    self.counts["running"] -= 1
+                    self.counts["completed" if success else "failed"] += 1
+                    if not success:
+                        self.failed_jobs.append(self._failed_record(job, gpu))
+                    self._write_summary_locked()
+                jobs.task_done()
+
+    def _dispatch(self, pending: list[Job]) -> None:
+        jobs: queue.Queue = queue.Queue()
+        for job in pending:
+            jobs.put(job)
+        self.counts["queued"] = len(pending)
+        with ThreadPoolExecutor(max_workers=len(self.config.gpus)) as executor:
+            futures = [executor.submit(self._work_gpu, gpu, jobs) for gpu in self.config.gpus]
+            for future in futures:
+                future.result()  # Unlike bare threads, worker exceptions reach the CLI.
+        if self.counts["failed"] or self.stop_requested.is_set():
+            raise RuntimeError("Study interrupted or trial failed; inspect state/logs and resume.")
+
+    def run(self) -> None:
+        """Write worker specifications, skip only verified results and dispatch both phases."""
+        self.log_dir.mkdir(parents=True, exist_ok=True)
+        manifest_dir = self.config.state_dir / "jobs"
+        manifest_dir.mkdir(parents=True, exist_ok=True)
+        for job in self.jobs:
+            manifest = {
+                "job": asdict(job),
+                "cache_spec": self.spec,
+                "cache_tensor_sha256": self.metadata["tensor_sha256"],
+            }
+            path = manifest_dir / f"{job.job_id}.json"
+            if path.exists() and json.loads(path.read_text()) != json.loads(json.dumps(manifest)):
+                raise ValueError("Worker manifest identity mismatch.")
+            features.atomic_json(path, manifest)
+        try:
+            for optimizer in ("adam", "lbfgs"):
+                phase = [job for job in self.jobs if job.trial.optimizer == optimizer]
+                pending = []
+                for job in phase:
+                    if self._is_complete(job):
+                        self.counts["skipped_existing"] += 1
+                    else:
+                        pending.append(job)
+                self._dispatch(pending)
+            missing = [job.job_id for job in self.jobs if not self._is_complete(job)]
+            if missing:
+                raise RuntimeError(f"Missing completed trials: {missing}")
+        finally:
+            aggregate(self.config.output_dir, self.jobs, self.metadata)
+            with self.state_lock:
+                self._write_summary_locked()
+
+
+def run_worker(args: argparse.Namespace) -> None:
+    """Execute exactly one validated manifest using the same production script."""
+    manifest = json.loads(args.worker.read_text())
+    spec = manifest["cache_spec"]
+    job_data = manifest["job"]
+    trial = convergence.TrialConfig(**job_data["trial"])
+    features.check_head_layers(trial.head, job_data["layers"])
+    features.preflight_heads([trial.head])
+    if spec["versions"] != features.software_versions():
+        raise ValueError("Worker source/dependency identity changed after scheduling.")
+    device = torch.device(args.device)
+    features.configure_device(device, strict=spec["strict_determinism"])
+    payload = features.load_cache(args.cache, spec)
+    if payload["metadata"]["tensor_sha256"] != manifest["cache_tensor_sha256"]:
+        raise ValueError("Worker cache checksum differs from scheduled cache.")
+    selected, metadata = features.select_layers(payload, job_data["layers"])
+    caches = {split: features.device_cache(data, device) for split, data in selected.items()}
+    result = convergence.run_trial(
+        trial, caches, metadata, args.output_dir / "trials", resume=args.resume
+    )
+    if result["status"] == "failed":
+        raise features.DivergedError(result["failure"])
+
+
+def build_parser(suite: str, doc: str) -> argparse.ArgumentParser:
+    """Expose study controls without a time budget or implicit safety caps."""
+    parser = argparse.ArgumentParser(
+        description=doc, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--dataset", default="burn_scars")
+    parser.add_argument("--model", default="timm/vit/vit_small_patch16_224")
+    parser.add_argument("--bands", choices=("rgb", "all"), default="rgb")
+    parser.add_argument("--image-size", type=int, default=224)
+    parser.add_argument(
+        "--normalization",
+        default="model_native",
+        choices=("model_native", "bandspec_zscore", "minmax", "minmax_zscore", "identity"),
+    )
+    parser.add_argument("--extract-batch-size", type=int, default=16)
+    parser.add_argument("--num-workers", type=int, default=4)
+    parser.add_argument(
+        "--gpus", default="all", help="all (default) or unique visible indices, e.g. 0,2."
+    )
+    parser.add_argument(
+        "--cache",
+        type=Path,
+        help="Default: OUTPUT/features.pt; exact compatible union caches may be reused.",
+    )
+    parser.add_argument(
+        "--output-dir", type=Path, default=Path(f"results/segmentation_{suite}_study")
+    )
+    parser.add_argument(
+        "--heads",
+        nargs="+",
+        choices=features.HEADS,
+        default=list(features.HEADS) if suite == "optimizer" else ["linear", "conv_block", "fpn"],
+    )
+    parser.add_argument("--seeds", nargs="+", type=int, default=[0, 1, 2])
+    parser.add_argument(
+        "--adam-lrs",
+        nargs="+",
+        type=float,
+        default=[1e-4, 3e-4, 1e-3, 3e-3, 1e-2, 3e-2]
+        if suite == "optimizer"
+        else [1e-4, 1e-3, 1e-2],
+    )
+    parser.add_argument(
+        "--lbfgs-lrs",
+        nargs="+",
+        type=float,
+        default=[0.3, 1.0],
+        help=argparse.SUPPRESS if suite == "layer" else None,
+    )
+    parser.add_argument(
+        "--phase",
+        choices=("adam", "lbfgs", "both") if suite == "optimizer" else ("adam",),
+        default="both" if suite == "optimizer" else "adam",
+    )
+    parser.add_argument("--batch-size", type=int, default=8)
+    parser.add_argument("--hidden-dim", type=int, default=256)
+    parser.add_argument(
+        "--check-every", type=int, default=5, help="Adam epochs between full-objective checks."
+    )
+    parser.add_argument(
+        "--lbfgs-iterations",
+        type=int,
+        default=20,
+        help="Internal L-BFGS iterations per monitored chunk.",
+    )
+    parser.add_argument("--history-size", type=int, default=10)
+    parser.add_argument(
+        "--patience",
+        type=int,
+        default=10,
+        help="Historical-best patience and recent-window checks (at least two for the window).",
+    )
+    parser.add_argument(
+        "--min-iterations",
+        type=int,
+        default=50,
+        help="Start collecting recent-loss checks at this many Adam epochs / L-BFGS iterations.",
+    )
+    parser.add_argument("--absolute-tol", type=float, default=1e-5)
+    parser.add_argument("--relative-tol", type=float, default=1e-4)
+    parser.add_argument("--gradient-tol", type=float, default=1e-7)
+    parser.add_argument("--numerical-patience", type=int, default=3)
+    parser.add_argument(
+        "--max-iterations", type=int, help="Optional safety cap: never implies convergence."
+    )
+    parser.add_argument("--bootstrap", type=int, default=1000)
+    parser.add_argument("--resume", action="store_true")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Log grid and subprocess commands; no data, downloads, cache or output writes.",
+    )
+    parser.add_argument("--strict-determinism", action=argparse.BooleanOptionalAction, default=True)
+    if suite == "optimizer":
+        parser.add_argument(
+            "--layers",
+            nargs="+",
+            default=LAYER_PRESETS["spread_four"],
+            help="Ordered deepest-first connections; patch_linear explicitly uses only the first.",
+        )
+    else:
+        groups = parser.add_mutually_exclusive_group()
+        groups.add_argument(
+            "--layer-groups", nargs="+", choices=list(LAYER_PRESETS), default=list(LAYER_PRESETS)
+        )
+        groups.add_argument(
+            "--layer-groups-json",
+            help='Custom ordered connections, e.g. \'{"deep":["blocks.11"]}\'.',
+        )
+    parser.add_argument("--worker", type=Path, help=argparse.SUPPRESS)
+    parser.add_argument("--device", default="cuda:0", help=argparse.SUPPRESS)
+    return parser
+
+
+def main(suite: str, doc: str, argv: list[str] | None = None) -> None:
+    """Prepare a single union cache and schedule independent, restartable trial workers."""
+    args = build_parser(suite, doc).parse_args(argv)
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    if args.worker:
+        run_worker(args)
+        return
+    if args.num_workers < 0:
+        raise ValueError("num_workers must be nonnegative.")
+    jobs = build_jobs(args, suite)
+    features.preflight_heads([] if args.dry_run else args.heads)
+    gpus = selected_gpus(args.gpus, dry_run=args.dry_run)
+    extraction = features.ExtractionConfig(
+        **{name: getattr(args, name) for name in features.ExtractionConfig.__dataclass_fields__}
+    )
+    spec = features.cache_spec(extraction, layer_union(jobs))
+    output = resolve_path(ROOT, args.output_dir)
+    cache = resolve_path(ROOT, args.cache) if args.cache else output / "features.pt"
+    config = StudyConfig(
+        root=ROOT,
+        cli=Path(sys.executable),
+        state_dir=output / "state",
+        gpus=gpus,
+        num_workers=args.num_workers,
+        max_attempts=1,
+        script=Path(__file__).with_name(f"run_segmentation_{suite}_study.py"),
+        cache=cache,
+        output_dir=output,
+        resume=args.resume,
+    )
+    if args.dry_run:
+        runner = StudyRunner(config, jobs, spec, {})
+        logger.info("%d trials; extract one union cache for layers %s", len(jobs), spec["layers"])
+        for index, job in enumerate(jobs):
+            logger.info(
+                "%s %s: %s",
+                job.layer_group,
+                asdict(job.trial),
+                runner._command(job, gpus[index % len(gpus)], 1),
+            )
+        return
+    output.mkdir(parents=True, exist_ok=True)
+    with FileLock(str(output / "study.lock"), timeout=0):
+        path = output / "metadata.json"
+        expected = json.loads(
+            json.dumps({"suite": suite, "cache_spec": spec, "jobs": [asdict(job) for job in jobs]})
+        )
+        if path.exists():
+            if not args.resume:
+                raise FileExistsError("Study exists; use --resume or a new output directory.")
+            if json.loads(path.read_text()) != expected:
+                raise ValueError("Incompatible study configuration; refusing resume.")
+        else:
+            if (
+                (output / "trials").exists()
+                or (output / "state").exists()
+                or (output / "combined.csv").exists()
+            ):
+                raise ValueError("Study metadata missing for existing artifacts.")
+            features.atomic_json(path, expected)
+        payload = features.prepare_cache(
+            cache, spec, torch.device(f"cuda:{gpus[0]}"), args.num_workers
+        )
+        metadata = payload["metadata"]
+        del payload
+        torch.cuda.empty_cache()
+        runner = StudyRunner(config, jobs, spec, metadata)
+        previous_handlers = {
+            sig: signal.signal(sig, runner.request_stop) for sig in (signal.SIGINT, signal.SIGTERM)
+        }
+        try:
+            runner.run()
+        finally:
+            for sig, handler in previous_handlers.items():
+                signal.signal(sig, handler)

--- a/scripts/run_segmentation_layer_study.py
+++ b/scripts/run_segmentation_layer_study.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+r"""Measure intermediate-layer sensitivity with converged constant-LR Adam probes.
+
+Examples (run from the repository root in the torchgeo-bench environment)::
+
+    python scripts/run_segmentation_layer_study.py --dry-run
+    python scripts/run_segmentation_layer_study.py --gpus all --resume
+    python scripts/run_segmentation_layer_study.py --heads linear fpn \
+        --layer-groups late_four spread_four early_four --adam-lrs 0.001 0.01
+    python scripts/run_segmentation_layer_study.py --heads dpt \
+        --layer-groups late_four spread_four early_four --output-dir results/layers-dpt
+    python scripts/run_segmentation_layer_study.py --heads patch_linear \
+        --layer-groups deep_single --output-dir results/layers-patch
+    python scripts/run_segmentation_layer_study.py --heads linear \
+        --layer-groups-json '{"deep":["blocks.11"],"middle":["blocks.5"]}'
+
+Defaults: Burn Scars, ViT-S/16, RGB 224, linear/conv_block/fpn, paired seeds
+0/1/2 and rates 1e-4/1e-3/1e-2. Presets are ordered deepest-first:
+deep_single=[11], late_single=[8], mid_single=[5], shallow_single=[2],
+late_four=[11,10,9,8], spread_four=[11,8,5,2], early_four=[5,4,3,2].
+Numbers denote blocks.N. All required layers share one union feature cache:
+the backbone sees each sample once; workers select ordered tensor subsets.
+Custom models need explicit compatible groups. DPT requires four layers and
+patch_linear exactly one; incompatible grids fail, never silently substitute.
+DPT's optional transformers dependency is preflighted before real extraction;
+--dry-run does not import it.
+
+Four-versus-four is the primary connection comparison: one-versus-four also
+changes decoder capacity. Both layer count and actual parameter count are saved.
+The optimizer study's accepted-training-CE convergence, deterministic FP32,
+train-only BN calibration, checkpoint resumption and timing protocol apply.
+Adam shuffles only the order of fixed BN microbatches, with summed CE scaled by
+number of batches / total valid pixels (also for a partial last batch).
+After --min-iterations, a recent window of --patience checks (at least two) must
+have range <= max(absolute_tol, relative_tol * window_min) for convergence, as
+well as stale cumulative-best patience. A nonflat window with stale best and no
+material first-half-to-second-half mean decrease is not_converged /
+no_best_improvement. Equal halves exclude an odd middle observation. Materially
+recovering windows continue even above the historical best; a flat window is
+operational convergence, not stationarity or an oscillation-floor certificate.
+No time budget/default cap; optional --max-iterations is labeled not_converged.
+
+OUTPUT/combined.csv preserves all raw trials and per-image test-bootstrap CIs.
+OUTPUT/validation_selected.csv selects one LR by mean validation over paired
+seeds for each head/group/optimizer, then reports mean test mIoU and seed SD.
+Incomplete grids are labeled, not silently compared. Test never selects anything.
+Checkpoint/progress/curve and per-job logs are kept under OUTPUT/trials and state.
+--resume requires exact scientific identity but permits different GPU scheduling,
+recording hardware changes separately. Avoid other workloads on selected GPUs.
+"""
+
+from _segmentation_study import main
+
+if __name__ == "__main__":
+    main("layer", __doc__)

--- a/scripts/run_segmentation_optimizer_study.py
+++ b/scripts/run_segmentation_optimizer_study.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+r"""Compare segmentation decoder optimizers using all visible GPUs and full splits.
+
+Examples (run from the repository root in the torchgeo-bench environment)::
+
+    python scripts/run_segmentation_optimizer_study.py --dry-run
+    python scripts/run_segmentation_optimizer_study.py --gpus all --resume
+    python scripts/run_segmentation_optimizer_study.py --heads linear fpn \
+        --adam-lrs 0.0001 0.001 0.01 --seeds 0 1 --output-dir results/optimizer-small
+
+Defaults: Burn Scars, pretrained ViT-S/16, RGB 224, model normalization, all five
+heads, paired seeds 0/1/2. Four connections are deepest-first; patch_linear
+explicitly uses just the deepest connection. The full Adam LR sweep finishes
+before any L-BFGS worker launches. Adam uses constant LR and zero weight decay;
+L-BFGS uses full-data, deterministic microbatch closures, strong Wolfe, persistent
+history 10 and chunks of up to 20 iterations. No time budget or default cap.
+
+Both optimizers use the same fixed, ordered microbatch membership for BN.
+Adam shuffles only batch order; summed batch CE is scaled by number of batches /
+total valid training pixels, including the partial last batch. Compare at the
+same batch size because BN changes the objective.
+
+Stopping monitors accepted train-mode full-training CE. After --min-iterations,
+the last --patience checks (at least two) form a recent window. Historical-best
+patience still accumulates small decreases, but converged/train_loss_plateau also
+requires the entire window range <= max(absolute_tol, relative_tol * window_min).
+A stale best with a nonflat, nonrecovering window is not_converged /
+no_best_improvement, including oscillation floors. A first-half mean minus
+second-half mean > tolerance means recovery: keep going even above an early best.
+Equal halves exclude an odd middle observation. Plateau is not stationarity.
+L-BFGS also reports gradient tolerance or numerical_stall. --max-iterations is
+an optional not_converged safety cap, independent of recovery.
+
+Features are cached once in FP32 through BenchModel; source/configuration/content
+mismatches are refused. DPT requires optional transformers; real runs preflight
+its decoder API before extraction, while --dry-run does not import it.
+
+OUTPUT contains combined.csv (every requested trial, including incomplete and
+failed rows), validation_selected.csv (one LR selected by mean validation across
+paired seeds per head/group/optimizer), immutable trials/*/{result.json,best.pt,
+final.pt,checkpoint.pt,curve.csv,progress.json,test_confusions.pt}, and state/logs.
+Per-trial test mIoU image-bootstrap CIs do not measure seed/spatial uncertainty.
+Never choose rates from test scores. --resume repairs interrupted block artifacts;
+changing scientific settings requires a new output directory. GPU scheduling is
+not scientific identity; resumed hardware changes are recorded and mixed timing
+segments flagged. Keep other GPU workloads off the selected devices for timing.
+"""
+
+from _segmentation_study import main
+
+if __name__ == "__main__":
+    main("optimizer", __doc__)

--- a/tests/test_segmentation_production_studies.py
+++ b/tests/test_segmentation_production_studies.py
@@ -1,0 +1,1016 @@
+"""CPU-only coverage of the standalone optimizer and layer production studies."""
+
+import copy
+import csv
+import importlib
+import json
+import logging
+import shutil
+import subprocess
+import sys
+from collections.abc import Iterator
+from dataclasses import replace
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+from uuid import uuid4
+
+import pytest
+import torch
+from torch import nn
+from torch.utils.data import DataLoader
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+features = importlib.import_module("_segmentation_features")
+convergence = importlib.import_module("_segmentation_convergence")
+study = importlib.import_module("_segmentation_study")
+CPU = torch.device("cpu")
+
+
+@pytest.fixture(autouse=True)
+def cpu_state(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    state = convergence.rng_snapshot(CPU)
+    deterministic = torch.are_deterministic_algorithms_enabled()
+    warn_only = torch.is_deterministic_algorithms_warn_only_enabled()
+    cudnn = (
+        torch.backends.cudnn.benchmark,
+        torch.backends.cudnn.deterministic,
+        torch.backends.cudnn.allow_tf32,
+    )
+    matmul = torch.backends.cuda.matmul.allow_tf32
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    features.seed_everything(13)
+    yield
+    convergence.restore_rng(state, CPU)
+    torch.use_deterministic_algorithms(deterministic, warn_only=warn_only)
+    (
+        torch.backends.cudnn.benchmark,
+        torch.backends.cudnn.deterministic,
+        torch.backends.cudnn.allow_tf32,
+    ) = cudnn
+    torch.backends.cuda.matmul.allow_tf32 = matmul
+
+
+@pytest.fixture
+def scratch() -> Iterator[Path]:
+    directory = ROOT / "outputs" / f"production-study-tests-{uuid4().hex}"
+    directory.mkdir(parents=True)
+    try:
+        yield directory
+    finally:
+        shutil.rmtree(directory)
+
+
+@pytest.fixture
+def payload() -> dict:
+    generator = torch.Generator().manual_seed(12)
+    spec = {
+        "dataset": "synthetic",
+        "model": "tiny",
+        "bands": "rgb",
+        "normalization": "identity",
+        "split_counts": {"train": 5, "val": 3, "test": 2},
+        "image_size": 8,
+        "num_classes": 2,
+        "layers": ["deep", "middle", "earlier", "shallow"],
+        "strict_determinism": True,
+        "versions": {},
+    }
+    splits = {
+        split: {
+            "features": [torch.randn(n, 4, 2, 2, generator=generator) for _ in range(4)],
+            "masks": torch.randint(2, (n, 8, 8), generator=generator),
+        }
+        for split, n in spec["split_counts"].items()
+    }
+    splits["train"]["masks"][2:4] = 255
+    return {
+        "metadata": {
+            "spec": spec,
+            "key": features.identity(spec),
+            "tensor_sha256": features.tensor_digest(features.cache_tensors(splits)),
+            "feature_shapes": [[4, 2, 2]] * 4,
+        },
+        "splits": splits,
+    }
+
+
+@pytest.fixture
+def config() -> convergence.TrialConfig:
+    return convergence.TrialConfig(
+        "linear",
+        "adam",
+        0.01,
+        batch_size=2,
+        hidden_dim=4,
+        check_every=1,
+        lbfgs_iterations=2,
+        max_iterations=2,
+        bootstrap=4,
+    )
+
+
+def selected(payload: dict, layers: list[str] | None = None) -> tuple[dict, dict]:
+    data, metadata = features.select_layers(
+        payload, layers or payload["metadata"]["spec"]["layers"]
+    )
+    return {name: features.device_cache(value, CPU) for name, value in data.items()}, metadata
+
+
+def runner_for(scratch: Path, payload: dict, jobs: list[study.Job]) -> study.StudyRunner:
+    config = study.StudyConfig(
+        root=ROOT,
+        cli=Path(sys.executable),
+        state_dir=scratch / "state",
+        gpus=[0, 1],
+        num_workers=0,
+        max_attempts=1,
+        script=ROOT / "scripts/run_segmentation_optimizer_study.py",
+        cache=scratch / "features.pt",
+        output_dir=scratch,
+        resume=True,
+    )
+    runner = study.StudyRunner(config, jobs, payload["metadata"]["spec"], payload["metadata"])
+    runner.log_dir.mkdir(parents=True)
+    return runner
+
+
+def assert_trees_equal(actual: object, expected: object) -> None:
+    if isinstance(expected, torch.Tensor):
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0, equal_nan=True)
+    elif isinstance(expected, dict):
+        assert actual.keys() == expected.keys()
+        for key in expected:
+            assert_trees_equal(actual[key], expected[key])
+    elif isinstance(expected, (list, tuple)):
+        assert len(actual) == len(expected)
+        for a, b in zip(actual, expected, strict=True):
+            assert_trees_equal(a, b)
+    else:
+        assert actual == expected
+
+
+def test_safe_cache_roundtrip_and_union_subset_invariants(payload: dict, scratch: Path) -> None:
+    path = scratch / "cache.pt"
+    features.atomic_save(path, payload)
+    loaded = features.load_cache(path, payload["metadata"]["spec"])
+    data, metadata = features.select_layers(loaded, ["shallow", "middle"])
+    assert data["train"]["features"][0] is loaded["splits"]["train"]["features"][3]
+    assert data["test"]["masks"] is loaded["splits"]["test"]["masks"]
+    assert metadata["selected_layers"] == ["shallow", "middle"]
+    assert metadata["key"] == loaded["metadata"]["key"]
+    assert metadata["tensor_sha256"] == loaded["metadata"]["tensor_sha256"]
+    with pytest.raises(ValueError, match="absent"):
+        features.select_layers(loaded, ["unknown"])
+    with pytest.raises(ValueError, match="Duplicate"):
+        features.select_layers(loaded, ["deep", "deep"])
+    loaded["splits"]["train"]["features"][0][0, 0, 0, 0] += 1
+    with pytest.raises(ValueError, match="checksum"):
+        features.validate_cache(loaded, payload["metadata"]["spec"])
+    with pytest.raises(ValueError, match="configuration mismatch"):
+        features.load_cache(path, {**payload["metadata"]["spec"], "image_size": 12})
+
+
+@pytest.mark.parametrize("corruption", ["splits", "counts", "labels", "geometry", "dtype"])
+def test_cache_rejects_invalid_invariants(payload: dict, corruption: str) -> None:
+    if corruption == "splits":
+        del payload["splits"]["test"]
+    elif corruption == "counts":
+        payload["splits"]["train"]["masks"] = payload["splits"]["train"]["masks"][:1]
+    elif corruption == "labels":
+        payload["splits"]["train"]["masks"].fill_(8)
+    elif corruption == "geometry":
+        payload["splits"]["val"]["features"][0] = torch.ones(3, 4, 3, 3)
+    else:
+        payload["splits"]["val"]["features"][0] = payload["splits"]["val"]["features"][0].half()
+    with pytest.raises(ValueError, match=r"Cache must|Invalid|geometry"):
+        features.validate_cache(payload, payload["metadata"]["spec"])
+
+
+def test_extractor_uses_actual_inputs_once_and_no_dummy_forward() -> None:
+    class Backbone(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.backbone = nn.Sequential(nn.Identity(), nn.Identity())
+            self.calls = 0
+
+        def forward(self, image: torch.Tensor) -> torch.Tensor:
+            self.calls += 1
+            return self.backbone(image)
+
+    backbone = Backbone()
+    extractor = features.FeatureExtractor(backbone, ["1", "0"])
+    assert backbone.calls == 0
+    samples = [
+        {"image": torch.ones(2, 3, 12, 12) * i, "mask": torch.zeros(1, 12, 12)} for i in range(3)
+    ]
+    result = extractor.extract(DataLoader(samples, batch_size=2))
+    assert backbone.calls == 2
+    assert result["features"][0].shape == (3, 3, 12, 12)
+    assert result["masks"].shape == (3, 12, 12)
+    assert_trees_equal(result["features"][0], result["features"][1])
+    for hook in extractor.hooks:
+        hook.remove()
+
+
+def test_grid_defaults_union_and_explicit_compatibility() -> None:
+    args = study.build_parser("optimizer", "").parse_args([])
+    jobs = study.build_jobs(args, "optimizer")
+    assert len(jobs) == 120
+    assert all(job.trial.optimizer == "adam" for job in jobs[:90])
+    assert all(job.trial.optimizer == "lbfgs" for job in jobs[90:])
+    assert args.max_iterations is None
+    assert args.lbfgs_iterations == 20
+    assert args.history_size == 10
+    assert all(len(job.layers) == 1 for job in jobs if job.trial.head == "patch_linear")
+    args = study.build_parser("layer", "").parse_args([])
+    jobs = study.build_jobs(args, "layer")
+    assert len(jobs) == 189
+    assert set(study.layer_union(jobs)) == {f"blocks.{n}" for n in (11, 10, 9, 8, 5, 4, 3, 2)}
+    assert len(study.layer_union(jobs)) == 8
+    for head in ("dpt", "patch_linear"):
+        args.heads = [head]
+        with pytest.raises(ValueError, match="requires"):
+            study.build_jobs(args, "layer")
+    args = study.build_parser("layer", "").parse_args(
+        ["--heads", "dpt", "--layer-groups", "late_four", "spread_four", "early_four"]
+    )
+    assert len(study.build_jobs(args, "layer")) == 27
+    args = study.build_parser("layer", "").parse_args(
+        ["--heads", "patch_linear", "--layer-groups", "deep_single"]
+    )
+    assert len(study.build_jobs(args, "layer")) == 9
+
+
+@pytest.mark.parametrize(
+    "option",
+    [
+        ["--seeds", "0", "0"],
+        ["--heads", "linear", "linear"],
+        ["--adam-lrs", "0.001", "0.001"],
+        ["--adam-lrs", "nan"],
+        ["--layer-groups-json", '{"a":["x"],"b":["x"]}'],
+        ["--layer-groups-json", '{"a":["x","x"]}'],
+        ["--layer-groups-json", '{"a":["x"],"a":["y"]}'],
+    ],
+)
+def test_grid_rejects_ambiguous_or_invalid_inputs(option: list[str]) -> None:
+    args = study.build_parser("layer", "").parse_args(option)
+    with pytest.raises(ValueError, match=r"[Dd]uplicate|positive"):
+        study.build_jobs(args, "layer")
+
+
+def test_gpu_autodetection_duplicates_and_command(
+    scratch: Path, payload: dict, config: convergence.TrialConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(torch.cuda, "device_count", lambda: 6)
+    assert study.selected_gpus("all") == list(range(6))
+    assert study.selected_gpus("1,4") == [1, 4]
+    with pytest.raises(ValueError, match="Duplicate"):
+        study.selected_gpus("2,2")
+    with pytest.raises(ValueError, match="invalid"):
+        study.selected_gpus("6")
+    job = study.Job(config, "deep", ("deep",))
+    runner = runner_for(scratch, payload, [job])
+    command = runner._command(job, 4, 1)
+    assert command[0] == sys.executable
+    assert command[1].endswith("scripts/run_segmentation_optimizer_study.py")
+    assert command[command.index("--device") + 1] == "cuda:4"
+    assert "--worker" in command
+    assert "--resume" in command
+    assert command[command.index("--worker") + 1].endswith(f"{job.job_id}.json")
+
+
+@pytest.mark.parametrize("suite", ["optimizer", "layer"])
+def test_dry_run_does_not_write_or_launch(
+    suite: str, scratch: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setattr(torch.cuda, "device_count", lambda: 0)
+    monkeypatch.setattr(features, "prepare_cache", Mock(side_effect=AssertionError("no cache")))
+    monkeypatch.setattr(
+        study.StudyRunner, "_run_attempt", Mock(side_effect=AssertionError("no worker"))
+    )
+    output = scratch / "untouched"
+    caplog.set_level(logging.INFO)
+    args = [
+        "--dry-run",
+        "--heads",
+        "linear",
+        "--seeds",
+        "0",
+        "--adam-lrs",
+        "0.001",
+        "--output-dir",
+        str(output),
+    ]
+    study.main(suite, "", args)
+    assert not output.exists()
+    assert "--worker" in caplog.text
+    assert "cuda:0" in caplog.text
+
+
+@pytest.mark.parametrize("head_name", features.HEADS)
+@pytest.mark.parametrize("optimizer", ["adam", "lbfgs"])
+def test_all_heads_optimize_pair_initializations_and_record_capacity(
+    head_name: str, optimizer: str, payload: dict, config: convergence.TrialConfig
+) -> None:
+    if head_name == "dpt":
+        pytest.importorskip("transformers", reason="The existing DPT head requires transformers")
+    layers = ["deep"] if head_name == "patch_linear" else payload["metadata"]["spec"]["layers"]
+    caches, metadata = selected(payload, layers)
+    config = replace(config, head=head_name, optimizer=optimizer, lr=0.1)
+    initial = []
+    counts = []
+    for lr in (0.01, 0.1):
+        features.seed_everything(config.seed)
+        head = features.make_head(head_name, caches["train"], 2, 4)
+        run = convergence.ConvergenceRun(head, caches, replace(config, lr=lr))
+        initial.append(run.initial_state_sha256)
+        counts.append(sum(p.numel() for p in head.parameters()))
+        assert run.optimize()
+        result = run.summary()
+        assert result["parameter_count"] == counts[-1]
+        assert result["optimizer_settings"]["lr"] == lr
+        if optimizer == "adam":
+            assert type(run.optimizer) is torch.optim.Adam
+            assert run.optimizer.defaults["weight_decay"] == 0
+        else:
+            assert run.optimizer.defaults["line_search_fn"] == "strong_wolfe"
+            assert run.iterations <= 2
+            assert run.objective.evaluations == run.lbfgs_state["func_evals"]
+        if head_name == "patch_linear":
+            assert head.patch_size == 4
+    assert initial[0] == initial[1]
+    assert counts[0] == counts[1]
+    assert "hardware" not in convergence.scientific_identity(config, metadata)
+
+
+def test_objective_is_deterministic_preserves_buffers(payload: dict) -> None:
+    caches, _ = selected(payload)
+    head = features.make_head("linear", caches["train"], 2, 4).eval()
+    head.register_buffer("counter", torch.tensor(3), persistent=False)
+
+    def count(module: nn.Module, _args: tuple, _output: torch.Tensor) -> None:
+        module.counter.add_(1)
+
+    head.register_forward_hook(count)
+    objective = convergence.FullObjective(head, caches["train"], 2)
+    before = convergence.model_snapshot(head)
+    loss = objective()
+    gradients = {name: p.grad.clone() for name, p in head.named_parameters()}
+    assert_trees_equal(convergence.model_snapshot(head), before)
+    assert_trees_equal(objective(), loss)
+    assert_trees_equal({name: p.grad for name, p in head.named_parameters()}, gradients)
+
+
+@pytest.mark.parametrize("head_name", ["linear", "conv_block", "fpn"])
+@pytest.mark.parametrize("ignored_bucket", [False, True])
+def test_fixed_bn_batch_gradient_mean_matches_full_objective_and_membership_persists(
+    head_name: str, payload: dict, *, ignored_bucket: bool
+) -> None:
+    caches, _ = selected(payload)
+    cache = caches["train"]
+    for tensor in cache.layer_tensors:
+        tensor.add_(torch.arange(5)[:, None, None, None] * 7)
+        tensor[:, 0, 0, 0] = torch.arange(5)
+    cache.masks[0, :3] = 255
+    cache.masks[4, :5] = 255
+    if not ignored_bucket:
+        cache.masks[2:4] = torch.arange(128).reshape(2, 8, 8) % 2
+    head = features.make_head(head_name, cache, 2, 4)
+    assert any(isinstance(module, nn.BatchNorm2d) for module in head.modules())
+    objective = convergence.FullObjective(head, cache, 2)
+    objective()
+    reference = {name: p.grad.clone() for name, p in head.named_parameters()}
+    assert objective.batch_count == 3
+    assert any(gradient.abs().max() > 0 for gradient in reference.values())
+
+    # Real Adam with lr=0 keeps theta fixed while exposing real BN/CE gradients.
+    optimizer = torch.optim.Adam(head.parameters(), lr=0.0)
+    averaged = {name: torch.zeros_like(gradient) for name, gradient in reference.items()}
+    buckets = []
+
+    def capture_gradient(_optimizer: torch.optim.Optimizer, _args: tuple, _kwargs: dict) -> None:
+        for name, p in head.named_parameters():
+            averaged[name].add_(p.grad / objective.batch_count)
+
+    def capture_membership(_module: nn.Module, args: tuple) -> None:
+        buckets.append(tuple(args[0][0][:, 0, 0, 0].tolist()))
+
+    gradient_hook = optimizer.register_step_pre_hook(capture_gradient)
+    membership_hook = head.register_forward_pre_hook(capture_membership)
+    counters = dict.fromkeys(("samples", "epochs", "optimizer_step_calls", "optimizer_updates"), 0)
+    expected_buckets = {(0.0, 1.0), (4.0,)}
+    if not ignored_bucket:
+        expected_buckets.add((2.0, 3.0))
+    orders = []
+    for epoch in range(5):
+        torch.manual_seed(epoch)
+        buckets.clear()
+        for value in averaged.values():
+            value.zero_()
+        convergence.adam_epoch(objective, optimizer, counters)
+        assert len(buckets) == len(expected_buckets)
+        assert set(buckets) == expected_buckets
+        orders.append(tuple(buckets))
+        for name, gradient in reference.items():
+            torch.testing.assert_close(averaged[name], gradient, atol=1e-6, rtol=1e-4)
+    gradient_hook.remove()
+    membership_hook.remove()
+    assert len(set(orders)) > 1
+    assert counters["samples"] == 25
+    assert counters["optimizer_updates"] == 5 * len(expected_buckets)
+    assert all(state["step"] == counters["optimizer_updates"] for state in optimizer.state.values())
+
+
+def test_stopping_plateau_accumulates_but_safety_and_stalls_are_not_convergence(
+    payload: dict, config: convergence.TrialConfig
+) -> None:
+    plateau = convergence.Plateau()
+    threshold = replace(config, min_iterations=0, patience=3, absolute_tol=0.01, relative_tol=0)
+    assert not plateau.observe(1, 0, threshold)
+    assert not plateau.observe(0.996, 1, threshold)
+    assert not plateau.observe(0.992, 2, threshold)
+    assert not plateau.observe(0.988, 3, threshold)
+    assert plateau.stale_checks == 0
+    assert not plateau.observe(0.984, 4, threshold)
+    assert not plateau.observe(0.980, 5, threshold)
+    assert not plateau.observe(0.976, 6, threshold)
+    assert plateau.stale_checks == 0
+    assert not plateau.observe(0.976, 7, threshold)
+    assert not plateau.observe(0.976, 8, threshold)
+    assert plateau.observe(0.976, 9, threshold) == "train_loss_plateau"
+    caches, _ = selected(payload)
+    head = features.make_head("linear", caches["train"], 2, 4)
+    run = convergence.ConvergenceRun(head, caches, config)
+    result = run.fit()
+    assert result["status"] == "not_converged"
+    assert result["stop_reason"] == "safety_max_iterations"
+    assert result["stationary"] is False
+    stalled = convergence.ConvergenceRun(head, caches, replace(config, optimizer="lbfgs"))
+    stalled.counters["stalled_iteration_blocks"] = config.numerical_patience
+    assert stalled.stopping_reason(1, 1, changed=False) == "numerical_stall"
+    assert stalled.stopping_reason(1, 0, changed=False) == "gradient_tolerance"
+
+
+@pytest.mark.parametrize("optimizer", ["adam", "lbfgs"])
+def test_checkpoint_resume_replays_identically_and_repairs_partial_csv(
+    optimizer: str, payload: dict, config: convergence.TrialConfig, scratch: Path
+) -> None:
+    config = replace(config, optimizer=optimizer, max_iterations=4, min_iterations=0)
+    caches, metadata = selected(payload)
+    expected = convergence.scientific_identity(config, metadata)
+    directory = convergence.trial_directory(scratch, expected)
+    directory.mkdir()
+    store = convergence.TrialStore(directory, expected)
+    features.seed_everything(config.seed)
+    head = features.make_head("linear", caches["train"], 2, 4)
+    run = convergence.ConvergenceRun(head, caches, config, store)
+    run.block(initial=True)
+    run.block()
+    state = copy.deepcopy(store.load())
+    assert len(state["plateau"]["recent_losses"]) == 2
+    run.store = None
+    run.block()
+    uninterrupted = copy.deepcopy(run.state())
+    (directory / "curve.csv").write_text("broken")
+    (directory / "progress.json").write_text("{")
+    resumed = convergence.ConvergenceRun(
+        features.make_head("linear", caches["train"], 2, 4), caches, config, store
+    )
+    resumed.restore(store.load())
+    assert_trees_equal(resumed.optimizer.state_dict(), state["optimizer"])
+    assert resumed.plateau == convergence.Plateau(**state["plateau"])
+    resumed.block()
+    for name in ("model", "optimizer", "rng", "counters", "plateau"):
+        assert_trees_equal(resumed.state()[name], uninterrupted[name])
+    with (directory / "curve.csv").open() as stream:
+        assert len(list(csv.DictReader(stream))) == len(resumed.curve)
+    assert (
+        json.loads((directory / "progress.json").read_text())["block"] == resumed.counters["blocks"]
+    )
+
+
+def test_immutable_results_atomic_aggregation_and_resume_failures(
+    payload: dict, config: convergence.TrialConfig, scratch: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    caches, metadata = selected(payload, ["deep"])
+    job = study.Job(config, "deep", ("deep",))
+    result = convergence.run_trial(config, caches, metadata, scratch / "trials")
+    expected = convergence.scientific_identity(config, metadata)
+    directory = convergence.trial_directory(scratch / "trials", expected)
+    original = (directory / "result.json").read_bytes()
+    with pytest.raises(FileExistsError):
+        convergence.run_trial(config, caches, metadata, scratch / "trials")
+    monkeypatch.setattr(
+        features, "make_head", Mock(side_effect=AssertionError("completed means immutable"))
+    )
+    assert convergence.run_trial(
+        config, caches, metadata, scratch / "trials", resume=True
+    ) == json.loads(json.dumps(result))
+    assert (directory / "result.json").read_bytes() == original
+    pending = study.Job(replace(config, lr=0.1), "deep", ("deep",))
+    study.aggregate(scratch, [job, pending], payload["metadata"])
+    with (scratch / "combined.csv").open() as stream:
+        rows = list(csv.DictReader(stream))
+    assert [row["status"] for row in rows] == ["not_converged", "incomplete"]
+    assert rows[0]["parameter_count"] == str(result["parameter_count"])
+    with (scratch / "validation_selected.csv").open() as stream:
+        assert next(csv.DictReader(stream))["selection_status"] == "incomplete_grid"
+    assert not list(scratch.rglob("*.writing"))
+    corrupted = json.loads(original)
+    corrupted["test"]["miou"] = 0.12345
+    features.atomic_json(directory / "result.json", corrupted)
+    with pytest.raises(ValueError, match="checksum"):
+        study.aggregate(scratch, [job], payload["metadata"])
+    assert (scratch / "combined.csv").read_text().count("incomplete") == 1
+
+
+def test_validation_lr_selection_uses_seed_mean_never_test() -> None:
+    rows = []
+    for lr, scores, test in [(0.01, [0.9, 0.1], 0.99), (0.1, [0.6, 0.6], 0.1)]:
+        for seed, score in enumerate(scores):
+            rows.append(
+                {
+                    "dataset": "x",
+                    "model": "y",
+                    "head": "linear",
+                    "layer_group": "deep",
+                    "optimizer": "adam",
+                    "layers": '["deep"]',
+                    "layer_count": 1,
+                    "status": "not_converged",
+                    "lr": lr,
+                    "seed": seed,
+                    "best_val_miou": score,
+                    "test_miou": test,
+                    "parameter_count": 10,
+                    "optimization_seconds": 3,
+                    "training_wall_seconds": 6,
+                    "selected_optimization_seconds": 1,
+                    "stationary": False,
+                    "mixed_hardware_timings": False,
+                    "hardware_history": "[]",
+                }
+            )
+    summary = study.validation_summary(rows)[0]
+    assert summary["selected_lr"] == 0.1
+    assert summary["mean_test_miou"] == 0.1
+    assert summary["converged_seeds"] == 0
+    assert summary["selection_status"] == "validation_selected"
+    rows[0]["status"] = "failed"
+    assert study.validation_summary(rows)[0]["selection_status"] == "incomplete_grid"
+
+
+@pytest.mark.parametrize("failure", ["nonzero", "exception", "missing"])
+def test_scheduler_propagates_failures_never_fake_completed(
+    failure: str,
+    payload: dict,
+    config: convergence.TrialConfig,
+    scratch: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    job = study.Job(config, "deep", ("deep",))
+    runner = runner_for(scratch, payload, [job])
+    if failure == "exception":
+        monkeypatch.setattr(runner, "_run_job", Mock(side_effect=OSError("spawn error")))
+        expected_error = OSError
+    else:
+        monkeypatch.setattr(runner, "_run_attempt", lambda *_args: failure == "missing")
+        expected_error = RuntimeError
+    with pytest.raises(expected_error):
+        runner._dispatch([job])
+    assert runner.counts["failed"] == 1
+    assert runner.counts["completed"] == 0
+    assert runner.counts["running"] == 0
+
+
+def test_scheduler_finishes_adam_before_lbfgs(
+    payload: dict, config: convergence.TrialConfig, scratch: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    jobs = [
+        study.Job(replace(config, optimizer=optimizer, seed=seed), "deep", ("deep",))
+        for optimizer in ("adam", "lbfgs")
+        for seed in (0, 1)
+    ]
+    runner = runner_for(scratch, payload, jobs)
+    done = set()
+
+    def execute(job: study.Job, _gpu: int) -> bool:
+        if job.trial.optimizer == "lbfgs":
+            assert all(first.job_id in done for first in jobs[:2])
+        done.add(job.job_id)
+        return True
+
+    monkeypatch.setattr(runner, "_is_complete", lambda job: job.job_id in done)
+    monkeypatch.setattr(runner, "_run_job", execute)
+    runner.run()
+    assert runner.counts["completed"] == 4
+
+
+def test_numerical_failure_is_immutable_but_not_success(
+    payload: dict, config: convergence.TrialConfig, scratch: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    caches, metadata = selected(payload, ["deep"])
+    monkeypatch.setattr(
+        convergence.FullObjective,
+        "monitor",
+        Mock(side_effect=features.DivergedError("bad objective")),
+    )
+    result = convergence.run_trial(config, caches, metadata, scratch / "trials")
+    assert result["status"] == "failed"
+    assert result["stationary"] is False
+    assert "test" not in result
+    job = study.Job(config, "deep", ("deep",))
+    runner = runner_for(scratch, payload, [job])
+    with pytest.raises(RuntimeError, match="Immutable failed trial"):
+        runner._is_complete(job)
+    study.aggregate(scratch, [job], payload["metadata"])
+    with (scratch / "combined.csv").open() as stream:
+        assert next(csv.DictReader(stream))["status"] == "failed"
+
+
+def test_prepare_cache_encodes_complete_splits_once_through_benchmodel(
+    scratch: Path, payload: dict, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class Backbone(features.BenchModel):
+        def __init__(self) -> None:
+            nn.Module.__init__(self)
+            self.backbone = nn.ModuleDict({name: nn.Identity() for name in ("deep", "shallow")})
+            self.calls = 0
+
+        def normalize_inputs(self, images: torch.Tensor) -> torch.Tensor:
+            return images * 2
+
+        def _forward_patch_features(self, images: torch.Tensor) -> torch.Tensor:
+            self.calls += 1
+            for module in self.backbone.values():
+                images = module(images)
+            return images.mean((2, 3))
+
+    spec = {
+        **payload["metadata"]["spec"],
+        "layers": ["deep", "shallow"],
+        "bands": "all",
+        "extraction_seed": 0,
+        "extract_batch_size": 2,
+        "interpolation": "bilinear",
+        "model_config": {},
+    }
+    loaders = [
+        DataLoader(
+            [
+                {"image": torch.ones(3, 8, 8), "mask": torch.zeros(8, 8, dtype=torch.long)}
+                for _ in range(count)
+            ],
+            batch_size=2,
+        )
+        for count in (5, 3, 2)
+    ]
+    backbone = Backbone()
+    instantiate = Mock(return_value=backbone)
+    monkeypatch.setattr(features, "instantiate", instantiate)
+    monkeypatch.setattr(features, "get_datasets", lambda **_kwargs: (None, *loaders))
+    monkeypatch.setattr(
+        features, "get_bench_dataset_class", lambda _name: lambda: SimpleNamespace(bands=[])
+    )
+    path = scratch / "features.pt"
+    first = features.prepare_cache(path, spec, CPU, 0)
+    second = features.prepare_cache(path, spec, CPU, 0)
+    assert backbone.calls == 6
+    assert instantiate.call_count == 1
+    assert first["metadata"]["tensor_sha256"] == second["metadata"]["tensor_sha256"]
+    assert first["metadata"]["feature_shapes"] == [[3, 8, 8], [3, 8, 8]]
+    assert first["splits"]["train"]["features"][0].eq(2).all()
+    assert all(not module._forward_hooks for module in backbone.modules())
+
+
+def test_worker_subprocess_executes_manifest_and_resumes(
+    payload: dict, config: convergence.TrialConfig, scratch: Path
+) -> None:
+    spec = payload["metadata"]["spec"]
+    spec["versions"] = features.software_versions()
+    payload["metadata"]["key"] = features.identity(spec)
+    cache = scratch / "features.pt"
+    manifest = scratch / "job.json"
+    features.atomic_save(cache, payload)
+    job = study.Job(replace(config, max_iterations=1), "deep", ("deep",))
+    features.atomic_json(
+        manifest,
+        {
+            "job": study.asdict(job),
+            "cache_spec": spec,
+            "cache_tensor_sha256": payload["metadata"]["tensor_sha256"],
+        },
+    )
+    command = [
+        sys.executable,
+        str(ROOT / "scripts/run_segmentation_layer_study.py"),
+        "--worker",
+        str(manifest),
+        "--device",
+        "cpu",
+        "--cache",
+        str(cache),
+        "--output-dir",
+        str(scratch),
+    ]
+    subprocess.run(command, cwd=ROOT, check=True, capture_output=True, text=True)
+    directory = convergence.trial_directory(
+        scratch / "trials", study.job_identity(job, payload["metadata"])
+    )
+    before = (directory / "result.json").read_bytes()
+    subprocess.run([*command, "--resume"], cwd=ROOT, check=True, capture_output=True, text=True)
+    assert (directory / "result.json").read_bytes() == before
+    result = convergence.completed_result(directory, study.job_identity(job, payload["metadata"]))
+    assert result["stop_reason"] == "safety_max_iterations"
+    assert result["status"] == "not_converged"
+
+
+def test_hardware_changes_are_labeled_not_part_of_scientific_identity(
+    payload: dict, config: convergence.TrialConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    caches, metadata = selected(payload)
+    expected = convergence.scientific_identity(config, metadata)
+    head = features.make_head("linear", caches["train"], 2, 4)
+    monkeypatch.setattr(features, "hardware", lambda _device: {"device": "cuda:0", "name": "A"})
+    first = convergence.ConvergenceRun(head, caches, config)
+    state = copy.deepcopy(first.state())
+    monkeypatch.setattr(features, "hardware", lambda _device: {"device": "cuda:3", "name": "A"})
+    moved = convergence.ConvergenceRun(head, caches, config)
+    moved.restore(copy.deepcopy(state))
+    assert convergence.scientific_identity(config, metadata) == expected
+    assert moved.summary()["mixed_hardware_timings"] is False
+    assert len(moved.hardware_history) == 2
+    monkeypatch.setattr(features, "hardware", lambda _device: {"device": "cuda:1", "name": "B"})
+    changed = convergence.ConvergenceRun(head, caches, config)
+    changed.restore(state)
+    assert changed.summary()["mixed_hardware_timings"] is True
+
+
+def test_single_vs_four_capacity_is_measured_not_assumed(payload: dict) -> None:
+    four, _ = selected(payload)
+    one, _ = selected(payload, ["deep"])
+    one_head = features.make_head("linear", one["train"], 2, 4)
+    four_head = features.make_head("linear", four["train"], 2, 4)
+    assert sum(p.numel() for p in one_head.parameters()) < sum(
+        p.numel() for p in four_head.parameters()
+    )
+
+
+def test_study_resume_refuses_config_changes_but_allows_gpu_rescheduling(
+    scratch: Path, payload: dict, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(torch.cuda, "device_count", lambda: 6)
+    monkeypatch.setattr(torch.cuda, "empty_cache", lambda: None)
+    monkeypatch.setattr(features, "cache_spec", lambda *_args: payload["metadata"]["spec"])
+    prepare = Mock(return_value=payload)
+    monkeypatch.setattr(features, "prepare_cache", prepare)
+    run = Mock()
+    monkeypatch.setattr(study.StudyRunner, "run", run)
+    arguments = [
+        "--heads",
+        "linear",
+        "--seeds",
+        "0",
+        "--adam-lrs",
+        "0.001",
+        "--phase",
+        "adam",
+        "--output-dir",
+        str(scratch),
+    ]
+    study.main("optimizer", "", [*arguments, "--gpus", "0"])
+    with pytest.raises(FileExistsError, match="use --resume"):
+        study.main("optimizer", "", arguments)
+    study.main("optimizer", "", [*arguments, "--resume", "--gpus", "3,5"])
+    assert run.call_count == 2
+    assert prepare.call_count == 2
+    before = (scratch / "metadata.json").read_bytes()
+    with pytest.raises(ValueError, match="Incompatible study configuration"):
+        study.main("optimizer", "", [*arguments, "--resume", "--batch-size", "3"])
+    assert prepare.call_count == 2
+    assert (scratch / "metadata.json").read_bytes() == before
+
+
+def test_atomic_write_without_directory_fsync_flag(
+    scratch: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = scratch / "portable.json"
+    path.write_text("old")
+    fsync = Mock(wraps=features.os.fsync)
+    directory_open = Mock(side_effect=AssertionError("Windows cannot open directories for fsync"))
+    with monkeypatch.context() as context:
+        context.delattr(features.os, "O_DIRECTORY", raising=False)
+        context.setattr(features.os, "fsync", fsync)
+        context.setattr(features.os, "open", directory_open)
+        features.atomic_json(path, {"committed": True})
+        assert fsync.call_count == 1
+        directory_open.assert_not_called()
+    assert json.loads(path.read_text()) == {"committed": True}
+    assert not path.with_name(path.name + ".writing").exists()
+
+    def interrupted_write() -> None:
+        with features.atomic_stream(path, "w") as stream:
+            stream.write("incomplete")
+            raise RuntimeError("interrupted")
+
+    with pytest.raises(RuntimeError, match="interrupted"):
+        interrupted_write()
+    assert json.loads(path.read_text()) == {"committed": True}
+    assert not path.with_name(path.name + ".writing").exists()
+
+
+@pytest.mark.parametrize("suite", ["optimizer", "layer"])
+def test_missing_dpt_dependency_fails_before_cache_or_workers(
+    suite: str, scratch: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    importer = Mock(side_effect=ModuleNotFoundError("missing", name="transformers"))
+    prepare = Mock(side_effect=AssertionError("must not extract"))
+    launch = Mock(side_effect=AssertionError("must not schedule"))
+    monkeypatch.setattr(features, "import_module", importer)
+    monkeypatch.setattr(features, "prepare_cache", prepare)
+    monkeypatch.setattr(study.StudyRunner, "run", launch)
+    monkeypatch.setattr(
+        torch.cuda, "device_count", Mock(side_effect=AssertionError("preflight first"))
+    )
+    output = scratch / "not-created"
+    arguments = ["--heads", "dpt", "--output-dir", str(output)]
+    if suite == "layer":
+        arguments += ["--layer-groups", "spread_four"]
+    with pytest.raises(ModuleNotFoundError, match="optional transformers dependency"):
+        study.main(suite, "", arguments)
+    importer.assert_called_once_with("transformers.models.dpt.modeling_dpt")
+    prepare.assert_not_called()
+    launch.assert_not_called()
+    assert not output.exists()
+
+
+def test_worker_checks_dpt_dependency_before_loading_cache(
+    scratch: Path, payload: dict, config: convergence.TrialConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    job = study.Job(
+        replace(config, head="dpt"), "four", tuple(payload["metadata"]["spec"]["layers"])
+    )
+    path = scratch / "job.json"
+    features.atomic_json(
+        path, {"job": study.asdict(job), "cache_spec": payload["metadata"]["spec"]}
+    )
+    monkeypatch.setattr(
+        features,
+        "import_module",
+        Mock(side_effect=ModuleNotFoundError("missing", name="transformers")),
+    )
+    load = Mock(side_effect=AssertionError("preflight before tensor load"))
+    monkeypatch.setattr(features, "load_cache", load)
+    with pytest.raises(ModuleNotFoundError, match="optional transformers dependency"):
+        study.run_worker(SimpleNamespace(worker=path))
+    load.assert_not_called()
+
+
+def test_dpt_dry_run_does_not_import_optional_dependency(
+    scratch: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    importer = Mock(side_effect=AssertionError("dry runs must not import transformers"))
+    monkeypatch.setattr(features, "import_module", importer)
+    monkeypatch.setattr(torch.cuda, "device_count", lambda: 0)
+    output = scratch / "not-created"
+    study.main(
+        "optimizer",
+        "",
+        [
+            "--heads",
+            "dpt",
+            "--seeds",
+            "0",
+            "--adam-lrs",
+            "0.001",
+            "--lbfgs-lrs",
+            "1",
+            "--dry-run",
+            "--output-dir",
+            str(output),
+        ],
+    )
+    importer.assert_not_called()
+    assert not output.exists()
+
+
+def test_preflight_checks_decoder_api_but_does_not_import_for_other_heads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    importer = Mock(return_value=SimpleNamespace())
+    monkeypatch.setattr(features, "import_module", importer)
+    features.preflight_heads(["linear", "conv_block", "fpn", "patch_linear"])
+    importer.assert_not_called()
+    with pytest.raises(ImportError, match="lacks the DPTFeatureFusionLayer"):
+        features.preflight_heads(["dpt"])
+
+
+def test_recent_plateau_window_starts_at_minimum_iterations(
+    config: convergence.TrialConfig,
+) -> None:
+    config = replace(config, min_iterations=4, patience=3)
+    plateau = convergence.Plateau()
+    for iteration in range(4):
+        assert plateau.observe(0.5, iteration, config) is None
+    assert plateau.recent_losses == []
+    assert plateau.observe(0.5, 4, config) is None
+    assert plateau.observe(0.5, 5, config) is None
+    assert plateau.observe(0.5, 6, config) == "train_loss_plateau"
+    assert plateau.recent_losses == [0.5, 0.5, 0.5]
+
+
+@pytest.mark.parametrize("patience", [2, 3, 10])
+def test_recovery_above_early_best_never_stops_without_explicit_safety_cap(
+    patience: int, payload: dict, config: convergence.TrialConfig
+) -> None:
+    config = replace(config, patience=patience, min_iterations=0, max_iterations=None)
+    caches, _ = selected(payload)
+    run = convergence.ConvergenceRun(
+        features.make_head("linear", caches["train"], 2, 4), caches, config
+    )
+    losses = (
+        [0.5, 35.7, 5.8, 2.91]
+        if patience < 10
+        else [
+            0.5,
+            35.7,
+            30,
+            25,
+            20,
+            16,
+            12,
+            9,
+            7,
+            5.8,
+            4.5,
+            3.8,
+            2.91,
+        ]
+    )
+    for iteration, loss in enumerate(losses):
+        run.counters["epochs"] = iteration
+        assert run.stopping_reason(loss, None, changed=True) is None
+    assert run.plateau.stale_checks >= config.patience
+    assert run.plateau.reference == 0.5
+    assert (
+        run.plateau.window_statistics(config)["recent_ce_half_mean_decrease"] > config.absolute_tol
+    )
+
+
+def test_recent_range_accumulates_small_recovery_steps(config: convergence.TrialConfig) -> None:
+    config = replace(config, patience=5, min_iterations=0, absolute_tol=0.01, relative_tol=0)
+    plateau = convergence.Plateau()
+    assert plateau.observe(0.5, 0, config) is None
+    for iteration in range(1, 15):
+        assert plateau.observe(1.0 - 0.004 * iteration, iteration, config) is None
+    window = plateau.window_statistics(config)
+    assert window["recent_ce_range"] > window["recent_ce_tolerance"]
+    assert window["recent_ce_half_mean_decrease"] > window["recent_ce_tolerance"]
+    restored = convergence.Plateau(**study.asdict(plateau))
+    assert restored.recent_losses == plateau.recent_losses
+    assert restored.observe(0.94, 15, config) == plateau.observe(0.94, 15, config)
+
+
+@pytest.mark.parametrize(
+    ("losses", "outcome"),
+    [
+        ([0.5, 5.0, 3.0, 5.0], ("no_best_improvement", "not_converged")),
+        ([0.5, 1.0, 2.0, 3.0], ("no_best_improvement", "not_converged")),
+        ([0.5, 0.5, 0.5, 0.5], ("train_loss_plateau", "converged")),
+        ([0.5, 35.7, 5.8, 2.91], (None, "running")),
+    ],
+)
+def test_recent_window_stop_reasons_never_claim_stationarity(
+    losses: list[float],
+    outcome: tuple[str | None, str],
+    payload: dict,
+    config: convergence.TrialConfig,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = replace(config, patience=3, min_iterations=0, max_iterations=None)
+    caches, _ = selected(payload)
+    run = convergence.ConvergenceRun(
+        features.make_head("linear", caches["train"], 2, 4), caches, config
+    )
+    stream = iter(losses)
+    monkeypatch.setattr(run.objective, "monitor", lambda **_kwargs: (next(stream), None))
+    for iteration in range(len(losses)):
+        run.counters["epochs"] = iteration
+        assert run.status == "running"
+        run.block(initial=True)
+    assert run.status == outcome[1]
+    assert run.stop_reason == outcome[0]
+    assert run.summary()["stationary"] is False
+    assert run.curve[-1]["recent_ce_range"] == max(losses[-3:]) - min(losses[-3:])
+
+
+def test_recent_flatness_uses_relative_tolerance(config: convergence.TrialConfig) -> None:
+    config = replace(config, patience=3, min_iterations=0, absolute_tol=0.01, relative_tol=0.001)
+    plateau = convergence.Plateau()
+    for iteration, loss in enumerate([1000.0, 1000.1, 1000.2]):
+        assert plateau.observe(loss, iteration, config) is None
+    assert plateau.observe(1000.3, 3, config) == "train_loss_plateau"
+    assert plateau.window_statistics(config)["recent_ce_tolerance"] > 1.0

--- a/tests/test_segmentation_production_studies.py
+++ b/tests/test_segmentation_production_studies.py
@@ -275,7 +275,7 @@ def test_gpu_autodetection_duplicates_and_command(
     runner = runner_for(scratch, payload, [job])
     command = runner._command(job, 4, 1)
     assert command[0] == sys.executable
-    assert command[1].endswith("scripts/run_segmentation_optimizer_study.py")
+    assert Path(command[1]).parts[-2:] == ("scripts", "run_segmentation_optimizer_study.py")
     assert command[command.index("--device") + 1] == "cuda:4"
     assert "--worker" in command
     assert "--resume" in command


### PR DESCRIPTION
Add multi-GPU scripts for an Adam learning-rate sweep followed by L-BFGS, and for intermediate-layer comparisons across decoder families. Both cache frozen features and save raw and validation-selected CSVs, making decoder speed and accuracy comparisons reproducible without time-budget cutoffs.

The optimizers share fixed BatchNorm batch memberships. Optional plateau LR decay and guarded checkpoint continuation let Adam settle without discarding previous fits. Optimization time is recorded separately from monitoring and checkpoint work, and stopping distinguishes flat loss from unsuccessful learning rates and numerical stalls.