### PR TITLE
ci: check every pull request base

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main, 'docs/refactor-**']
 
 jobs:
   test:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main, 'docs/refactor-**']
   workflow_dispatch:
 
 # Run one deployment at a time without interrupting the one in progress.

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1,0 +1,32 @@
+"""Workflow coverage for independently reviewable stacked pull requests."""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+WORKFLOWS = Path(__file__).resolve().parents[1] / ".github" / "workflows"
+
+
+@pytest.mark.parametrize("name", ["ci", "docs"])
+def test_checks_cover_every_pull_request_base(name: str) -> None:
+    # BaseLoader keeps GitHub's "on" key instead of treating it as a YAML 1.1 boolean.
+    config = yaml.load((WORKFLOWS / f"{name}.yaml").read_text(), Loader=yaml.BaseLoader)
+    events = config["on"]
+    assert "pull_request" in events
+    selection = events["pull_request"] or {}
+    assert "branches" not in selection
+    assert "branches-ignore" not in selection
+    assert events["push"]["branches"] == ["main"]
+
+
+def test_pull_requests_cannot_deploy_documentation() -> None:
+    config = yaml.load((WORKFLOWS / "docs.yaml").read_text(), Loader=yaml.BaseLoader)
+    not_pull_request = "github.event_name != 'pull_request'"
+    assert config["jobs"]["deploy"]["if"] == not_pull_request
+    upload = next(
+        step
+        for step in config["jobs"]["build"]["steps"]
+        if step.get("name") == "Upload Pages artifact"
+    )
+    assert upload["if"] == not_pull_request


### PR DESCRIPTION
The current base-branch allowlist leaves stacked PRs without CI or documentation checks. Run checks for all pull request bases while retaining main-only push runs and preventing PRs from uploading or deploying Pages artifacts.